### PR TITLE
setup: pin macOS torch stack for Demucs compatibility

### DIFF
--- a/scripts/reaper/_internal/STEMwerk_Runtime_Setup.lua
+++ b/scripts/reaper/_internal/STEMwerk_Runtime_Setup.lua
@@ -886,7 +886,7 @@ function M.ensureDependenciesInteractive()
             if err == "samplerate_missing" then hasSamplerate = true end
             if err == "stemwerk_core_missing" then hasCore = true end
             if err == "torch_too_new_for_demucs" then
-                missing[#missing + 1] = "macOS Torch version is too new for bundled Demucs/audio-separator; run Rebuild venv or Repair"
+                missing[#missing + 1] = "macOS Torch version is too new for the bundled Demucs/audio-separator path; run Rebuild venv/Repair to install the pinned torch stack."
             end
             if err == "numpy_too_new_for_demucs" then
                 missing[#missing + 1] = "NumPy version is too new for bundled Demucs/audio-separator; run Rebuild venv or Repair"

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -233,6 +233,7 @@ def test_macos_runtime_verification_rejects_torch_26_plus():
     assert "torch_too_new_for_demucs" in setup_internal
     assert "numpy_too_new_for_demucs" in runtime_setup
     assert "numpy_too_new_for_demucs" in setup_internal
+    assert "macOS Torch version is too new for the bundled Demucs/audio-separator path; run Rebuild venv/Repair to install the pinned torch stack." in runtime_setup
     assert "macOS Torch version is too new for the bundled Demucs/audio-separator path" in setup_internal
 
 


### PR DESCRIPTION
Fixes macOS Apple Silicon runtime drift where torch>=2.6, for example torch 2.11.0, can break Demucs/audio-separator 0.23.0 model loading because PyTorch changed torch.load weights_only defaults. Keeps macOS on the known compatible torch 2.5.1 stack and makes verification fail clearly when torch drifts too new.