### PR TITLE
support: add support bundle collector

### DIFF
--- a/.github/workflows/support-bundle-headless.yml
+++ b/.github/workflows/support-bundle-headless.yml
@@ -1,0 +1,43 @@
+name: Support Bundle Headless
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: support-bundle-headless-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  headless-support-bundle:
+    name: Headless Support Bundle (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-14]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Lua
+        uses: leafo/gh-actions-lua@v11
+        with:
+          luaVersion: "5.4"
+
+      - name: Show Lua version
+        shell: bash
+        run: |
+          lua -v
+          luac -v
+
+      - name: Validate support bundle Lua files
+        shell: bash
+        run: |
+          luac -p scripts/reaper/STEMwerk_Save_Support_Bundle.lua
+          luac -p tests/support/run_support_bundle_headless.lua
+
+      - name: Run headless support bundle coverage
+        shell: bash
+        run: lua tests/support/run_support_bundle_headless.lua

--- a/.github/workflows/support-bundle-headless.yml
+++ b/.github/workflows/support-bundle-headless.yml
@@ -32,8 +32,16 @@ jobs:
         shell: pwsh
         run: |
           choco install lua -y
-          lua -v
-          luac -v
+          $luaDir = "C:\Program Files (x86)\Lua\5.1"
+          if (!(Test-Path "$luaDir\lua.exe")) {
+            Write-Host "Lua directory listing:"
+            Get-ChildItem "C:\Program Files (x86)\Lua" -Recurse -ErrorAction SilentlyContinue
+            throw "lua.exe not found at expected path: $luaDir\lua.exe"
+          }
+          echo "$luaDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          $env:PATH = "$luaDir;$env:PATH"
+          & "$luaDir\lua.exe" -v
+          & "$luaDir\luac.exe" -v
 
       - name: Show Lua version
         shell: bash

--- a/.github/workflows/support-bundle-headless.yml
+++ b/.github/workflows/support-bundle-headless.yml
@@ -44,17 +44,39 @@ jobs:
           & "$luaDir\luac.exe" -v
 
       - name: Show Lua version
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           lua -v
           luac -v
 
+      - name: Show Lua version on Windows
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          "/c/Program Files (x86)/Lua/5.1/lua.exe" -v
+          "/c/Program Files (x86)/Lua/5.1/luac.exe" -v
+
       - name: Validate support bundle Lua files
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           luac -p scripts/reaper/STEMwerk_Save_Support_Bundle.lua
           luac -p tests/support/run_support_bundle_headless.lua
 
+      - name: Validate support bundle Lua files on Windows
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          "/c/Program Files (x86)/Lua/5.1/luac.exe" -p scripts/reaper/STEMwerk_Save_Support_Bundle.lua
+          "/c/Program Files (x86)/Lua/5.1/luac.exe" -p tests/support/run_support_bundle_headless.lua
+
       - name: Run headless support bundle coverage
+        if: runner.os != 'Windows'
         shell: bash
         run: lua tests/support/run_support_bundle_headless.lua
+
+      - name: Run headless support bundle coverage on Windows
+        if: runner.os == 'Windows'
+        shell: bash
+        run: '"/c/Program Files (x86)/Lua/5.1/lua.exe" tests/support/run_support_bundle_headless.lua'

--- a/.github/workflows/support-bundle-headless.yml
+++ b/.github/workflows/support-bundle-headless.yml
@@ -22,9 +22,18 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Lua
+        if: runner.os != 'Windows'
         uses: leafo/gh-actions-lua@v11
         with:
           luaVersion: "5.4"
+
+      - name: Set up Lua on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install lua -y
+          lua -v
+          luac -v
 
       - name: Show Lua version
         shell: bash

--- a/index.xml
+++ b/index.xml
@@ -13,6 +13,7 @@
 ]]></changelog>
         <source file="../STEMwerk.lua" type="script" main="main">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/STEMwerk.lua</source>
         <source file="../STEMwerk-SETUP.lua" type="script">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/STEMwerk-SETUP.lua</source>
+        <source file="../STEMwerk_Save_Support_Bundle.lua" type="script">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/STEMwerk_Save_Support_Bundle.lua</source>
         <source file="../STEMwerk_AI_Separate.lua" type="script">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/STEMwerk_AI_Separate.lua</source>
         <source file="../STEMwerk_Setup_Toolbar.lua" type="script">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/STEMwerk_Setup_Toolbar.lua</source>
         <source file="../STEMwerk_Explode_Takes.lua" type="script">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/STEMwerk_Explode_Takes.lua</source>

