### PR TITLE
fix: avoid MPS by default for Apple Silicon Auto

### DIFF
--- a/scripts/reaper/STEMwerk.lua
+++ b/scripts/reaper/STEMwerk.lua
@@ -1388,6 +1388,37 @@ local function effectiveRunRequestedParallel()
     return (SETTINGS and SETTINGS.parallelProcessing) and true or false
 end
 
+local KNOWN_MPS_UNSUPPORTED_MARKER = "STEMWERK_MPS_UNSUPPORTED_OP output_channels_gt_65536"
+
+local function isKnownMpsUnsupportedFailure(logSnippet)
+    local text = string.lower(tostring(logSnippet or ""))
+    if text == "" then return false end
+    if text:find(string.lower(KNOWN_MPS_UNSUPPORTED_MARKER), 1, true) then
+        return true
+    end
+    return text:find("output channels > 65536 not supported at the mps device", 1, true) ~= nil
+end
+
+local function buildKnownSeparationFailureMessage(logSnippet, exitCode, cmdLine, logPath, debugLogPath, stdoutSnippet)
+    if not isKnownMpsUnsupportedFailure(logSnippet) then
+        return nil
+    end
+
+    local msg = "Apple MPS failed because this model hits a PyTorch MPS limitation.\n"
+        .. "Please use CPU for now.\n\n"
+        .. "Exit code: " .. tostring(exitCode or "unknown") .. "\n"
+        .. "Command: " .. tostring(cmdLine or "unknown") .. "\n"
+        .. "Python log (" .. tostring(logPath or "unknown") .. "):\n"
+        .. tostring(logSnippet or "(no log output found)")
+        .. "\n\nDebug log: " .. tostring(debugLogPath or SW_LOG.getLogPath())
+
+    if stdoutSnippet and stdoutSnippet ~= "" then
+        msg = msg .. "\n\nStdout (first 1200 chars):\n" .. stdoutSnippet
+    end
+
+    return msg
+end
+
 local function isEffectiveRun6Stem()
     return effectiveRunModel() == "htdemucs_6s"
 end