--- a/scripts/reaper/STEMwerk_Save_Support_Bundle.lua
+++ b/scripts/reaper/STEMwerk_Save_Support_Bundle.lua
@@ -1,0 +1,1503 @@
+-- @description Stemwerk: Save Support Bundle
+-- @author flarkAUDIO <flarkaudio@pm.me>
+-- @version 2.2.2.1.7
+-- @changelog
+--   Collects a read-only STEMwerk support bundle with runtime diagnostics, logs, and temp-folder inventory.
+-- @link Repository https://github.com/flarkflarkflark/STEMwerk
+
+local EXT_SECTION = "STEMwerk"
+
+local function msgBox(title, text, boxType)
+    if reaper and reaper.ShowMessageBox then
+        return reaper.ShowMessageBox(tostring(text or ""), tostring(title or "STEMwerk"), boxType or 0)
+    end
+    return 0
+end
+
+local function getScriptDir()
+    local info = debug.getinfo(1, "S")
+    return (info and info.source and info.source:match("@?(.*[/\\])")) or ""
+end
+
+local SCRIPT_DIR = getScriptDir()
+
+local function getOS()
+    local ros = ""
+    if reaper and reaper.GetOS then
+        ros = tostring(reaper.GetOS() or "")
+    end
+    if ros:match("Win") then return "Windows", ros end
+    if ros:match("OSX") or ros:match("macOS") then return "macOS", ros end
+    return "Linux", ros
+end
+
+local OS, REAPER_OS_RAW = getOS()
+local PATH_SEP = OS == "Windows" and "\\" or "/"
+
+local function pad2(n)
+    n = tonumber(n) or 0
+    if n < 10 then return "0" .. tostring(n) end
+    return tostring(n)
+end
+
+local function timestampParts(epoch)
+    local now = os.date("*t", epoch or os.time())
+    return now, string.format(
+        "%04d%s%s-%s%s%s",
+        tonumber(now.year) or 0,
+        pad2(now.month),
+        pad2(now.day),
+        pad2(now.hour),
+        pad2(now.min),
+        pad2(now.sec)
+    )
+end
+
+local function trim(value)
+    local text = tostring(value or "")
+    return (text:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+local function startsWith(text, prefix)
+    text = tostring(text or "")
+    prefix = tostring(prefix or "")
+    return prefix ~= "" and text:sub(1, #prefix) == prefix
+end
+
+local function endsWith(text, suffix)
+    text = tostring(text or "")
+    suffix = tostring(suffix or "")
+    return suffix ~= "" and text:sub(-#suffix) == suffix
+end
+
+local function normalizePath(path)
+    local p = tostring(path or "")
+    if p == "" then return "" end
+    if OS == "Windows" then
+        p = p:gsub("/", "\\"):lower()
+    else
+        p = p:gsub("\\", "/")
+    end
+    return p
+end
+
+local function stripTrailingSep(path)
+    return tostring(path or ""):gsub("[/\\]+$", "")
+end
+
+local function joinPath(...)
+    local parts = { ... }
+    local out = ""
+    for i = 1, #parts do
+        local part = tostring(parts[i] or "")
+        if part ~= "" then
+            if out == "" then
+                out = part:gsub("[/\\]+$", "")
+            else
+                part = part:gsub("^[/\\]+", ""):gsub("[/\\]+$", "")
+                out = out .. PATH_SEP .. part
+            end
+        end
+    end
+    return out
+end
+
+local function fileExists(path)
+    if not path or path == "" then return false end
+    local f = io.open(path, "rb")
+    if f then
+        f:close()
+        return true
+    end
+    return false
+end
+
+local function pathExists(path)
+    if not path or path == "" then return false end
+    local ok, _, code = os.rename(path, path)
+    if ok then return true end
+    return tonumber(code) == 13
+end
+
+local function ensureDir(path)
+    if not path or path == "" then return false end
+    if reaper and reaper.RecursiveCreateDirectory then
+        reaper.RecursiveCreateDirectory(path, 0)
+        return pathExists(path)
+    end
+    if OS == "Windows" then
+        os.execute('mkdir "' .. tostring(path):gsub('"', '""') .. '" 2>nul')
+    else
+        os.execute("mkdir -p " .. "'" .. tostring(path):gsub("'", "'\\''") .. "' >/dev/null 2>&1")
+    end
+    return pathExists(path)
+end
+
+local function readFile(path, mode)
+    local f = io.open(path, mode or "rb")
+    if not f then return nil end
+    local data = f:read("*a")
+    f:close()
+    return data
+end
+
+local function writeFile(path, data, mode)
+    local f = io.open(path, mode or "wb")
+    if not f then return false end
+    f:write(data or "")
+    f:close()
+    return true
+end
+
+local function fileSizeBytes(path)
+    local f = io.open(path, "rb")
+    if not f then return nil end
+    local size = f:seek("end")
+    f:close()
+    return tonumber(size)
+end
+
+local function quoteArg(arg)
+    arg = tostring(arg or "")
+    if OS == "Windows" then
+        return '"' .. arg:gsub('"', '""') .. '"'
+    end
+    if arg == "" then return "''" end
+    return "'" .. arg:gsub("'", "'\\''") .. "'"
+end
+
+local function buildCommand(exe, args)
+    local parts = { quoteArg(exe) }
+    for i = 1, #(args or {}) do
+        parts[#parts + 1] = quoteArg(args[i])
+    end
+    return table.concat(parts, " ")
+end
+
+local function execCapturePipe(cmd)
+    if not io or not io.popen then
+        return -1, ""
+    end
+    local handle = io.popen(cmd .. " 2>&1", "r")
+    if not handle then
+        return -1, ""
+    end
+    local out = handle:read("*a") or ""
+    local ok, _, code = handle:close()
+    if ok == true then
+        return 0, out
+    end
+    return tonumber(code) or -1, out
+end
+
+local function execCapture(cmd, timeoutMs)
+    if reaper and reaper.ExecProcess then
+        local rc, out = reaper.ExecProcess(cmd, timeoutMs or 8000)
+        return tonumber(rc) or -1, out or ""
+    end
+    return execCapturePipe(cmd)
+end
+
+local function buildShellCommand(cmd, timeoutMs)
+    local shellCmd = tostring(cmd or "")
+    if OS == "Linux" and timeoutMs and timeoutMs > 0 then
+        local seconds = math.max(1, math.ceil((tonumber(timeoutMs) or 0) / 1000))
+        shellCmd = "timeout " .. tostring(seconds) .. "s " .. shellCmd
+    end
+    return shellCmd
+end
+
+local function execCommand(exe, args, timeoutMs)
+    local cmd = buildCommand(exe, args or {})
+    if OS ~= "Windows" then
+        local shellCmd = buildShellCommand(cmd, timeoutMs)
+        local rc, out = execCapturePipe(shellCmd)
+        if rc == 0 or trim(out) ~= "" then
+            return rc, out
+        end
+        if reaper and reaper.ExecProcess then
+            local sh = fileExists("/bin/sh") and "/bin/sh" or "sh"
+            return execCapture(buildCommand(sh, {"-lc", shellCmd}), timeoutMs)
+        end
+        return rc, out
+    end
+    return execCapture(cmd, timeoutMs)
+end
+
+local function execPowerShell(script, timeoutMs)
+    return execCommand("powershell.exe", {"-NoProfile", "-Command", script}, timeoutMs or 8000)
+end
+
+local function openPath(path)
+    if not path or path == "" then return end
+    if reaper and reaper.CF_ShellExecute then
+        reaper.CF_ShellExecute(path)
+        return
+    end
+    if OS == "Windows" then
+        execCommand("explorer.exe", {path}, 1000)
+    elseif OS == "macOS" then
+        execCommand("open", {path}, 1000)
+    else
+        execCommand("xdg-open", {path}, 1000)
+    end
+end
+
+local function basename(path)
+    local clean = tostring(path or ""):gsub("[/\\]+$", "")
+    return clean:match("([^/\\]+)$") or clean
+end
+
+local function sanitizePathValue(path)
+    local value = trim(path)
+    if value == "" then return "missing" end
+    return value
+end
+
+local function sanitizeUserFolder(path)
+    local value = trim(path)
+    if value == "" then return "not set" end
+    return basename(value) .. " (sanitized)"
+end
+
+local MEDIA_PATH_EXTENSIONS = {
+    "wav", "flac", "mp3", "aiff", "aif", "m4a", "ogg", "opus", "mp4", "mov"
+}
+
+local function classifyMediaArtifact(pathLower)
+    for i = 1, #MEDIA_PATH_EXTENSIONS do
+        local ext = MEDIA_PATH_EXTENSIONS[i]
+        if pathLower:match("%." .. ext .. "$") then
+            return "media"
+        end
+        if pathLower:match("%." .. ext .. "%.ffmpeg%.log$") then
+            return "ffmpeg_log"
+        end
+        if pathLower:match("%." .. ext .. "%.reapeaks$") then
+            return "reapeaks"
+        end
+    end
+    return nil
+end
+
+local function sanitizeAbsolutePathToken(token)
+    local suffix = token:match("([,%);%]%}]+)$") or ""
+    local core = suffix ~= "" and token:sub(1, #token - #suffix) or token
+    local lower = core:lower()
+    local artifactKind = classifyMediaArtifact(lower)
+    local tempRoot, tempRest = core:match("^(.*[/\\]STEMwerk_[^/\\%s\"']+)(.*)$")
+    local isTempPath = tempRoot ~= nil
+
+    if artifactKind == "ffmpeg_log" then
+        return (isTempPath and "[STEMWERK_TEMP_DIR]" or "[TEMP_DIR]") .. "/[TEMP_AUDIO_FILE].ffmpeg.log" .. suffix
+    end
+    if artifactKind == "reapeaks" then
+        return (isTempPath and "[STEMWERK_TEMP_DIR]" or "[TEMP_DIR]") .. "/[TEMP_AUDIO_FILE].reapeaks" .. suffix
+    end
+    if artifactKind == "media" then
+        return (isTempPath and "[TEMP_AUDIO_FILE]" or "[MEDIA_FILE]") .. suffix
+    end
+    if lower:match("%.rpp$") then
+        return "[PROJECT_FILE]" .. suffix
+    end
+    if isTempPath then
+        return "[STEMWERK_TEMP_DIR]" .. (tempRest or "") .. suffix
+    end
+    return token
+end
+
+local function sanitizeTextContent(text)
+    local sanitized = tostring(text or "")
+    sanitized = sanitized:gsub("([A-Za-z]:[/\\][^%s\"'<>]+%.[Ww][Aa][Vv])", sanitizeAbsolutePathToken)
+    sanitized = sanitized:gsub("([A-Za-z]:[/\\][^%s\"'<>]+%.[Ff][Ll][Aa][Cc])", sanitizeAbsolutePathToken)
+    sanitized = sanitized:gsub("([A-Za-z]:[/\\][^%s\"'<>]+%.[Mm][Pp]3)", sanitizeAbsolutePathToken)
+    sanitized = sanitized:gsub("([A-Za-z]:[/\\][^%s\"'<>]+%.[Aa][Ii][Ff][Ff]?)", sanitizeAbsolutePathToken)
+    sanitized = sanitized:gsub("([A-Za-z]:[/\\][^%s\"'<>]+%.[Mm]4[Aa])", sanitizeAbsolutePathToken)
+    sanitized = sanitized:gsub("([A-Za-z]:[/\\][^%s\"'<>]+%.[Oo][Gg][Gg])", sanitizeAbsolutePathToken)
+    sanitized = sanitized:gsub("([A-Za-z]:[/\\][^%s\"'<>]+%.[Oo][Pp][Uu][Ss])", sanitizeAbsolutePathToken)
+    sanitized = sanitized:gsub("([A-Za-z]:[/\\][^%s\"'<>]+%.[Mm][Pp]4)", sanitizeAbsolutePathToken)
+    sanitized = sanitized:gsub("([A-Za-z]:[/\\][^%s\"'<>]+%.[Mm][Oo][Vv])", sanitizeAbsolutePathToken)
+    sanitized = sanitized:gsub("(/[^%s\"'<>]+%.[Ww][Aa][Vv])", sanitizeAbsolutePathToken)
+    sanitized = sanitized:gsub("(/[^%s\"'<>]+%.[Ff][Ll][Aa][Cc])", sanitizeAbsolutePathToken)
+    sanitized = sanitized:gsub("(/[^%s\"'<>]+%.[Mm][Pp]3)", sanitizeAbsolutePathToken)
+    sanitized = sanitized:gsub("(/[^%s\"'<>]+%.[Aa][Ii][Ff][Ff]?)", sanitizeAbsolutePathToken)
+    sanitized = sanitized:gsub("(/[^%s\"'<>]+%.[Mm]4[Aa])", sanitizeAbsolutePathToken)
+    sanitized = sanitized:gsub("(/[^%s\"'<>]+%.[Oo][Gg][Gg])", sanitizeAbsolutePathToken)
+    sanitized = sanitized:gsub("(/[^%s\"'<>]+%.[Oo][Pp][Uu][Ss])", sanitizeAbsolutePathToken)
+    sanitized = sanitized:gsub("(/[^%s\"'<>]+%.[Mm][Pp]4)", sanitizeAbsolutePathToken)
+    sanitized = sanitized:gsub("(/[^%s\"'<>]+%.[Mm][Oo][Vv])", sanitizeAbsolutePathToken)
+    sanitized = sanitized:gsub('"([A-Za-z]:[/\\][^"\r\n]+)"', function(path)
+        return '"' .. sanitizeAbsolutePathToken(path) .. '"'
+    end)
+    sanitized = sanitized:gsub('"(/[^"\r\n]+)"', function(path)
+        return '"' .. sanitizeAbsolutePathToken(path) .. '"'
+    end)
+    sanitized = sanitized:gsub("'([A-Za-z]:[/\\][^'\r\n]+)'", function(path)
+        return "'" .. sanitizeAbsolutePathToken(path) .. "'"
+    end)
+    sanitized = sanitized:gsub("'(/[^'\r\n]+)'", function(path)
+        return "'" .. sanitizeAbsolutePathToken(path) .. "'"
+    end)
+    sanitized = sanitized:gsub("([A-Za-z]:[/\\][^%s\"'<>]+)", sanitizeAbsolutePathToken)
+    sanitized = sanitized:gsub("(/[^%s\"'<>]+)", sanitizeAbsolutePathToken)
+    return sanitized
+end
+
+local function humanBytes(bytes)
+    bytes = tonumber(bytes) or 0
+    local units = {"B", "KB", "MB", "GB"}
+    local idx = 1
+    while bytes >= 1024 and idx < #units do
+        bytes = bytes / 1024
+        idx = idx + 1
+    end
+    if idx == 1 then
+        return string.format("%d %s", math.floor(bytes), units[idx])
+    end
+    return string.format("%.1f %s", bytes, units[idx])
+end
+
+local function readEnvFile(path)
+    local data = {}
+    if not path or path == "" then return data end
+    local f = io.open(path, "r")
+    if not f then return data end
+    for line in f:lines() do
+        local key, value = line:match("^([A-Z0-9_]+)%s*=%s*(.*)$")
+        if key and value then
+            data[key] = value:gsub("\r", "")
+        end
+    end
+    f:close()
+    return data
+end
+
+local function parseKeyValueText(text)
+    local data = {}
+    for line in tostring(text or ""):gmatch("[^\r\n]+") do
+        local key, value = line:match("^([%w%._%-]+)=(.*)$")
+        if key then
+            data[key] = trim(value)
+        end
+    end
+    return data
+end
+
+local function readVersionHeader(path)
+    local f = io.open(path, "r")
+    if not f then return "" end
+    for _ = 1, 80 do
+        local line = f:read("*l")
+        if not line then break end
+        local version = line:match("^%-%-%s*@version%s+([%w%._%-]+)")
+        if version and version ~= "" then
+            f:close()
+            return version
+        end
+    end
+    f:close()
+    return ""
+end
+
+local function readAppVersionConstant(path)
+    local f = io.open(path, "r")
+    if not f then return "" end
+    for _ = 1, 140 do
+        local line = f:read("*l")
+        if not line then break end
+        local version = line:match('local%s+APP_VERSION%s*=%s*"([^"]+)"')
+        if version and version ~= "" then
+            f:close()
+            return version
+        end
+    end
+    f:close()
+    return ""
+end
+
+local function readPackageVersion(rootPath, mainVersion)
+    local versionFile = joinPath(rootPath, "VERSION")
+    local raw = readFile(versionFile, "rb")
+    if raw and trim(raw) ~= "" then
+        return trim(raw)
+    end
+    return mainVersion or ""
+end
+
+local function loadPathHelper()
+    local ok, mod = pcall(dofile, SCRIPT_DIR .. "_internal/STEMwerk_Path_Helper.lua")
+    if ok and type(mod) == "table" then
+        return mod
+    end
+    return nil
+end
+
+local PATH_HELPER = loadPathHelper()
+local INSTALL = PATH_HELPER and PATH_HELPER.resolveInstallRoot(SCRIPT_DIR, { os = OS }) or {
+    ok = true,
+    root = SCRIPT_DIR,
+    scriptsDir = SCRIPT_DIR,
+    canonical = "",
+    reapack = "",
+    status = "fallback",
+}
+
+local function getResourcePath()
+    if reaper and reaper.GetResourcePath then
+        local rp = tostring(reaper.GetResourcePath() or "")
+        if rp ~= "" then
+            return rp
+        end
+    end
+    if PATH_HELPER and PATH_HELPER.getReaperResourcePath then
+        return PATH_HELPER.getReaperResourcePath(OS, PATH_SEP)
+    end
+    local home = os.getenv(OS == "Windows" and "USERPROFILE" or "HOME") or "/tmp"
+    if OS == "Windows" then
+        return (os.getenv("APPDATA") or (home .. "\\AppData\\Roaming")) .. "\\REAPER"
+    elseif OS == "macOS" then
+        return home .. "/Library/Application Support/REAPER"
+    end
+    return home .. "/.config/REAPER"
+end
+
+local function isAbsolutePath(path)
+    local value = tostring(path or "")
+    if value == "" then return false end
+    if value:match("^%a:[/\\]") then return true end
+    return value:sub(1, 1) == "/"
+end
+
+local function extStateValue(key)
+    if reaper and reaper.GetExtState then
+        return tostring(reaper.GetExtState(EXT_SECTION, key) or "")
+    end
+    return ""
+end
+
+local function getHome()
+    if OS == "Windows" then
+        return os.getenv("USERPROFILE") or "C:\\Users\\Default"
+    end
+    return os.getenv("HOME") or "/tmp"
+end
+
+local function detectRuntimeBase()
+    local override = trim(extStateValue("runtimeBase"))
+    if override ~= "" and isAbsolutePath(override) then
+        return override, "extstate"
+    end
+
+    local home = getHome()
+    local candidates = {}
+    if OS == "Windows" then
+        local localAppData = os.getenv("LOCALAPPDATA") or ""
+        if localAppData ~= "" then
+            candidates[#candidates + 1] = localAppData .. "\\STEMwerk"
+        end
+    elseif OS == "macOS" then
+        candidates[#candidates + 1] = home .. "/Library/Application Support/STEMwerk"
+    else
+        local xdg = os.getenv("XDG_DATA_HOME") or ""
+        if xdg ~= "" then
+            candidates[#candidates + 1] = xdg .. "/STEMwerk"
+        end
+        candidates[#candidates + 1] = home .. "/.local/share/STEMwerk"
+    end
+
+    for i = 1, #candidates do
+        if pathExists(candidates[i]) then
+            return candidates[i], "existing_default"
+        end
+    end
+
+    return candidates[1] or (home .. PATH_SEP .. ".STEMwerk"), "default_candidate"
+end
+
+local function getRuntimePaths(runtimeBase)
+    local base = runtimeBase or ""
+    local venvDir = joinPath(base, ".venv")
+    return {
+        base = base,
+        runtimeState = joinPath(base, "state"),
+        runtimeLogs = joinPath(base, "logs"),
+        runtimeCache = joinPath(base, "cache"),
+        venvDir = venvDir,
+        venvPython = OS == "Windows" and joinPath(venvDir, "Scripts", "python.exe") or joinPath(venvDir, "bin", "python"),
+    }
+end
+
+local function resolveCommandOnPath(name)
+    if not name or name == "" then return "" end
+    if OS == "Windows" then
+        local rc, out = execCommand("where.exe", {name}, 5000)
+        if rc == 0 and out ~= "" then
+            local first = trim((out:gsub("\r", "")):match("([^\n]+)"))
+            return first or ""
+        end
+    else
+        local rc, out = execCommand("which", {name}, 5000)
+        if rc == 0 and out ~= "" then
+            local first = trim((out:gsub("\r", "")):match("([^\n]+)"))
+            return first or ""
+        end
+    end
+    return ""
+end
+
+local function firstUsablePath(candidates)
+    local seen = {}
+    for i = 1, #candidates do
+        local value = trim(candidates[i])
+        local key = normalizePath(value)
+        if value ~= "" and not seen[key] then
+            seen[key] = true
+            if not isAbsolutePath(value) then
+                return value
+            end
+            if fileExists(value) or pathExists(value) then
+                return value
+            end
+        end
+    end
+    return ""
+end
+
+local function getTempBase()
+    if OS == "Windows" then
+        return os.getenv("TEMP") or os.getenv("TMP") or "C:\\Temp"
+    end
+    local flatpakId = os.getenv("FLATPAK_ID")
+    local container = trim(os.getenv("container"))
+    if (flatpakId and flatpakId ~= "") or container:lower():find("flatpak", 1, true) then
+        return joinPath(getHome(), ".cache", "STEMwerk")
+    end
+    return os.getenv("TMPDIR") or "/tmp"
+end
+
+local function shouldIgnoreTempFolder(name)
+    local lower = tostring(name or ""):lower()
+    if lower == "" then return true end
+    if lower:match("^stemwerk%-support%-bundle%-headless%-") then return true end
+    if lower:match("^support%-bundle%-headless%-") then return true end
+    if lower:match("^stemwerk[_%-].*support[_%-]bundle[_%-]headless") then return true end
+    return false
+end
+
+local function enumerateSubdirs(path)
+    local out = {}
+    if not (reaper and reaper.EnumerateSubdirectories) then
+        return out
+    end
+    local idx = 0
+    while true do
+        local name = reaper.EnumerateSubdirectories(path, idx)
+        if not name then break end
+        out[#out + 1] = tostring(name)
+        idx = idx + 1
+    end
+    return out
+end
+
+local function enumerateFiles(path)
+    local out = {}
+    if not (reaper and reaper.EnumerateFiles) then
+        return out
+    end
+    local idx = 0
+    while true do
+        local name = reaper.EnumerateFiles(path, idx)
+        if not name then break end
+        out[#out + 1] = tostring(name)
+        idx = idx + 1
+    end
+    return out
+end
+
+local function getPathStat(path)
+    if not path or path == "" then
+        return {
+            ok = false,
+            epoch = 0,
+            size = nil,
+            sizeLabel = "unavailable (missing path)",
+            mtime = "unavailable (missing path)",
+            kind = "missing",
+            reason = "missing path",
+        }
+    end
+
+    local kind = fileExists(path) and "file" or (pathExists(path) and "dir" or "missing")
+    if kind == "missing" then
+        return {
+            ok = false,
+            epoch = 0,
+            size = nil,
+            sizeLabel = "unavailable (missing)",
+            mtime = "unavailable (missing)",
+            kind = kind,
+            reason = "missing",
+        }
+    end
+
+    local rc, out
+    if OS == "Windows" then
+        local literal = tostring(path):gsub("'", "''")
+        rc, out = execPowerShell(
+            "$item = Get-Item -LiteralPath '" .. literal .. "' -ErrorAction Stop; " ..
+            "Write-Output ([DateTimeOffset]$item.LastWriteTime).ToUnixTimeSeconds(); " ..
+            "if ($item.PSIsContainer) { Write-Output 0 } else { Write-Output $item.Length }",
+            5000
+        )
+    elseif OS == "macOS" then
+        rc, out = execCommand("stat", {"-f", "%m\n%z", path}, 5000)
+    else
+        rc, out = execCommand("stat", {"-c", "%Y\n%s", path}, 5000)
+    end
+
+    if rc ~= 0 or trim(out) == "" then
+        local fallbackSize = (kind == "file") and fileSizeBytes(path) or nil
+        local reason = "stat failed"
+        if rc == 124 then
+            reason = "stat timed out"
+        elseif rc ~= 0 then
+            reason = "stat failed (exit " .. tostring(rc) .. ")"
+        end
+        return {
+            ok = false,
+            epoch = 0,
+            size = fallbackSize,
+            sizeLabel = fallbackSize and humanBytes(fallbackSize) or ("unavailable (" .. reason .. ")"),
+            mtime = "unavailable (" .. reason .. ")",
+            kind = kind,
+            reason = reason,
+        }
+    end
+
+    local lines = {}
+    for line in tostring(out):gmatch("[^\r\n]+") do
+        lines[#lines + 1] = trim(line)
+    end
+    local epoch = tonumber(lines[1]) or 0
+    local size = tonumber(lines[2])
+    if kind == "dir" then
+        size = nil
+    elseif size == nil or size < 0 then
+        size = fileSizeBytes(path)
+    end
+    local mtime = epoch > 0 and os.date("%Y-%m-%d %H:%M:%S", epoch) or "unavailable (invalid timestamp)"
+    return {
+        ok = epoch > 0 or size ~= nil,
+        epoch = epoch,
+        size = size,
+        sizeLabel = (kind == "dir") and "-" or (size and humanBytes(size) or "unavailable (size probe failed)"),
+        mtime = mtime,
+        kind = kind,
+        reason = (epoch > 0 or size ~= nil) and "" or "stat returned incomplete metadata",
+    }
+end
+
+local function copySupportTextFile(src, dst, maxBytes)
+    maxBytes = tonumber(maxBytes) or (512 * 1024)
+    local f = io.open(src, "rb")
+    if not f then return false, "missing" end
+    local size = f:seek("end") or 0
+    f:seek("set", 0)
+
+    local data
+    if size <= maxBytes then
+        data = f:read("*a") or ""
+    else
+        local headBytes = math.floor(maxBytes * 0.60)
+        local tailBytes = math.max(0, maxBytes - headBytes)
+        local head = f:read(headBytes) or ""
+        local tail = ""
+        if tailBytes > 0 and size > tailBytes then
+            f:seek("end", -tailBytes)
+            tail = f:read("*a") or ""
+        end
+        data = table.concat({
+            "[STEMwerk support bundle] File truncated to keep the bundle small.\n",
+            "Original size: " .. tostring(size) .. " bytes\n",
+            "Included: first " .. tostring(#head) .. " bytes and last " .. tostring(#tail) .. " bytes\n",
+            "----- BEGIN HEAD -----\n",
+            head,
+            "\n----- END HEAD -----\n",
+            "----- BEGIN TAIL -----\n",
+            tail,
+            "\n----- END TAIL -----\n",
+        })
+    end
+    f:close()
+    data = sanitizeTextContent(data)
+    ensureDir(stripTrailingSep(dst):match("^(.*)[/\\][^/\\]+$") or "")
+    return writeFile(dst, data, "wb"), size > maxBytes and "truncated" or "copied"
+end
+
+local function appendLine(lines, text)
+    lines[#lines + 1] = tostring(text or "")
+end
+
+local function appendKey(lines, key, value)
+    appendLine(lines, string.format("%-28s %s", tostring(key) .. ":", tostring(value or "missing")))
+end
+
+local function modelModeLabel(model)
+    if model == "htdemucs_ft" then return "Quality" end
+    if model == "htdemucs_6s" then return "6-Stem" end
+    return "Fast"
+end
+
+local function boolLabel(value)
+    return value and "true" or "false"
+end
+
+local function extBool(key)
+    return trim(extStateValue(key)) == "1"
+end
+
+local mainScriptPath = joinPath(INSTALL.scriptsDir or SCRIPT_DIR, "STEMwerk.lua")
+local setupScriptPath = joinPath(INSTALL.scriptsDir or SCRIPT_DIR, "STEMwerk-SETUP.lua")
+local packageVersion = readPackageVersion(INSTALL.root or SCRIPT_DIR, readVersionHeader(mainScriptPath))
+local mainHeaderVersion = readVersionHeader(mainScriptPath)
+local mainAppVersion = readAppVersionConstant(mainScriptPath)
+local setupVersion = readVersionHeader(setupScriptPath)
+
+local runtimeBase, runtimeBaseSource = detectRuntimeBase()
+local runtimePaths = getRuntimePaths(runtimeBase)
+local bootstrapEnvPath = joinPath(runtimePaths.runtimeState, "bootstrap.env")
+local capabilitiesEnvPath = joinPath(runtimePaths.runtimeState, "capabilities.env")
+local bootstrapPidPath = joinPath(runtimePaths.runtimeState, "bootstrap.pid")
+local bootstrapGuardPath = joinPath(runtimePaths.runtimeState, "bootstrap.guard")
+local runtimeState = readEnvFile(bootstrapEnvPath)
+local capabilityState = readEnvFile(capabilitiesEnvPath)
+
+local detectedPythonPath = firstUsablePath({
+    capabilityState.PYTHON_PATH,
+    runtimeState.PYTHON_PATH,
+    runtimeState.VENV_PYTHON,
+    extStateValue("pythonPath"),
+    runtimePaths.venvPython,
+    resolveCommandOnPath("python3"),
+    resolveCommandOnPath("python"),
+})
+
+local detectedFfmpegPath = firstUsablePath({
+    capabilityState.FFMPEG_PATH,
+    runtimeState.FFMPEG_PATH,
+    extStateValue("ffmpegPath"),
+    resolveCommandOnPath("ffmpeg"),
+})
+
+local function detectReaPackVersion(resourcePath)
+    local direct = reaper and reaper.ReaPack_GetVersion
+    if type(direct) == "function" then
+        local ok, value = pcall(direct)
+        if ok and trim(value) ~= "" then
+            return trim(value), true
+        end
+    end
+
+    local iniCandidates = {
+        joinPath(resourcePath, "reapack.ini"),
+        joinPath(resourcePath, "reaper-reapack.ini"),
+        joinPath(resourcePath, "UserPlugins", "reapack.ini"),
+    }
+    for i = 1, #iniCandidates do
+        local raw = readFile(iniCandidates[i], "rb")
+        if raw then
+            local version = raw:match("[Vv]ersion%s*=%s*([%w%._%-]+)")
+            if version and version ~= "" then
+                return version, true
+            end
+        end
+    end
+
+    local pluginsDir = joinPath(resourcePath, "UserPlugins")
+    local pluginFound = false
+    for _, file in ipairs(enumerateFiles(pluginsDir)) do
+        if tostring(file):lower():find("reapack", 1, true) then
+            pluginFound = true
+            break
+        end
+    end
+
+    if pluginFound then
+        return "installed (version not detectable)", false
+    end
+    return "not detected", false
+end
+
+local function getPythonVersion(path)
+    if trim(path) == "" then return "missing" end
+    local rc, out = execCommand(path, {"--version"}, 8000)
+    if rc ~= 0 or trim(out) == "" then
+        rc, out = execCommand(path, {"-V"}, 8000)
+    end
+    local line = trim((out:gsub("\r", "")):match("([^\n]+)") or "")
+    if line ~= "" then
+        return line
+    end
+    if rc == 124 then
+        return "error: timeout"
+    end
+    return rc ~= 0 and ("error: probe failed (exit " .. tostring(rc) .. ")") or "error: no output"
+end
+
+local function getFfmpegVersion(path)
+    if trim(path) == "" then return "missing" end
+    local rc, out = execCommand(path, {"-version"}, 8000)
+    local line = trim((out:gsub("\r", "")):match("([^\n]+)") or "")
+    if line ~= "" then
+        return line
+    end
+    if rc == 124 then
+        return "error: timeout"
+    end
+    if rc ~= 0 then
+        return "error: probe failed (exit " .. tostring(rc) .. ")"
+    end
+    return "error: no output"
+end
+
+local function getPlatformDetails()
+    local details = {
+        architecture = "undetected",
+        osName = OS,
+        osVersion = trim(REAPER_OS_RAW) ~= "" and trim(REAPER_OS_RAW) or OS,
+        reaperOsRaw = REAPER_OS_RAW,
+        extraSummary = {},
+        rawBlocks = {},
+    }
+
+    if OS == "macOS" then
+        local _, swProduct = execCommand("sw_vers", {"-productVersion"}, 5000)
+        local _, swBuild = execCommand("sw_vers", {"-buildVersion"}, 5000)
+        local _, unameM = execCommand("uname", {"-m"}, 5000)
+        local productVersion = trim(swProduct)
+        local buildVersion = trim(swBuild)
+        local arch = trim(unameM)
+        details.architecture = arch ~= "" and arch or "undetected"
+        if productVersion ~= "" then
+            details.osVersion = "macOS " .. productVersion
+        end
+        details.extraSummary[#details.extraSummary + 1] = "sw_vers productVersion: " .. (productVersion ~= "" and productVersion or "missing")
+        details.extraSummary[#details.extraSummary + 1] = "sw_vers buildVersion: " .. (buildVersion ~= "" and buildVersion or "missing")
+        details.extraSummary[#details.extraSummary + 1] = "uname -m: " .. (arch ~= "" and arch or "missing")
+        local backend = trim(capabilityState.BACKEND or runtimeState.BACKEND or "")
+        local profile
+        if arch == "arm64" or arch == "aarch64" then
+            profile = "Apple Silicon macOS"
+        else
+            profile = "Intel macOS CPU fallback"
+        end
+        if backend ~= "" then
+            profile = profile .. " (backend=" .. backend .. ")"
+        end
+        details.extraSummary[#details.extraSummary + 1] = "detected profile: " .. profile
+        details.rawBlocks[#details.rawBlocks + 1] = "[sw_vers -productVersion]\n" .. trim(swProduct)
+        details.rawBlocks[#details.rawBlocks + 1] = "[sw_vers -buildVersion]\n" .. trim(swBuild)
+        details.rawBlocks[#details.rawBlocks + 1] = "[uname -m]\n" .. trim(unameM)
+    elseif OS == "Linux" then
+        local _, unameA = execCommand("uname", {"-a"}, 5000)
+        local _, unameM = execCommand("uname", {"-m"}, 5000)
+        local osRelease = readFile("/etc/os-release", "rb")
+        local prettyName = osRelease and (osRelease:match('\nPRETTY_NAME="([^"]+)"') or osRelease:match('^PRETTY_NAME="([^"]+)"')) or ""
+        local arch = trim(unameM)
+        if arch == "" then
+            arch = trim(os.getenv("HOSTTYPE") or os.getenv("MACHTYPE") or "")
+        end
+        details.architecture = arch ~= "" and arch or "undetected"
+        if prettyName ~= "" then
+            details.osVersion = prettyName
+        end
+        details.extraSummary[#details.extraSummary + 1] = "uname -m: " .. (arch ~= "" and arch or "missing")
+        details.extraSummary[#details.extraSummary + 1] = "uname -a: " .. trim(unameA)
+        details.extraSummary[#details.extraSummary + 1] = "/etc/os-release: " .. (osRelease and "included below" or "missing")
+        details.rawBlocks[#details.rawBlocks + 1] = "[uname -m]\n" .. trim(unameM)
+        details.rawBlocks[#details.rawBlocks + 1] = "[uname -a]\n" .. trim(unameA)
+        details.rawBlocks[#details.rawBlocks + 1] = "[/etc/os-release]\n" .. trim(osRelease or "missing")
+    else
+        local arch = trim(os.getenv("PROCESSOR_ARCHITEW6432") or os.getenv("PROCESSOR_ARCHITECTURE") or "")
+        local rc, regOut = execPowerShell(
+            "$cv = Get-ItemProperty 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion' -ErrorAction Stop; " ..
+            "Write-Output ($cv.ProductName); Write-Output ($cv.DisplayVersion); Write-Output ($cv.CurrentBuildNumber)",
+            6000
+        )
+        local versionLines = {}
+        for line in tostring(regOut or ""):gmatch("[^\r\n]+") do
+            if trim(line) ~= "" then
+                versionLines[#versionLines + 1] = trim(line)
+            end
+        end
+        details.architecture = arch ~= "" and arch or "undetected"
+        if rc == 0 and #versionLines > 0 then
+            local name = versionLines[1] or "Windows"
+            local display = versionLines[2] or ""
+            local build = versionLines[3] or ""
+            details.osVersion = trim(table.concat({name, display ~= "" and ("version " .. display) or "", build ~= "" and ("build " .. build) or ""}, " "))
+            details.extraSummary[#details.extraSummary + 1] = "Windows version/build: " .. details.osVersion
+        else
+            local _, verOut = execCommand("cmd.exe", {"/C", "ver"}, 5000)
+            details.extraSummary[#details.extraSummary + 1] = "Windows version/build: " .. trim(verOut)
+            details.osVersion = trim(verOut) ~= "" and trim(verOut) or "Windows"
+        end
+        details.extraSummary[#details.extraSummary + 1] = "CPU architecture: " .. details.architecture
+        details.rawBlocks[#details.rawBlocks + 1] = "[windows-version]\n" .. trim(regOut ~= "" and regOut or "")
+    end
+
+    return details
+end
+
+local function runPythonProbe(bundleDir, pythonPath)
+    local result = {
+        summary = {},
+        rawOutput = "",
+        status = "missing",
+        data = {},
+    }
+    if trim(pythonPath) == "" then
+        result.summary[#result.summary + 1] = "Python diagnostics: missing (no Python path detected)"
+        result.rawOutput = "Python diagnostics missing: no Python path detected.\n"
+        return result
+    end
+
+    local probeScriptPath = joinPath(bundleDir, "_python_probe.py")
+    local probeScript = table.concat({
+        "import platform",
+        "import sys",
+        "import importlib",
+        "try:",
+        "    from importlib import metadata as importlib_metadata",
+        "except Exception:",
+        "    import importlib_metadata",
+        "",
+        "def emit(key, value):",
+        "    if isinstance(value, (list, tuple)):",
+        "        value = ', '.join(str(v) for v in value)",
+        "    elif isinstance(value, bool):",
+        "        value = 'true' if value else 'false'",
+        "    elif value is None:",
+        "        value = ''",
+        "    print(f'{key}={value}')",
+        "",
+        "def dist_version(name):",
+        "    try:",
+        "        return importlib_metadata.version(name)",
+        "    except Exception as exc:",
+        "        return f'missing ({type(exc).__name__})'",
+        "",
+        "def module_version(module_name, dist_name=None):",
+        "    try:",
+        "        mod = importlib.import_module(module_name)",
+        "        version = getattr(mod, '__version__', None)",
+        "        if version:",
+        "            return version",
+        "        if dist_name:",
+        "            return dist_version(dist_name)",
+        "        return 'imported'",
+        "    except Exception as exc:",
+        "        if dist_name:",
+        "            return f'import_error ({type(exc).__name__}); dist={dist_version(dist_name)}'",
+        "        return f'import_error ({type(exc).__name__})'",
+        "",
+        "emit('python_executable', sys.executable)",
+        "emit('python_version', platform.python_version())",
+        "emit('numpy', module_version('numpy', 'numpy'))",
+        "emit('numba', module_version('numba', 'numba'))",
+        "emit('llvmlite', module_version('llvmlite', 'llvmlite'))",
+        "emit('torch', module_version('torch', 'torch'))",
+        "emit('torchvision', module_version('torchvision', 'torchvision'))",
+        "emit('torchaudio', module_version('torchaudio', 'torchaudio'))",
+        "emit('audio_separator', module_version('audio_separator', 'audio-separator'))",
+        "emit('audio_separator_dist', dist_version('audio-separator'))",
+        "emit('onnxruntime', module_version('onnxruntime', 'onnxruntime'))",
+        "emit('stemwerk_core', dist_version('stemwerk-core'))",
+        "emit('torch_directml', dist_version('torch-directml'))",
+        "",
+        "try:",
+        "    import torch",
+        "    emit('torch_cuda_available', torch.cuda.is_available())",
+        "    emit('torch_cuda_device_count', torch.cuda.device_count() if torch.cuda.is_available() else 0)",
+        "    emit('torch_cuda_version', getattr(getattr(torch, 'version', None), 'cuda', ''))",
+        "    emit('torch_hip_version', getattr(getattr(torch, 'version', None), 'hip', ''))",
+        "    backends = getattr(torch, 'backends', None)",
+        "    mps = getattr(backends, 'mps', None) if backends else None",
+        "    emit('torch_mps_built', mps.is_built() if mps and hasattr(mps, 'is_built') else '')",
+        "    emit('torch_mps_available', mps.is_available() if mps and hasattr(mps, 'is_available') else '')",
+        "except Exception as exc:",
+        "    emit('torch_import_error', f'{type(exc).__name__}: {exc}')",
+        "",
+        "try:",
+        "    import onnxruntime as ort",
+        "    emit('onnxruntime_providers', ort.get_available_providers())",
+        "except Exception as exc:",
+        "    emit('onnxruntime_providers_error', f'{type(exc).__name__}: {exc}')",
+        "",
+        "try:",
+        "    import torch_directml as dml",
+        "    count = dml.device_count() if hasattr(dml, 'device_count') else 0",
+        "    emit('directml_device_count', count)",
+        "    if count:",
+        "        try:",
+        "            emit('directml_device_0', dml.device_name(0))",
+        "        except Exception as exc:",
+        "            emit('directml_device_0_error', f'{type(exc).__name__}: {exc}')",
+        "except Exception as exc:",
+        "    emit('torch_directml_import_error', f'{type(exc).__name__}: {exc}')",
+        "",
+    }, "\n")
+
+    writeFile(probeScriptPath, probeScript, "wb")
+    local rc, out = execCommand(pythonPath, {probeScriptPath}, 15000)
+    result.rawOutput = out or ""
+    result.data = parseKeyValueText(result.rawOutput)
+    result.status = (rc == 0 and next(result.data) ~= nil) and "ok" or "failed"
+    if fileExists(probeScriptPath) then
+        os.remove(probeScriptPath)
+    end
+
+    if result.status == "ok" then
+        result.summary[#result.summary + 1] = "Python diagnostics: ok"
+        result.summary[#result.summary + 1] = "numpy: " .. (result.data.numpy or "missing")
+        result.summary[#result.summary + 1] = "numba: " .. (result.data.numba or "missing")
+        result.summary[#result.summary + 1] = "llvmlite: " .. (result.data.llvmlite or "missing")
+        result.summary[#result.summary + 1] = "torch: " .. (result.data.torch or "missing")
+        result.summary[#result.summary + 1] = "torchvision: " .. (result.data.torchvision or "missing")
+        result.summary[#result.summary + 1] = "torchaudio: " .. (result.data.torchaudio or "missing")
+        result.summary[#result.summary + 1] = "audio-separator: " .. (result.data.audio_separator_dist or result.data.audio_separator or "missing")
+        result.summary[#result.summary + 1] = "onnxruntime: " .. (result.data.onnxruntime or "missing")
+        if OS == "macOS" then
+            result.summary[#result.summary + 1] = "torch MPS built/available: "
+                .. tostring(result.data.torch_mps_built or "missing") .. "/"
+                .. tostring(result.data.torch_mps_available or "missing")
+        end
+        if trim(result.data.torch_cuda_version) ~= "" or trim(result.data.torch_cuda_available) ~= "" then
+            result.summary[#result.summary + 1] = "CUDA available/version: "
+                .. tostring(result.data.torch_cuda_available or "missing") .. "/"
+                .. tostring(result.data.torch_cuda_version or "missing")
+        end
+        if trim(result.data.torch_hip_version) ~= "" then
+            result.summary[#result.summary + 1] = "ROCm HIP version: " .. tostring(result.data.torch_hip_version)
+        end
+        if trim(result.data.onnxruntime_providers) ~= "" then
+            result.summary[#result.summary + 1] = "ONNX Runtime providers: " .. tostring(result.data.onnxruntime_providers)
+        end
+        if trim(result.data.directml_device_count) ~= "" then
+            result.summary[#result.summary + 1] = "DirectML device count: " .. tostring(result.data.directml_device_count)
+        end
+    else
+        local reason = (rc == 124) and "timed out" or ("failed (exit " .. tostring(rc) .. ")")
+        result.summary[#result.summary + 1] = "Python diagnostics: " .. reason
+        if trim(result.rawOutput) == "" then
+            result.rawOutput = table.concat({
+                "Python diagnostics " .. reason .. ".",
+                "Python path: " .. tostring(pythonPath),
+                "No output captured.",
+                "",
+            }, "\n")
+        end
+        result.summary[#result.summary + 1] = "Python probe output captured in python_diagnostics.txt"
+    end
+
+    return result
+end
+
+local function classifyFileForBundle(name)
+    local lower = tostring(name or ""):lower()
+    local textExt = {
+        [".txt"] = true, [".log"] = true, [".env"] = true, [".json"] = true,
+        [".out"] = true, [".err"] = true, [".pid"] = true, [".cfg"] = true,
+        [".ini"] = true, [".trace"] = true,
+    }
+    local binaryExt = {
+        [".wav"] = true, [".mp3"] = true, [".flac"] = true, [".ogg"] = true,
+        [".aiff"] = true, [".aif"] = true, [".m4a"] = true, [".aac"] = true,
+        [".mp4"] = true, [".mov"] = true, [".avi"] = true, [".mkv"] = true,
+        [".pt"] = true, [".pth"] = true, [".ckpt"] = true, [".onnx"] = true,
+        [".bin"] = true, [".safetensors"] = true, [".npy"] = true, [".npz"] = true,
+    }
+    for ext, _ in pairs(binaryExt) do
+        if endsWith(lower, ext) then
+            return "excluded_binary"
+        end
+    end
+    for ext, _ in pairs(textExt) do
+        if endsWith(lower, ext) then
+            return "text"
+        end
+    end
+    if lower == "stdout.txt" or lower == "stderr.txt" or lower == "separation_log.txt" or lower == "bootstrap.log" then
+        return "text"
+    end
+    if lower:find("debug", 1, true) and (lower:find(".log", 1, true) or lower:find(".txt", 1, true)) then
+        return "text"
+    end
+    return "other"
+end
+
+local function collectExpectedFileStatus(lines, label, path)
+    local status = fileExists(path) and "present" or "missing"
+    appendKey(lines, label, status .. " - " .. sanitizePathValue(path))
+end
+
+local function relativePath(base, path)
+    local nBase = normalizePath(base)
+    local nPath = normalizePath(path)
+    if nBase ~= "" and nPath ~= "" and startsWith(nPath, nBase) then
+        local rel = path:sub(#base + 1)
+        return rel:gsub("^[/\\]+", "")
+    end
+    return basename(path)
+end
+
+local function collectStateFiles(runtimeDir, bundleDir, copiedFiles)
+    local statusLines = {}
+    local destDir = joinPath(bundleDir, "runtime_state")
+    ensureDir(destDir)
+
+    collectExpectedFileStatus(statusLines, "bootstrap.env", bootstrapEnvPath)
+    collectExpectedFileStatus(statusLines, "capabilities.env", capabilitiesEnvPath)
+    collectExpectedFileStatus(statusLines, "bootstrap.pid", bootstrapPidPath)
+    collectExpectedFileStatus(statusLines, "bootstrap.guard", bootstrapGuardPath)
+
+    for _, name in ipairs(enumerateFiles(runtimeDir)) do
+        local src = joinPath(runtimeDir, name)
+        local class = classifyFileForBundle(name)
+        if class == "text" or class == "other" then
+            local dst = joinPath(destDir, basename(src))
+            local ok, mode = copySupportTextFile(src, dst, 1024 * 1024)
+            if ok then
+                copiedFiles[#copiedFiles + 1] = "runtime_state/" .. basename(src) .. " (" .. mode .. ")"
+            end
+        end
+    end
+
+    return statusLines
+end
+
+local function collectRuntimeLogs(runtimeDir, bundleDir, copiedFiles)
+    local lines = {}
+    local destDir = joinPath(bundleDir, "runtime_logs")
+    ensureDir(destDir)
+    local bootstrapLogPath = joinPath(runtimeDir, "bootstrap.log")
+
+    appendKey(lines, "bootstrap.log", fileExists(bootstrapLogPath) and ("present - " .. bootstrapLogPath) or ("missing - " .. bootstrapLogPath))
+
+    local found = false
+    for _, name in ipairs(enumerateFiles(runtimeDir)) do
+        found = true
+        local src = joinPath(runtimeDir, name)
+        local dst = joinPath(destDir, basename(src))
+        local ok, mode = copySupportTextFile(src, dst, 1024 * 1024)
+        appendLine(lines, string.format("- %s: %s", basename(src), ok and mode or "missing"))
+        if ok then
+            copiedFiles[#copiedFiles + 1] = "runtime_logs/" .. basename(src) .. " (" .. mode .. ")"
+        end
+    end
+    if not found then
+        appendLine(lines, "- runtime logs folder missing or empty")
+    end
+    return lines
+end
+
+local function collectTempInventory(bundleDir, copiedFiles)
+    local tempBase = getTempBase()
+    local inventoryLines = {}
+    local copied = {}
+    local folders = {}
+    local summary = {
+        stdout = false,
+        stderr = false,
+        separation = false,
+    }
+
+    if not pathExists(tempBase) then
+        appendLine(inventoryLines, "Temp base missing: " .. tempBase)
+        return inventoryLines, copied, tempBase, summary
+    end
+
+    for _, name in ipairs(enumerateSubdirs(tempBase)) do
+        local lower = tostring(name):lower()
+        if startsWith(lower, "stemwerk") and not shouldIgnoreTempFolder(name) then
+            local full = joinPath(tempBase, name)
+            local stat = getPathStat(full)
+            folders[#folders + 1] = {
+                name = name,
+                path = full,
+                epoch = stat.epoch or 0,
+                mtime = stat.mtime or "unknown",
+            }
+        end
+    end
+
+    table.sort(folders, function(a, b)
+        return (a.epoch or 0) > (b.epoch or 0)
+    end)
+
+    local function sanitizeInventoryDisplayPath(relPath, fileClass)
+        local rel = tostring(relPath or ""):gsub("\\", "/")
+        local lower = rel:lower()
+        local artifactKind = classifyMediaArtifact(lower)
+        if fileClass == "excluded_binary" or artifactKind == "media" then
+            return "[STEMWERK_TEMP_DIR]/[TEMP_AUDIO_FILE]"
+        end
+        if artifactKind == "ffmpeg_log" then
+            return "[STEMWERK_TEMP_DIR]/[TEMP_AUDIO_FILE].ffmpeg.log"
+        end
+        if artifactKind == "reapeaks" then
+            return "[STEMWERK_TEMP_DIR]/peaks/[TEMP_AUDIO_FILE].reapeaks"
+        end
+        return "[STEMWERK_TEMP_DIR]/" .. rel
+    end
+
+    local function walkDir(rootDir, relDir, depth, maxDepth)
+        if depth > maxDepth then return end
+        local currentDir = relDir == "" and rootDir or joinPath(rootDir, relDir)
+        for _, fileName in ipairs(enumerateFiles(currentDir)) do
+            local relPath = relDir == "" and fileName or joinPath(relDir, fileName)
+            local fullPath = joinPath(rootDir, relPath)
+            local stat = getPathStat(fullPath)
+            local class = classifyFileForBundle(fileName)
+            local lowerName = tostring(fileName):lower()
+            if lowerName == "stdout.txt" then summary.stdout = true end
+            if lowerName == "stderr.txt" then summary.stderr = true end
+            if lowerName == "separation_log.txt" then summary.separation = true end
+            local action = "listed"
+            if class == "excluded_binary" then
+                action = "excluded-binary"
+            elseif class == "text" then
+                local tempDestDir = joinPath(bundleDir, "temp_logs", basename(rootDir))
+                local tempDestPath = joinPath(tempDestDir, relPath)
+                ensureDir(tempDestPath:match("^(.*)[/\\][^/\\]+$") or tempDestDir)
+                local ok, mode = copySupportTextFile(fullPath, tempDestPath, 256 * 1024)
+                if ok then
+                    action = "included-" .. tostring(mode)
+                    copied[#copied + 1] = "temp_logs/" .. sanitizeInventoryDisplayPath(relPath, class)
+                else
+                    action = "text-copy-failed"
+                end
+            end
+            appendLine(
+                inventoryLines,
+                string.format(
+                    "%s | %s | %s | %s | %s%s",
+                    stat.mtime or "unavailable",
+                    stat.sizeLabel or "unavailable",
+                    stat.kind or "file",
+                    action,
+                    sanitizeInventoryDisplayPath(relPath, class),
+                    (not stat.ok and trim(stat.reason) ~= "") and (" | metadata=" .. tostring(stat.reason)) or ""
+                )
+            )
+        end
+        for _, subDirName in ipairs(enumerateSubdirs(currentDir)) do
+            local nextRel = relDir == "" and subDirName or joinPath(relDir, subDirName)
+            walkDir(rootDir, nextRel, depth + 1, maxDepth)
+        end
+    end
+
+    local maxFolders = math.min(#folders, 8)
+    if maxFolders == 0 then
+        appendLine(inventoryLines, "No STEMwerk temp folders found under: " .. tempBase)
+    end
+
+    for i = 1, maxFolders do
+        local folder = folders[i]
+        appendLine(inventoryLines, "")
+        appendLine(
+            inventoryLines,
+            string.format("[Folder] %s | [STEMWERK_TEMP_DIR] (%s)", folder.mtime, basename(folder.path))
+        )
+        walkDir(folder.path, "", 0, 3)
+    end
+
+    for i = 1, #copied do
+        copiedFiles[#copiedFiles + 1] = copied[i]
+    end
+
+    return inventoryLines, copied, tempBase, summary
+end
+
+local resourcePath = getResourcePath()
+local _, bundleSuffix = timestampParts(os.time())
+local bundleName = "STEMwerk-support-bundle-" .. bundleSuffix
+local bundleParent = joinPath(resourcePath, "STEMwerk-support-bundles")
+local bundleDir = joinPath(bundleParent, bundleName)
+
+if not ensureDir(bundleParent) or not ensureDir(bundleDir) then
+    msgBox("STEMwerk Support Bundle", "Could not create bundle folder:\n" .. tostring(bundleDir), 0)
+    return
+end
+
+local reapackVersion = detectReaPackVersion(resourcePath)
+local platform = getPlatformDetails()
+local pythonProbe = runPythonProbe(bundleDir, detectedPythonPath)
+local pythonVersion = pythonProbe.data.python_version or getPythonVersion(detectedPythonPath)
+local ffmpegVersion = getFfmpegVersion(detectedFfmpegPath)
+local reaperVersion = reaper and reaper.GetAppVersion and tostring(reaper.GetAppVersion() or "") or "undetected"
+local bundleTimestamp = os.date("%Y-%m-%d %H:%M:%S")
+
+local diagnostics = {}
+appendLine(diagnostics, "=== COPY/PASTE VERSION AND PLATFORM SUMMARY ===")
+appendKey(diagnostics, "STEMwerk package version", packageVersion ~= "" and packageVersion or "missing")
+appendKey(diagnostics, "ReaPack version", reapackVersion)
+appendKey(diagnostics, "Main script @version", mainHeaderVersion ~= "" and mainHeaderVersion or "missing")
+appendKey(diagnostics, "Main script APP_VERSION", mainAppVersion ~= "" and mainAppVersion or "missing")
+appendKey(diagnostics, "OS", platform.osName)
+appendKey(diagnostics, "OS version", platform.osVersion)
+appendKey(diagnostics, "Architecture", platform.architecture)
+appendKey(diagnostics, "REAPER version", reaperVersion ~= "" and reaperVersion or "undetected")
+appendKey(diagnostics, "REAPER resource path", resourcePath)
+appendKey(diagnostics, "Runtime base path", runtimeBase)
+appendKey(diagnostics, "Python path", sanitizePathValue(detectedPythonPath))
+appendKey(diagnostics, "Python version", pythonVersion)
+appendKey(diagnostics, "FFmpeg path", sanitizePathValue(detectedFfmpegPath))
+appendKey(diagnostics, "FFmpeg version", ffmpegVersion)
+appendKey(diagnostics, "Bundle created", bundleTimestamp)
+appendKey(diagnostics, "Bundle path", bundleDir)
+for i = 1, #platform.extraSummary do
+    appendLine(diagnostics, platform.extraSummary[i])
+end
+appendLine(diagnostics, "=== END VERSION AND PLATFORM SUMMARY ===")
+appendLine(diagnostics, "")
+appendLine(diagnostics, "STEMwerk Support Bundle")
+appendLine(diagnostics, "")
+
+appendLine(diagnostics, "Install Detection")
+appendKey(diagnostics, "Install root", INSTALL.root or "missing")
+appendKey(diagnostics, "Install scripts dir", INSTALL.scriptsDir or "missing")
+appendKey(diagnostics, "Canonical scripts root", INSTALL.canonical or "missing")
+appendKey(diagnostics, "ReaPack scripts root", INSTALL.reapack or "missing")
+appendKey(diagnostics, "Install status", INSTALL.status or "undetected")
+appendKey(diagnostics, "Runtime base source", runtimeBaseSource)
+appendKey(diagnostics, "Setup action @version", setupVersion ~= "" and setupVersion or "missing")
+appendKey(diagnostics, "REAPER GetOS raw", REAPER_OS_RAW ~= "" and REAPER_OS_RAW or "missing")
+appendLine(diagnostics, "")
+
+appendLine(diagnostics, "Runtime State Files")
+local copiedFiles = {}
+for _, line in ipairs(collectStateFiles(runtimePaths.runtimeState, bundleDir, copiedFiles)) do
+    appendLine(diagnostics, line)
+end
+appendLine(diagnostics, "")
+
+appendLine(diagnostics, "Runtime Logs")
+for _, line in ipairs(collectRuntimeLogs(runtimePaths.runtimeLogs, bundleDir, copiedFiles)) do
+    appendLine(diagnostics, line)
+end
+appendLine(diagnostics, "")
+
+local debugLogPath = joinPath(getTempBase(), "STEMwerk_debug.log")
+appendLine(diagnostics, "Known Extra Logs")
+appendKey(diagnostics, "Temp debug log", fileExists(debugLogPath) and debugLogPath or "missing")
+if fileExists(debugLogPath) then
+    local ok, mode = copySupportTextFile(debugLogPath, joinPath(bundleDir, "runtime_logs", "STEMwerk_debug.log"), 512 * 1024)
+    if ok then
+        copiedFiles[#copiedFiles + 1] = "runtime_logs/STEMwerk_debug.log (" .. mode .. ")"
+    end
+end
+appendLine(diagnostics, "")
+
+appendLine(diagnostics, "Settings Snapshot")
+local selectedModel = trim(extStateValue("model"))
+if selectedModel == "" then selectedModel = "htdemucs" end
+appendKey(diagnostics, "Backend/device mode", trim(extStateValue("device")) ~= "" and trim(extStateValue("device")) or "auto")
+appendKey(diagnostics, "Capability profile", trim(capabilityState.PROFILE) ~= "" and trim(capabilityState.PROFILE) or "missing")
+appendKey(diagnostics, "Capability backend", trim(capabilityState.BACKEND) ~= "" and trim(capabilityState.BACKEND) or "missing")
+appendKey(diagnostics, "Capability verification", trim(capabilityState.VERIFICATION) ~= "" and trim(capabilityState.VERIFICATION) or "missing")
+appendKey(diagnostics, "Bootstrap status", trim(capabilityState.BOOTSTRAP_STATUS) ~= "" and trim(capabilityState.BOOTSTRAP_STATUS) or trim(runtimeState.STATUS) ~= "" and trim(runtimeState.STATUS) or "missing")
+appendKey(diagnostics, "Quality/model mode", selectedModel .. " (" .. modelModeLabel(selectedModel) .. ")")
+appendKey(diagnostics, "Output track mode", extBool("createNewTracks") and "new tracks" or "in place / takes")
+appendKey(diagnostics, "Create folder", boolLabel(extBool("createFolder")))
+appendKey(diagnostics, "Stem file destination", trim(extStateValue("stemFileDestination")) ~= "" and trim(extStateValue("stemFileDestination")) or "temp")
+appendKey(diagnostics, "Custom stem folder", sanitizeUserFolder(extStateValue("customStemDir")))
+appendKey(diagnostics, "Post-process takes", trim(extStateValue("postProcessTakes")) ~= "" and trim(extStateValue("postProcessTakes")) or "none")
+appendKey(diagnostics, "Language", trim(extStateValue("language")) ~= "" and trim(extStateValue("language")) or "system/default")
+appendKey(diagnostics, "Parallel processing", boolLabel(extBool("parallelProcessing")))
+appendKey(diagnostics, "Keep temp files", boolLabel(extBool("keepTempFiles")))
+appendKey(diagnostics, "Color mode", trim(extStateValue("colorMode")) ~= "" and trim(extStateValue("colorMode")) or "both")
+appendKey(diagnostics, "Theme preset", trim(extStateValue("themePreset")) ~= "" and trim(extStateValue("themePreset")) or "classic")
+appendKey(diagnostics, "Visual FX", boolLabel(extBool("visualFX")))
+appendKey(diagnostics, "Tooltips", boolLabel(extBool("tooltips")))
+appendKey(diagnostics, "Mute original", boolLabel(extBool("muteOriginal")))
+appendKey(diagnostics, "Mute selection", boolLabel(extBool("muteSelection")))
+appendKey(diagnostics, "Delete original", boolLabel(extBool("deleteOriginal")))
+appendKey(diagnostics, "Delete selection", boolLabel(extBool("deleteSelection")))
+appendKey(diagnostics, "Delete original track", boolLabel(extBool("deleteOriginalTrack")))
+appendKey(diagnostics, "Mute original track", boolLabel(extBool("muteOriginalTrack")))
+appendKey(diagnostics, "Debug mode", boolLabel(extBool("debugMode") or extBool("debug")))
+appendLine(diagnostics, "")
+
+appendLine(diagnostics, "Python Dependency Diagnostics")
+for i = 1, #pythonProbe.summary do
+    appendLine(diagnostics, "- " .. pythonProbe.summary[i])
+end
+appendLine(diagnostics, "")
+
+local tempInventory, _, tempBase, tempSummary = collectTempInventory(bundleDir, copiedFiles)
+appendLine(diagnostics, "Temp Folder Inventory")
+appendKey(diagnostics, "Temp base", tempBase)
+appendKey(diagnostics, "Temp inventory file", "temp_inventory.txt")
+appendKey(diagnostics, "Recent separation_log.txt", tempSummary.separation and "present" or "missing")
+appendKey(diagnostics, "Recent stdout.txt", tempSummary.stdout and "present" or "missing")
+appendKey(diagnostics, "Recent stderr.txt", tempSummary.stderr and "present" or "missing")
+appendLine(diagnostics, "")
+
+appendLine(diagnostics, "Collected Files")
+if #copiedFiles == 0 then
+    appendLine(diagnostics, "- no files copied")
+else
+    table.sort(copiedFiles)
+    for i = 1, #copiedFiles do
+        appendLine(diagnostics, "- " .. copiedFiles[i])
+    end
+end
+appendLine(diagnostics, "")
+appendLine(diagnostics, "Intentional Exclusions")
+appendLine(diagnostics, "- audio/media files (wav, mp3, flac, aiff, m4a, video)")
+appendLine(diagnostics, "- model/runtime payload files (.onnx, .pt, .pth, .bin, .safetensors, .npy, .npz)")
+appendLine(diagnostics, "- user project media and project-specific output folders")
+appendLine(diagnostics, "- large binary temp artifacts; inventory lists them as excluded when seen")
+appendLine(diagnostics, "")
+
+local readme = {
+    "STEMwerk Support Bundle",
+    "",
+    "This bundle was created by the REAPER action:",
+    "  STEMwerk_Save_Support_Bundle.lua",
+    "",
+    "Included:",
+    "- diagnostics.txt with version/platform/runtime summary",
+    "- runtime state files from the STEMwerk state folder when present",
+    "- runtime logs from the STEMwerk logs folder when present",
+    "- small text logs copied from recent STEMwerk temp folders",
+    "- temp_inventory.txt listing recent STEMwerk temp-folder contents",
+    "- platform_details.txt with raw OS command output",
+    "- python_diagnostics.txt with dependency probe output when Python could be queried",
+    "",
+    "Intentionally excluded:",
+    "- source audio, rendered stems, project media, and other user media",
+    "- model files and other large runtime payloads",
+    "- large binary temp artifacts",
+    "",
+    "Privacy note:",
+    "- Full runtime, Python, FFmpeg, and REAPER resource paths are included because they are often necessary for support.",
+    "- Custom/project/media output paths are sanitized or omitted.",
+    "",
+    "Bundle folder:",
+    "  " .. bundleDir,
+    "",
+}
+
+writeFile(joinPath(bundleDir, "README.txt"), table.concat(readme, "\n"), "wb")
+writeFile(joinPath(bundleDir, "diagnostics.txt"), table.concat(diagnostics, "\n"), "wb")
+writeFile(joinPath(bundleDir, "temp_inventory.txt"), table.concat(tempInventory, "\n"), "wb")
+writeFile(joinPath(bundleDir, "platform_details.txt"), table.concat(platform.rawBlocks, "\n\n"), "wb")
+writeFile(joinPath(bundleDir, "python_diagnostics.txt"), pythonProbe.rawOutput or "", "wb")
+
+local prompt = "STEMwerk support bundle created:\n\n" .. bundleDir .. "\n\nOpen the folder now?"
+local choice = msgBox("STEMwerk Support Bundle", prompt, 4)
+if choice == 6 then
+    openPath(bundleDir)
+end

--- a/scripts/reaper/STEMwerk_Setup_Toolbar.lua
+++ b/scripts/reaper/STEMwerk_Setup_Toolbar.lua
@@ -174,6 +174,7 @@ local toolbarAssetDir = joinPath(scriptDir, "assets", "toolbar_icons")
 local scriptFiles = {
     "STEMwerk.lua",
     "STEMwerk-SETUP.lua",
+    "STEMwerk_Save_Support_Bundle.lua",
     "STEMwerk_Explode_Takes.lua",
     "STEMwerk_Karaoke.lua",
     "STEMwerk_Vocals_Only.lua",

--- a/scripts/reaper/_internal/STEMwerk_Setup_Internal.lua
+++ b/scripts/reaper/_internal/STEMwerk_Setup_Internal.lua
@@ -184,6 +184,29 @@ local function launchMainStemwerkScript()
     return true
 end
 
+local function runSupportBundleAction()
+    local scriptsDir = resolveSetupScriptsDir()
+    local supportScript = tostring(scriptsDir or "") .. "STEMwerk_Save_Support_Bundle.lua"
+    if not fileExists(supportScript) then
+        msgBox(
+            "STEMwerk Setup",
+            "Missing support bundle script:\n\n" .. tostring(supportScript) .. "\n\nReinstall STEMwerk.",
+            0
+        )
+        return false
+    end
+    local ok, err = pcall(dofile, supportScript)
+    if not ok then
+        msgBox(
+            "STEMwerk Setup",
+            "Could not create the STEMwerk support bundle.\n\nError:\n" .. tostring(err),
+            0
+        )
+        return false
+    end
+    return true
+end
+
 local function quoteArg(s)
     s = tostring(s)
     if s:find('"') then
@@ -3357,6 +3380,7 @@ local function linuxDrawFinal(finalLines, finalSuccess, state, logLines, pid)
     end
     actionButtons[#actionButtons + 1] = { label = "Open Log", action = "open_log" }
     actionButtons[#actionButtons + 1] = { label = "Open Capabilities", action = "open_cap" }
+    actionButtons[#actionButtons + 1] = { label = "Save Support Bundle", action = "save_support_bundle" }
     actionButtons[#actionButtons + 1] = { label = "Open Action List", action = "open_action_list" }
     actionButtons[#actionButtons + 1] = { label = "Open REAPER Help", action = "open_help" }
     actionButtons[#actionButtons + 1] = { label = "Copy Summary", action = "copy_summary" }
@@ -3548,6 +3572,13 @@ local function linuxSetupTick()
                         openActionList()
                     elseif b.action == "open_help" then
                         openPath(LINUX_SETUP.helpFile)
+                    elseif b.action == "save_support_bundle" then
+                        gfx.quit()
+                        LINUX_SETUP = nil
+                        reaper.defer(function()
+                            runSupportBundleAction()
+                        end)
+                        return
                     elseif b.action == "repair" then
                         local runtime = LINUX_SETUP.runtime
                         local separatorScript = LINUX_SETUP.separatorScript or (SCRIPT_DIR .. "audio_separator_process.py")
@@ -4949,6 +4980,10 @@ local function existingRuntimeSetupMenuTick()
             verifyExistingSetup(runtime, separatorScript)
         elseif chosen == "repair" or chosen == "rebuild-venv" then
             startLinuxSetup(runtime, separatorScript, chosen)
+        elseif chosen == "support-bundle" then
+            reaper.defer(function()
+                runSupportBundleAction()
+            end)
         end
         return
     end
@@ -4980,6 +5015,7 @@ local function startExistingRuntimeSetupMenu(runtime, separatorScript)
             { id = "verify",       label = "Check only",   sub = "Fast check, no reinstall",         accent = { 0.22, 0.70, 0.50 } },
             { id = "repair",       label = "Repair",        sub = "Rerun setup, keep models",          accent = { 0.92, 0.55, 0.10 } },
             { id = "rebuild-venv", label = "Rebuild venv",  sub = "Recreate Python env, keep models", accent = { 0.45, 0.52, 0.90 } },
+            { id = "support-bundle", label = "Save Support Bundle", sub = "Collect logs and diagnostics, no changes", accent = { 0.26, 0.60, 0.88 } },
             { id = "delete-models",label = "Delete models...", sub = "Cache reset; re-download when needed",  accent = { 0.88, 0.28, 0.28 } },
             { id = "delete-runtime",label = "Delete runtime...", sub = "Full reset; removes venv + models", accent = { 0.82, 0.22, 0.22 } },
             { id = "cancel",       label = "Cancel",        sub = "Exit without changes",              accent = { 0.38, 0.38, 0.42 } },

--- a/tests/support/run_support_bundle_headless.lua
+++ b/tests/support/run_support_bundle_headless.lua
@@ -1,0 +1,699 @@
+local SEP = package.config:sub(1, 1)
+local IS_WINDOWS = SEP == "\\"
+
+local function detectUnixName()
+    if IS_WINDOWS then
+        return "Windows"
+    end
+    local handle = io.popen("uname -s 2>/dev/null", "r")
+    if not handle then
+        return "Linux"
+    end
+    local out = handle:read("*a") or ""
+    handle:close()
+    out = (out:gsub("%s+$", ""))
+    if out == "Darwin" then
+        return "macOS"
+    end
+    return "Linux"
+end
+
+local PLATFORM_NAME = detectUnixName()
+local REAL_IO_POPEN = io.popen
+local REAL_OS_GETENV = os.getenv
+local ENV_OVERRIDES = nil
+local COMMAND_INTERCEPTOR = nil
+
+local function trim(value)
+    local text = tostring(value or "")
+    return (text:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+local function joinPath(...)
+    local parts = { ... }
+    local out = ""
+    for i = 1, #parts do
+        local part = tostring(parts[i] or "")
+        if part ~= "" then
+            part = part:gsub("[/\\]+", SEP)
+            if out == "" then
+                out = part:gsub("[/\\]+$", "")
+            else
+                part = part:gsub("^[/\\]+", ""):gsub("[/\\]+$", "")
+                out = out .. SEP .. part
+            end
+        end
+    end
+    return out
+end
+
+local function normalizePath(path)
+    local text = tostring(path or "")
+    if IS_WINDOWS then
+        return text:gsub("/", "\\"):lower()
+    end
+    return text:gsub("\\", "/")
+end
+
+local function assertf(condition, message)
+    if not condition then
+        error(message, 2)
+    end
+end
+
+local function shellQuote(path)
+    local text = tostring(path or "")
+    if IS_WINDOWS then
+        return '"' .. text:gsub('"', '""') .. '"'
+    end
+    if text == "" then
+        return "''"
+    end
+    return "'" .. text:gsub("'", "'\\''") .. "'"
+end
+
+local function fileExists(path)
+    local f = io.open(path, "rb")
+    if f then
+        f:close()
+        return true
+    end
+    return false
+end
+
+local function readFile(path)
+    local f = io.open(path, "rb")
+    if not f then
+        return nil
+    end
+    local data = f:read("*a")
+    f:close()
+    return data
+end
+
+local function writeFile(path, data)
+    local f = io.open(path, "wb")
+    assertf(f ~= nil, "Could not open for writing: " .. tostring(path))
+    f:write(data or "")
+    f:close()
+end
+
+local function pathExists(path)
+    if not path or path == "" then
+        return false
+    end
+    local ok, _, code = os.rename(path, path)
+    if ok then
+        return true
+    end
+    return tonumber(code) == 13
+end
+
+local function mkdirP(path)
+    if not path or path == "" then
+        return
+    end
+    if pathExists(path) then
+        return
+    end
+    if IS_WINDOWS then
+        os.execute('mkdir "' .. tostring(path):gsub('"', '""') .. '" >nul 2>nul')
+    else
+        os.execute("mkdir -p " .. shellQuote(path) .. " >/dev/null 2>&1")
+    end
+    assertf(pathExists(path), "Failed to create directory: " .. tostring(path))
+end
+
+local function removeTree(path)
+    if not path or path == "" or not pathExists(path) then
+        return
+    end
+    if IS_WINDOWS then
+        os.execute('rmdir /S /Q "' .. tostring(path):gsub('"', '""') .. '" >nul 2>nul')
+    else
+        os.execute("rm -rf " .. shellQuote(path) .. " >/dev/null 2>&1")
+    end
+end
+
+local function parentDir(path)
+    return tostring(path or ""):match("^(.*)[/\\][^/\\]+$") or ""
+end
+
+local function listChildren(path, wantDirs)
+    if not pathExists(path) then
+        return {}
+    end
+    local cmd
+    if IS_WINDOWS then
+        cmd = string.format(
+            'cmd.exe /d /c dir /B %s %s 2>nul',
+            wantDirs and "/AD" or "/A-D",
+            shellQuote(path)
+        )
+    else
+        cmd = string.format(
+            'find %s -mindepth 1 -maxdepth 1 -type %s -exec basename {} \\; 2>/dev/null',
+            shellQuote(path),
+            wantDirs and "d" or "f"
+        )
+    end
+    local handle = REAL_IO_POPEN(cmd, "r")
+    if not handle then
+        return {}
+    end
+    local out = handle:read("*a") or ""
+    handle:close()
+    local items = {}
+    for line in out:gmatch("[^\r\n]+") do
+        items[#items + 1] = trim(line)
+    end
+    table.sort(items)
+    return items
+end
+
+local function walkFiles(root)
+    local files = {}
+    local function walk(path)
+        for _, fileName in ipairs(listChildren(path, false)) do
+            files[#files + 1] = joinPath(path, fileName)
+        end
+        for _, dirName in ipairs(listChildren(path, true)) do
+            walk(joinPath(path, dirName))
+        end
+    end
+    if pathExists(root) then
+        walk(root)
+    end
+    table.sort(files)
+    return files
+end
+
+local function makeFakeHandle(output, exitCode)
+    local data = output or ""
+    local code = tonumber(exitCode) or 0
+    return {
+        read = function()
+            return data
+        end,
+        close = function()
+            if code == 0 then
+                return true
+            end
+            return nil, "exit", code
+        end,
+    }
+end
+
+os.getenv = function(key)
+    if ENV_OVERRIDES and ENV_OVERRIDES[key] ~= nil then
+        return ENV_OVERRIDES[key]
+    end
+    return REAL_OS_GETENV(key)
+end
+
+io.popen = function(cmd, mode)
+    if COMMAND_INTERCEPTOR then
+        local handled, handle = COMMAND_INTERCEPTOR(cmd, mode)
+        if handled then
+            return handle
+        end
+    end
+    return REAL_IO_POPEN(cmd, mode)
+end
+
+local function scriptDir()
+    local info = debug.getinfo(1, "S")
+    return (info and info.source and info.source:match("@?(.*[/\\])")) or "."
+end
+
+local function getCwd()
+    local cmd = IS_WINDOWS and "cd" or "pwd"
+    local handle = REAL_IO_POPEN(cmd, "r")
+    if not handle then
+        return "."
+    end
+    local out = trim(handle:read("*a") or "")
+    handle:close()
+    return out ~= "" and out or "."
+end
+
+local TEST_DIR = scriptDir()
+if not TEST_DIR:match("^%a:[/\\]") and TEST_DIR:sub(1, 1) ~= "/" then
+    TEST_DIR = joinPath(getCwd(), TEST_DIR)
+end
+local REPO_ROOT = TEST_DIR:gsub("[/\\]tests[/\\]support[/\\]?$", "")
+local ACTION_SCRIPT = joinPath(REPO_ROOT, "scripts", "reaper", "STEMwerk_Save_Support_Bundle.lua")
+
+local function currentTempBase()
+    if IS_WINDOWS then
+        return os.getenv("TEMP") or os.getenv("TMP") or joinPath(os.getenv("USERPROFILE") or "C:\\", "Temp")
+    end
+    return os.getenv("TMPDIR") or "/tmp"
+end
+
+local function writePlaceholder(path)
+    mkdirP(parentDir(path))
+    writeFile(path, "placeholder\n")
+end
+
+local function waitNextSecond()
+    local start = os.time()
+    repeat until os.time() > start
+end
+
+local function containsNormalized(haystack, needle)
+    return normalizePath(haystack):find(normalizePath(needle), 1, true) ~= nil
+end
+
+local function isWhichCommand(cmd, name)
+    local lower = cmd:lower()
+    if IS_WINDOWS then
+        return lower:find("where.exe", 1, true) and lower:find(name:lower(), 1, true)
+    end
+    return lower:match("^%s*which%s+") and lower:find(name, 1, true)
+end
+
+local function makeCommandInterceptor(context)
+    return function(cmd)
+        local lower = cmd:lower()
+        if context.disableCommandResolution then
+            if isWhichCommand(cmd, "python3") or isWhichCommand(cmd, "python")
+                or isWhichCommand(cmd, "ffmpeg") then
+                return true, makeFakeHandle("", 1)
+            end
+        end
+
+        if context.fakePythonPath and containsNormalized(cmd, context.fakePythonPath) then
+            if lower:find("--version", 1, true) or lower:find(" -v", 1, true) then
+                return true, makeFakeHandle("Python 3.11.9\n", 0)
+            end
+            return true, makeFakeHandle(table.concat({
+                "python_executable=" .. context.fakePythonPath,
+                "python_version=3.11.9",
+                "numpy=2.1.1",
+                "numba=0.60.0",
+                "llvmlite=0.43.0",
+                "torch=2.5.1",
+                "torchvision=0.20.1",
+                "torchaudio=2.5.1",
+                "audio_separator=0.30.1",
+                "audio_separator_dist=0.30.1",
+                "onnxruntime=1.19.2",
+                "stemwerk_core=0.0.0-test",
+                "torch_directml=missing (PackageNotFoundError)",
+                "torch_cuda_available=false",
+                "torch_cuda_device_count=0",
+                "torch_cuda_version=",
+                "torch_hip_version=6.2.0",
+                "torch_mps_built=false",
+                "torch_mps_available=false",
+                "onnxruntime_providers=CPUExecutionProvider, ROCMExecutionProvider",
+                "directml_device_count=0",
+                "",
+            }, "\n"), 0)
+        end
+
+        if context.fakeFfmpegPath and containsNormalized(cmd, context.fakeFfmpegPath) then
+            return true, makeFakeHandle("ffmpeg version 7.0-fake\n", 0)
+        end
+
+        return false
+    end
+end
+
+local function makeReaperMock(resourcePath, extState)
+    local boxes = {}
+    local function enumerate(path, idx, wantDirs)
+        local items = listChildren(path, wantDirs)
+        return items[(tonumber(idx) or 0) + 1]
+    end
+
+    local function showMessageBox(text, title, boxType)
+        boxes[#boxes + 1] = {
+            text = tostring(text or ""),
+            title = tostring(title or ""),
+            boxType = tonumber(boxType) or 0,
+        }
+        if tonumber(boxType) == 4 then
+            return 7
+        end
+        return 1
+    end
+
+    return {
+        _boxes = boxes,
+        GetResourcePath = function()
+            return resourcePath
+        end,
+        GetAppVersion = function()
+            return "7.50/headless"
+        end,
+        GetOS = function()
+            if IS_WINDOWS then return "Win64" end
+            if PLATFORM_NAME == "macOS" then return "OSX64" end
+            return "Linux"
+        end,
+        ShowMessageBox = showMessageBox,
+        MB = showMessageBox,
+        CF_ShellExecute = function()
+            return true
+        end,
+        RecursiveCreateDirectory = function(path)
+            mkdirP(path)
+        end,
+        EnumerateFiles = function(path, idx)
+            return enumerate(path, idx, false)
+        end,
+        EnumerateSubdirectories = function(path, idx)
+            return enumerate(path, idx, true)
+        end,
+        GetExtState = function(section, key)
+            if tostring(section) ~= "STEMwerk" then
+                return ""
+            end
+            return extState[key] or ""
+        end,
+        ReaPack_GetVersion = function()
+            return "1.2.4-headless"
+        end,
+    }
+end
+
+local function makeCommonEnv(baseRoot, tempRoot)
+    local env = {
+        HOME = joinPath(baseRoot, "home"),
+        XDG_DATA_HOME = joinPath(baseRoot, "xdg-data"),
+        TMPDIR = tempRoot,
+        TMP = tempRoot,
+        TEMP = tempRoot,
+    }
+    if IS_WINDOWS then
+        env.USERPROFILE = joinPath(baseRoot, "home")
+        env.LOCALAPPDATA = joinPath(baseRoot, "local-app-data")
+        env.APPDATA = joinPath(baseRoot, "app-data")
+    end
+    for _, value in pairs(env) do
+        mkdirP(value)
+    end
+    return env
+end
+
+local function createPresentScenario(baseRoot)
+    local resourcePath = joinPath(baseRoot, "resource-present")
+    local tempRoot = joinPath(baseRoot, "tmp-present")
+    local env = makeCommonEnv(baseRoot, tempRoot)
+    local runtimeBase = joinPath(baseRoot, "runtime-present")
+    local runtimeStateDir = joinPath(runtimeBase, "state")
+    local runtimeLogsDir = joinPath(runtimeBase, "logs")
+    local fakePythonPath = joinPath(baseRoot, "bin", IS_WINDOWS and "fake-python.cmd" or "fake-python")
+    local fakeFfmpegPath = joinPath(baseRoot, "bin", IS_WINDOWS and "fake-ffmpeg.cmd" or "fake-ffmpeg")
+    local tempDir = joinPath(tempRoot, "STEMwerk_fake_present")
+    local mediaBase = IS_WINDOWS and "C:\\Users\\Headless\\Music\\private_song.wav" or "/home/headless/Music/private_song.wav"
+    local projectPath = IS_WINDOWS and "C:\\Users\\Headless\\Projects\\private_project.rpp" or "/home/headless/Projects/private_project.rpp"
+
+    mkdirP(resourcePath)
+    mkdirP(joinPath(resourcePath, "UserPlugins"))
+    mkdirP(runtimeStateDir)
+    mkdirP(runtimeLogsDir)
+    mkdirP(tempDir)
+    mkdirP(joinPath(tempDir, "peaks"))
+    mkdirP(joinPath(tempDir, "nested"))
+    writePlaceholder(fakePythonPath)
+    writePlaceholder(fakeFfmpegPath)
+
+    writeFile(joinPath(resourcePath, "reapack.ini"), "Version=1.2.4-headless\n")
+    writeFile(joinPath(runtimeStateDir, "bootstrap.env"), table.concat({
+        "PYTHON_PATH=" .. fakePythonPath,
+        "FFMPEG_PATH=" .. fakeFfmpegPath,
+        "STATUS=ok",
+        "BACKEND=rocm",
+        "BOOTSTRAP_STATUS=ok",
+        "VENV_PYTHON=" .. fakePythonPath,
+        "",
+    }, "\n"))
+    writeFile(joinPath(runtimeStateDir, "capabilities.env"), table.concat({
+        "PROFILE=linux-rocm",
+        "BACKEND=rocm",
+        "VERIFICATION=ok",
+        "PYTHON_PATH=" .. fakePythonPath,
+        "FFMPEG_PATH=" .. fakeFfmpegPath,
+        "BOOTSTRAP_STATUS=ok",
+        "",
+    }, "\n"))
+    writeFile(joinPath(runtimeStateDir, "bootstrap.pid"), "12345\n")
+    writeFile(joinPath(runtimeStateDir, "bootstrap.guard"), "STATUS=ok\nREASON=completed\n")
+    writeFile(joinPath(runtimeLogsDir, "bootstrap.log"), table.concat({
+        "bootstrap ok",
+        "input=" .. joinPath(tempDir, "input.wav"),
+        "source=" .. mediaBase,
+        "project=" .. projectPath,
+        "",
+    }, "\n"))
+    writeFile(joinPath(tempDir, "separation_log.txt"), table.concat({
+        "separation started",
+        joinPath(tempDir, "input.wav"),
+        joinPath(tempDir, "bass.wav"),
+        joinPath(tempDir, "drums.wav"),
+        joinPath(tempDir, "vocals.wav"),
+        joinPath(tempDir, "other.wav"),
+        projectPath,
+        mediaBase,
+        "",
+    }, "\n"))
+    writeFile(joinPath(tempDir, "stdout.txt"), "stdout path " .. joinPath(tempDir, "bass.wav") .. "\n")
+    writeFile(joinPath(tempDir, "stderr.txt"), "stderr path " .. mediaBase .. "\n")
+    writeFile(joinPath(tempDir, "nested", "debug.log"), "nested log " .. projectPath .. "\n")
+    writeFile(joinPath(tempRoot, "STEMwerk_debug.log"), "debug " .. joinPath(tempDir, "other.wav") .. "\n")
+
+    writeFile(joinPath(tempDir, "input.wav"), string.rep("a", 128))
+    writeFile(joinPath(tempDir, "bass.wav"), string.rep("b", 64))
+    writeFile(joinPath(tempDir, "drums.wav"), string.rep("c", 64))
+    writeFile(joinPath(tempDir, "vocals.wav"), string.rep("d", 64))
+    writeFile(joinPath(tempDir, "other.wav"), string.rep("e", 64))
+    writeFile(joinPath(tempDir, "model.onnx"), string.rep("m", 256))
+    writeFile(joinPath(tempDir, "weights.pt"), string.rep("p", 256))
+    writeFile(joinPath(tempDir, "peaks", "input.wav.reapeaks"), "peaks\n")
+
+    return {
+        name = "present-runtime",
+        resourcePath = resourcePath,
+        env = env,
+        extState = {
+            runtimeBase = runtimeBase,
+            pythonPath = fakePythonPath,
+            ffmpegPath = fakeFfmpegPath,
+            device = "auto",
+            model = "htdemucs_ft",
+            createNewTracks = "1",
+            createFolder = "1",
+            stemFileDestination = "custom",
+            customStemDir = mediaBase,
+            postProcessTakes = "glue",
+            language = "en",
+            parallelProcessing = "1",
+            keepTempFiles = "0",
+            colorMode = "both",
+            themePreset = "classic",
+            visualFX = "1",
+            tooltips = "1",
+            muteOriginal = "0",
+            muteSelection = "0",
+            deleteOriginal = "0",
+            deleteSelection = "0",
+            deleteOriginalTrack = "0",
+            muteOriginalTrack = "0",
+            debugMode = "1",
+        },
+        fakePythonPath = fakePythonPath,
+        fakeFfmpegPath = fakeFfmpegPath,
+        disableCommandResolution = false,
+        expectedRawPaths = {
+            joinPath(tempDir, "input.wav"),
+            joinPath(tempDir, "bass.wav"),
+            joinPath(tempDir, "drums.wav"),
+            joinPath(tempDir, "vocals.wav"),
+            joinPath(tempDir, "other.wav"),
+            mediaBase,
+            projectPath,
+            tempDir,
+        },
+    }
+end
+
+local function createMissingScenario(baseRoot)
+    local resourcePath = joinPath(baseRoot, "resource-missing")
+    local tempRoot = joinPath(baseRoot, "tmp-missing")
+    local env = makeCommonEnv(baseRoot, tempRoot)
+    local runtimeBase = joinPath(baseRoot, "runtime-missing")
+    mkdirP(resourcePath)
+    mkdirP(joinPath(resourcePath, "UserPlugins"))
+    writeFile(joinPath(resourcePath, "reapack.ini"), "Version=1.2.4-headless\n")
+
+    return {
+        name = "missing-runtime",
+        resourcePath = resourcePath,
+        env = env,
+        extState = {
+            runtimeBase = runtimeBase,
+            pythonPath = "",
+            ffmpegPath = "",
+            device = "auto",
+            model = "htdemucs",
+            customStemDir = "",
+        },
+        disableCommandResolution = true,
+        expectedRawPaths = {},
+    }
+end
+
+local function latestBundleDir(resourcePath)
+    local bundlesRoot = joinPath(resourcePath, "STEMwerk-support-bundles")
+    local dirs = listChildren(bundlesRoot, true)
+    table.sort(dirs)
+    local latest = dirs[#dirs]
+    if not latest then
+        return nil
+    end
+    return joinPath(bundlesRoot, latest)
+end
+
+local function readBundleText(bundleDir)
+    local chunks = {}
+    for _, path in ipairs(walkFiles(bundleDir)) do
+        local lower = path:lower()
+        if lower:match("%.txt$") or lower:match("%.log$") or lower:match("%.env$") or lower:match("%.pid$")
+            or lower:match("diagnostics") or lower:match("readme") then
+            local data = readFile(path)
+            if data then
+                chunks[#chunks + 1] = data
+            end
+        end
+    end
+    return table.concat(chunks, "\n")
+end
+
+local FORBIDDEN_EXTENSIONS = {
+    ".wav", ".flac", ".mp3", ".aiff", ".aif", ".m4a", ".ogg", ".opus", ".mp4", ".mov",
+    ".onnx", ".pth", ".pt", ".ckpt",
+}
+
+local function assertNoForbiddenFiles(bundleDir)
+    for _, path in ipairs(walkFiles(bundleDir)) do
+        local lower = path:lower()
+        for i = 1, #FORBIDDEN_EXTENSIONS do
+            if lower:sub(-#FORBIDDEN_EXTENSIONS[i]) == FORBIDDEN_EXTENSIONS[i] then
+                error("Forbidden payload copied into bundle: " .. path, 2)
+            end
+        end
+    end
+end
+
+local function assertMaxFileSize(bundleDir, maxBytes)
+    for _, path in ipairs(walkFiles(bundleDir)) do
+        local data = readFile(path) or ""
+        assertf(#data <= maxBytes, "Bundle file too large for headless fixture: " .. path)
+    end
+end
+
+local function assertPresentScenario(bundleDir, context)
+    assertf(fileExists(joinPath(bundleDir, "README.txt")), "README.txt missing")
+    assertf(fileExists(joinPath(bundleDir, "diagnostics.txt")), "diagnostics.txt missing")
+    assertf(fileExists(joinPath(bundleDir, "platform_details.txt")), "platform_details.txt missing")
+    assertf(fileExists(joinPath(bundleDir, "python_diagnostics.txt")), "python_diagnostics.txt missing")
+    assertf(fileExists(joinPath(bundleDir, "temp_inventory.txt")), "temp_inventory.txt missing")
+    assertf(fileExists(joinPath(bundleDir, "runtime_state", "bootstrap.env")), "bootstrap.env not copied")
+    assertf(fileExists(joinPath(bundleDir, "runtime_state", "capabilities.env")), "capabilities.env not copied")
+    assertf(fileExists(joinPath(bundleDir, "runtime_logs", "bootstrap.log")), "bootstrap.log not copied")
+    assertf(fileExists(joinPath(bundleDir, "temp_logs", "STEMwerk_fake_present", "separation_log.txt")), "temp separation log not copied")
+    assertf(fileExists(joinPath(bundleDir, "temp_logs", "STEMwerk_fake_present", "stdout.txt")), "temp stdout log not copied")
+
+    local diagnostics = readFile(joinPath(bundleDir, "diagnostics.txt")) or ""
+    local pythonDiagnostics = readFile(joinPath(bundleDir, "python_diagnostics.txt")) or ""
+    local tempInventory = readFile(joinPath(bundleDir, "temp_inventory.txt")) or ""
+    local allText = readBundleText(bundleDir)
+
+    assertf(diagnostics:find("STEMwerk package version", 1, true) ~= nil, "diagnostics missing version block")
+    assertf(diagnostics:find("Python version", 1, true) ~= nil and diagnostics:find("3.11.9", 1, true) ~= nil, "diagnostics missing Python version")
+    assertf(diagnostics:find("FFmpeg version", 1, true) ~= nil and diagnostics:find("ffmpeg version 7.0-fake", 1, true) ~= nil, "diagnostics missing FFmpeg version")
+    assertf(trim(pythonDiagnostics) ~= "", "python_diagnostics.txt is empty")
+    assertf(pythonDiagnostics:find("python_version=3.11.9", 1, true) ~= nil, "python diagnostics missing version payload")
+    assertf(allText:find("[TEMP_AUDIO_FILE]", 1, true) ~= nil, "sanitization placeholder not present")
+    assertf(allText:find("[STEMWERK_TEMP_DIR]", 1, true) ~= nil, "temp directory placeholder not present")
+    assertf(tempInventory:find("| file |", 1, true) ~= nil, "temp inventory missing file metadata")
+    assertf(tempInventory:find("stemwerk%-support%-bundle%-headless%-", 1) == nil, "headless support-bundle fixture leaked into temp inventory")
+
+    for _, rawPath in ipairs(context.expectedRawPaths) do
+        assertf(allText:find(rawPath, 1, true) == nil, "Raw path leaked into bundle text: " .. rawPath)
+    end
+
+    assertNoForbiddenFiles(bundleDir)
+    assertMaxFileSize(bundleDir, 1024 * 1024)
+end
+
+local function assertMissingScenario(bundleDir)
+    assertf(fileExists(joinPath(bundleDir, "README.txt")), "README.txt missing")
+    assertf(fileExists(joinPath(bundleDir, "diagnostics.txt")), "diagnostics.txt missing")
+    assertf(fileExists(joinPath(bundleDir, "platform_details.txt")), "platform_details.txt missing")
+    assertf(fileExists(joinPath(bundleDir, "python_diagnostics.txt")), "python_diagnostics.txt missing")
+    assertf(fileExists(joinPath(bundleDir, "temp_inventory.txt")), "temp_inventory.txt missing")
+
+    local diagnostics = readFile(joinPath(bundleDir, "diagnostics.txt")) or ""
+    local pythonDiagnostics = readFile(joinPath(bundleDir, "python_diagnostics.txt")) or ""
+
+    assertf(diagnostics:find("Python path", 1, true) ~= nil and diagnostics:find("missing", 1, true) ~= nil, "missing scenario did not report missing Python path")
+    assertf(diagnostics:find("FFmpeg path", 1, true) ~= nil and diagnostics:find("missing", 1, true) ~= nil, "missing scenario did not report missing FFmpeg path")
+    assertf(diagnostics:find("bootstrap.env", 1, true) ~= nil and diagnostics:find("missing", 1, true) ~= nil, "missing runtime files not reported")
+    assertf(trim(pythonDiagnostics) ~= "", "missing scenario python_diagnostics.txt is empty")
+    assertf(pythonDiagnostics:find("no Python path detected", 1, true) ~= nil or pythonDiagnostics:find("missing", 1, true) ~= nil,
+        "missing scenario python diagnostics did not explain the failure")
+
+    assertNoForbiddenFiles(bundleDir)
+    assertMaxFileSize(bundleDir, 1024 * 1024)
+end
+
+local function runScenario(context, assertionFn)
+    ENV_OVERRIDES = context.env
+    COMMAND_INTERCEPTOR = makeCommandInterceptor(context)
+    reaper = makeReaperMock(context.resourcePath, context.extState)
+
+    local ok, err = pcall(dofile, ACTION_SCRIPT)
+    ENV_OVERRIDES = nil
+    COMMAND_INTERCEPTOR = nil
+
+    assertf(ok, context.name .. " crashed: " .. tostring(err))
+    local bundleDir = latestBundleDir(context.resourcePath)
+    assertf(bundleDir ~= nil, context.name .. " did not create a support bundle")
+    assertionFn(bundleDir, context)
+    return bundleDir
+end
+
+local function main()
+    math.randomseed(os.time())
+    local baseRoot = joinPath(currentTempBase(), "stemwerk-support-bundle-headless-" .. tostring(os.time()) .. "-" .. tostring(math.random(100000, 999999)))
+    removeTree(baseRoot)
+    mkdirP(baseRoot)
+
+    print("Running headless support bundle collector tests")
+    print("Repo root: " .. REPO_ROOT)
+    print("Temp root: " .. baseRoot)
+
+    local present = createPresentScenario(baseRoot)
+    local presentBundle = runScenario(present, assertPresentScenario)
+    print("PASS present-runtime -> " .. presentBundle)
+
+    waitNextSecond()
+
+    local missing = createMissingScenario(baseRoot)
+    local missingBundle = runScenario(missing, assertMissingScenario)
+    print("PASS missing-runtime -> " .. missingBundle)
+
+    print("All headless support bundle tests passed.")
+end
+
+local ok, err = pcall(main)
+ENV_OVERRIDES = nil
+COMMAND_INTERCEPTOR = nil
+if not ok then
+    io.stderr:write("Headless support bundle test failed: " .. tostring(err) .. "\n")
+    os.exit(1)
+end


### PR DESCRIPTION
Adds a user-facing support bundle collector for STEMwerk.

What changed:
- adds `STEMwerk_Save_Support_Bundle.lua`
- creates support bundles with diagnostics, logs, runtime state, and temp inventory
- excludes audio/media/model/binary payloads
- sanitizes copied text logs and temp inventory output
- includes a prominent version / OS / platform block at the top of `diagnostics.txt`
- includes Python / FFmpeg / backend dependency diagnostics
- adds headless CI coverage across Linux, Windows, and macOS
- exposes Save Support Bundle from the setup/maintenance UI

Validation:
- `luac -p scripts/reaper/STEMwerk_Save_Support_Bundle.lua`
- `luac -p scripts/reaper/STEMwerk_Setup_Toolbar.lua`
- `luac -p tests/support/run_support_bundle_headless.lua`
- `lua tests/support/run_support_bundle_headless.lua`
- YAML parse for `.github/workflows/support-bundle-headless.yml`
- `luac -p scripts/reaper/_internal/STEMwerk_Setup_Internal.lua`

Smoke test:
- passed a real Linux REAPER smoke test on an AMD / ROCm system

Release scope:
- no version bump
- no release assets