@@ -13125,6 +13156,7 @@ WORKFLOW.configure({
     GUI                           = GUI,
     T                             = T,
     showMessage                   = showMessage,
+    buildKnownSeparationFailureMessage = buildKnownSeparationFailureMessage,
     captureWindowGeometry         = captureWindowGeometry,
     saveSettings                  = saveSettings,
     ensureDependenciesInteractive = ensureDependenciesInteractive,
@@ -17005,13 +17037,22 @@ processAllStemsResult = function()
         local cmdLine = firstJob and firstJob.lastCmd or nil
         local debugLogPath = firstJob and (firstJob.execLogPath or SW_LOG.getLogPath()) or SW_LOG.getLogPath()
 
-        local msg = "No stems were created.\n\n"
-            .. "This usually means the Python separator failed to start or crashed.\n\n"
-            .. "Exit code: " .. tostring(exitCode or "unknown") .. "\n"
-            .. "Command: " .. tostring(cmdLine or "unknown") .. "\n"
-            .. "Python log (" .. tostring(logPath or "unknown") .. "):\n"
-            .. logSnippet
-            .. "\n\nDebug log: " .. tostring(debugLogPath)
+        local msg = buildKnownSeparationFailureMessage(
+            logSnippet,
+            exitCode,
+            cmdLine,
+            logPath,
+            debugLogPath
+        )
+        if not msg then
+            msg = "No stems were created.\n\n"
+                .. "This usually means the Python separator failed to start or crashed.\n\n"
+                .. "Exit code: " .. tostring(exitCode or "unknown") .. "\n"
+                .. "Command: " .. tostring(cmdLine or "unknown") .. "\n"
+                .. "Python log (" .. tostring(logPath or "unknown") .. "):\n"
+                .. logSnippet
+                .. "\n\nDebug log: " .. tostring(debugLogPath)
+        end
 
         -- Friendly hint for the most common missing dependency.
         if logSnippet:find("No module named 'onnxruntime'", 1, true) then

--- a/scripts/reaper/_internal/STEMwerk_Workflow.lua
+++ b/scripts/reaper/_internal/STEMwerk_Workflow.lua
@@ -679,14 +679,27 @@ function WORKFLOW.finishSeparationCallback()
             local exitCode = SW_LOG.readExitCode(C.progressState.exitCodeFile)
             local logSnippet = SW_LOG.readFileSnippet(C.progressState.logFile, 2000) or "(no log output found)"
             local stdoutSnippet = SW_LOG.readFileSnippet(C.progressState.stdoutFile, 1200)
-            local errMsg = "No stems created"
-                .. "\n\nExit code: " .. tostring(exitCode or "unknown")
-                .. "\nCommand: " .. tostring(C.progressState.lastCmd or "unknown")
-                .. "\nLog file: " .. tostring(C.progressState.logFile or "unknown")
-                .. "\nDebug log: " .. tostring(C.progressState.execLogPath or SW_LOG.getLogPath())
-                .. "\n\nOutput (first 2000 chars):\n" .. logSnippet
-            if stdoutSnippet then
-                errMsg = errMsg .. "\n\nStdout (first 1200 chars):\n" .. stdoutSnippet
+            local errMsg = nil
+            if C.buildKnownSeparationFailureMessage then
+                errMsg = C.buildKnownSeparationFailureMessage(
+                    logSnippet,
+                    exitCode,
+                    C.progressState.lastCmd,
+                    C.progressState.logFile,
+                    C.progressState.execLogPath or SW_LOG.getLogPath(),
+                    stdoutSnippet
+                )
+            end
+            if not errMsg then
+                errMsg = "No stems created"
+                    .. "\n\nExit code: " .. tostring(exitCode or "unknown")
+                    .. "\nCommand: " .. tostring(C.progressState.lastCmd or "unknown")
+                    .. "\nLog file: " .. tostring(C.progressState.logFile or "unknown")
+                    .. "\nDebug log: " .. tostring(C.progressState.execLogPath or SW_LOG.getLogPath())
+                    .. "\n\nOutput (first 2000 chars):\n" .. logSnippet
+                if stdoutSnippet then
+                    errMsg = errMsg .. "\n\nStdout (first 1200 chars):\n" .. stdoutSnippet
+                end
             end
             -- Keep this visible until user closes it; auto-monitor mode can immediately
             -- bounce back to the main window and hide actionable error details.

--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -28,6 +28,9 @@ select_device = None
 core_devices = None
 _core_loaded = False
 
+MPS_UNSUPPORTED_MARKER = "STEMWERK_MPS_UNSUPPORTED_OP output_channels_gt_65536"
+MPS_FALLBACK_ENV = "PYTORCH_ENABLE_MPS_FALLBACK"
+
 
 def _require_core() -> None:
     global StemSeparator, get_available_devices, select_device, core_devices, _core_loaded
@@ -366,12 +369,14 @@ def _emit_env_diagnostics() -> None:
 def _build_env_json() -> Dict[str, object]:
     env: Dict[str, object] = {
         "platform": platform.system(),
+        "platform_machine": platform.machine(),
         "python": platform.python_version(),
         "python_version": platform.python_version(),
         "sys_executable": sys.executable,
         "python_executable": sys.executable,
         "pythonpath_env": os.environ.get("PYTHONPATH"),
         "ld_library_path_env": os.environ.get("LD_LIBRARY_PATH"),
+        "mps_fallback_env": os.environ.get(MPS_FALLBACK_ENV),
         "torch": None,
         "torch_version": None,
         "torchaudio_version": None,
@@ -472,13 +477,67 @@ def _emit_runtime_diagnostics(selected_device: Optional[str]) -> Dict[str, objec
     env["selected_device"] = selected_device
     print(f"STEMWERK_DIAG python_executable={env.get('python_executable')}", file=sys.stderr)
     print(f"STEMWERK_DIAG python_version={env.get('python_version')}", file=sys.stderr)
+    print(f"STEMWERK_DIAG platform={env.get('platform')} machine={env.get('platform_machine')}", file=sys.stderr)
     print(f"STEMWERK_DIAG torch_version={env.get('torch_version')}", file=sys.stderr)
     print(f"STEMWERK_DIAG torchaudio_version={env.get('torchaudio_version')}", file=sys.stderr)
     print(f"STEMWERK_DIAG onnxruntime_version={env.get('onnxruntime_version')}", file=sys.stderr)
     print(f"STEMWERK_DIAG mps_built={env.get('mps_built')}", file=sys.stderr)
     print(f"STEMWERK_DIAG mps_available={env.get('mps_available')}", file=sys.stderr)
+    print(f"STEMWERK_DIAG mps_fallback_env={env.get('mps_fallback_env')}", file=sys.stderr)
     print(f"STEMWERK_DIAG selected_device={selected_device}", file=sys.stderr)
     return env
+
+
+def _enable_mps_runtime_fallback(requested_device: str, resolved_device: str) -> bool:
+    if resolved_device != "mps":
+        return False
+    os.environ[MPS_FALLBACK_ENV] = "1"
+    print(
+        f"STEMWERK_DIAG mps_fallback_enabled=1 requested_device={requested_device} resolved_device={resolved_device}",
+        file=sys.stderr,
+    )
+    return True
+
+
+def _classify_runtime_failure(
+    exc: BaseException,
+    traceback_text: str,
+    requested_device: str,
+    selected_device: str,
+    model_name: str,
+    env: Optional[Dict[str, object]] = None,
+) -> Optional[Dict[str, object]]:
+    text = "\n".join(
+        part for part in (str(exc or ""), traceback_text or "") if part
+    )
+    lower = text.lower()
+    is_mps_unsupported = (
+        "output channels > 65536 not supported at the mps device" in lower
+        or (
+            "notimplementederror" in lower
+            and "pytorch_enable_mps_fallback" in lower
+            and "mps" in lower
+        )
+    )
+    if not is_mps_unsupported:
+        return None
+
+    env = env or {}
+    details = {
+        "requested_device": requested_device or "",
+        "selected_device": selected_device or "",
+        "model": model_name or "",
+        "torch_version": str(env.get("torch_version") or env.get("torch") or "unknown"),
+        "platform": str(env.get("platform") or platform.system()),
+        "platform_machine": str(env.get("platform_machine") or platform.machine()),
+        "mps_built": str(env.get("mps_built")),
+        "mps_available": str(env.get("mps_available")),
+        "mps_fallback_env": str(env.get("mps_fallback_env") or os.environ.get(MPS_FALLBACK_ENV, "")),
+    }
+    return {
+        "marker": MPS_UNSUPPORTED_MARKER,
+        "details": details,
+    }
 
 
 def _log_device_diagnostics(devices: List[Dict[str, str]], env: Dict[str, object]) -> None:
@@ -770,10 +829,12 @@ def main():
     else:
         print(f"STEMWERK_DIAG requested_device={device_preference}", file=sys.stderr)
 
+    runtime_env: Dict[str, object] = {}
     try:
         output_root = Path(args.output_dir).resolve()
         output_root.mkdir(parents=True, exist_ok=True)
-        _emit_runtime_diagnostics(resolved_device)
+        _enable_mps_runtime_fallback(device_preference, resolved_device)
+        runtime_env = _emit_runtime_diagnostics(resolved_device)
 
         sep = StemSeparator(model=args.model, device=resolved_device)
 
@@ -828,10 +889,23 @@ def main():
 
         return 0
     except Exception as exc:
-        print(f"ERROR: {exc}", file=sys.stderr)
         import traceback
 
-        traceback.print_exc(file=sys.stderr)
+        traceback_text = traceback.format_exc()
+        failure = _classify_runtime_failure(
+            exc,
+            traceback_text,
+            device_preference,
+            resolved_device,
+            args.model,
+            runtime_env,
+        )
+        if failure:
+            print(failure["marker"], file=sys.stderr)
+            for key, value in failure.get("details", {}).items():
+                print(f"STEMWERK_MPS_CONTEXT {key}={value}", file=sys.stderr)
+        print(f"ERROR: {exc}", file=sys.stderr)
+        print(traceback_text, file=sys.stderr, end="" if traceback_text.endswith("\n") else "\n")
         if write_done:
             write_done("ERROR")
         return 1

--- a/scripts/reaper/vendor/stemwerk-core/src/stemwerk_core/devices.py
+++ b/scripts/reaper/vendor/stemwerk-core/src/stemwerk_core/devices.py
@@ -16,6 +16,15 @@ def _windows_no_window_kwargs() -> Dict[str, int]:
     return {}
 
 
+def _is_macos_apple_silicon() -> bool:
+    machine = ""
+    try:
+        machine = platform.machine().lower()
+    except Exception:
+        machine = ""
+    return platform.system() == "Darwin" and machine in {"arm64", "aarch64"}
+
+
 def _rocm_arches_from_rocminfo() -> List[str]:
     """Best-effort list of GPU arch names (gfx...) in enumeration order."""
     try:
@@ -226,6 +235,13 @@ def select_device(requested_device: str = "auto") -> Tuple[str, str]:
         return None
 
     if requested_device == "auto":
+        if _is_macos_apple_silicon():
+            has_mps = any(
+                str(dev.get("id", "")) == "mps" or str(dev.get("type", "")) == "mps"
+                for dev in available
+            )
+            if has_mps:
+                return "cpu", "CPU"
         for dev in available:
             if dev["type"] in ("cuda", "directml", "mps"):
                 return dev["id"], dev["name"]

--- a/tests/test_macos_mps_fallback.py
+++ b/tests/test_macos_mps_fallback.py
@@ -1,0 +1,123 @@
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CORE_SRC = ROOT / "scripts" / "reaper" / "vendor" / "stemwerk-core" / "src"
+
+if str(CORE_SRC) not in sys.path:
+    sys.path.insert(0, str(CORE_SRC))
+
+
+def _load_audio_separator_process_module():
+    path = ROOT / "scripts" / "reaper" / "audio_separator_process.py"
+    spec = importlib.util.spec_from_file_location("audio_separator_process_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fake_torch(mps_available=True):
+    return SimpleNamespace(
+        backends=SimpleNamespace(
+            mps=SimpleNamespace(
+                is_available=lambda: mps_available,
+                is_built=lambda: True,
+            )
+        )
+    )
+
+
+def test_select_device_auto_prefers_cpu_on_macos_apple_silicon(monkeypatch):
+    import stemwerk_core.devices as devices
+
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(mps_available=True))
+    monkeypatch.setattr(devices.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(devices.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(
+        devices,
+        "get_available_devices",
+        lambda: [
+            {"id": "auto", "name": "Auto", "type": "auto"},
+            {"id": "cpu", "name": "CPU", "type": "cpu"},
+            {"id": "mps", "name": "Apple MPS", "type": "mps"},
+        ],
+    )
+
+    device_id, device_name = devices.select_device("auto")
+
+    assert (device_id, device_name) == ("cpu", "CPU")
+
+
+def test_select_device_explicit_mps_still_uses_mps(monkeypatch):
+    import stemwerk_core.devices as devices
+
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(mps_available=True))
+    monkeypatch.setattr(devices.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(devices.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(
+        devices,
+        "get_available_devices",
+        lambda: [
+            {"id": "auto", "name": "Auto", "type": "auto"},
+            {"id": "cpu", "name": "CPU", "type": "cpu"},
+            {"id": "mps", "name": "Apple MPS", "type": "mps"},
+        ],
+    )
+
+    device_id, device_name = devices.select_device("mps")
+
+    assert (device_id, device_name) == ("mps", "Apple MPS")
+
+
+def test_enable_mps_runtime_fallback_sets_env(monkeypatch):
+    module = _load_audio_separator_process_module()
+    monkeypatch.delenv(module.MPS_FALLBACK_ENV, raising=False)
+
+    changed = module._enable_mps_runtime_fallback("mps", "mps")
+
+    assert changed is True
+    assert os.environ[module.MPS_FALLBACK_ENV] == "1"
+
+
+def test_classify_runtime_failure_marks_known_mps_limitation():
+    module = _load_audio_separator_process_module()
+    exc = NotImplementedError(
+        "Output channels > 65536 not supported at the MPS device. "
+        "As a temporary fix, you can set the environment variable "
+        "PYTORCH_ENABLE_MPS_FALLBACK=1 to use the CPU as a fallback for this op."
+    )
+    env = {
+        "torch_version": "2.5.1",
+        "platform": "Darwin",
+        "platform_machine": "arm64",
+        "mps_built": True,
+        "mps_available": True,
+        "mps_fallback_env": "1",
+    }
+
+    classified = module._classify_runtime_failure(
+        exc,
+        "traceback...",
+        requested_device="mps",
+        selected_device="mps",
+        model_name="htdemucs_ft",
+        env=env,
+    )
+
+    assert classified is not None
+    assert classified["marker"] == module.MPS_UNSUPPORTED_MARKER
+    assert classified["details"]["requested_device"] == "mps"
+    assert classified["details"]["selected_device"] == "mps"
+    assert classified["details"]["model"] == "htdemucs_ft"
+
+
+def test_failure_message_uses_mps_marker():
+    script = (ROOT / "scripts" / "reaper" / "STEMwerk.lua").read_text(encoding="utf-8")
+
+    assert "STEMWERK_MPS_UNSUPPORTED_OP output_channels_gt_65536" in script
+    assert "Apple MPS failed because this model hits a PyTorch MPS limitation." in script


### PR DESCRIPTION
Real Apple Silicon user logs confirmed this is no longer a setup/bootstrap issue: HTDemucs on PyTorch MPS can fail during inference with:

`NotImplementedError: Output channels > 65536 not supported at the MPS device`

This change makes macOS behavior safer without changing dependency stacks.

What changed:
- Auto on Apple Silicon now chooses CPU instead of MPS for safer default behavior.
- Explicit Apple MPS remains available, but the backend now sets `PYTORCH_ENABLE_MPS_FALLBACK=1`.
- The backend classifies the known MPS unsupported-op failure and writes a stable marker:
  - `STEMWERK_MPS_UNSUPPORTED_OP output_channels_gt_65536`
- Lua detects that marker and shows a specific user-facing message instead of generic `No stems created`.

Impact:
- CPU path is unchanged.
- Linux, Windows, and Intel macOS behavior are unchanged by intent.
- No dependency stack changes are included in this PR.

Validation:
- `python3 -m compileall scripts/reaper/audio_separator_process.py`
- `pytest -q tests/test_macos_mps_fallback.py`
- `luac -p scripts/reaper/STEMwerk.lua`
- `luac -p scripts/reaper/_internal/STEMwerk_Workflow.lua`
