### PR TITLE
fix: correct ReaScript API return handling

### DIFF
--- a/scripts/reaper/STEMwerk.lua
+++ b/scripts/reaper/STEMwerk.lua
@@ -746,7 +746,13 @@ local function findPython()
             f:write("fileExists: " .. tostring(fileExists(resolved)) .. "\n")
             -- Attempt to run via reaper.ExecProcess if available
             if reaper and reaper.ExecProcess then
-                local rc, out = reaper.ExecProcess(quoteArg(resolved) .. " --version", 8000)
+                local raw = reaper.ExecProcess(quoteArg(resolved) .. " --version", 8000)
+                local rc, out = nil, ""
+                if type(raw) == "string" then
+                    local firstLine, rest = raw:match("^([^\r\n]*)\r?\n?(.*)$")
+                    rc = tonumber(firstLine)
+                    out = (rc ~= nil) and (rest or "") or raw
+                end
                 f:write("ExecProcess rc=" .. tostring(rc) .. " outLen=" .. tostring(out and #out or 0) .. "\n")
                 f:write("ExecProcess out:\n" .. tostring(out) .. "\n")
             end
@@ -12543,13 +12549,8 @@ local function renderTakeAccessorToWav(take, startTime, endTime, outputPath)
         end
     end
 
-    -- Try to set bounds when available (not required, but can improve correctness).
-    if reaper.GetSet_AudioAccessorStartTime then
-        pcall(function() reaper.GetSet_AudioAccessorStartTime(acc, true, sampleStart) end)
-    end
-    if reaper.GetSet_AudioAccessorEndTime then
-        pcall(function() reaper.GetSet_AudioAccessorEndTime(acc, true, sampleEnd) end)
-    end
+    -- Accessor bounds are read-only via GetAudioAccessorStartTime/EndTime.
+    -- Keep clamp logic above; do not call legacy/non-existent setter variants.
 
     local f = io.open(outputPath, "wb")
     if not f then

--- a/scripts/reaper/STEMwerk_Save_Support_Bundle.lua
+++ b/scripts/reaper/STEMwerk_Save_Support_Bundle.lua
@@ -216,9 +216,21 @@ local function execCapturePipe(cmd)
     return tonumber(code) or -1, out
 end
 
+local function parseExecProcessResult(result)
+    if type(result) ~= "string" then
+        return nil, ""
+    end
+    local firstLine, rest = result:match("^([^\r\n]*)\r?\n?(.*)$")
+    local rc = tonumber(firstLine)
+    if rc == nil then
+        return nil, result
+    end
+    return rc, rest or ""
+end
+
 local function execCapture(cmd, timeoutMs)
     if reaper and reaper.ExecProcess then
-        local rc, out = reaper.ExecProcess(cmd, timeoutMs or 8000)
+        local rc, out = parseExecProcessResult(reaper.ExecProcess(cmd, timeoutMs or 8000))
         return tonumber(rc) or -1, out or ""
     end
     return execCapturePipe(cmd)

--- a/scripts/reaper/_internal/STEMwerk_Glue_Helpers.lua
+++ b/scripts/reaper/_internal/STEMwerk_Glue_Helpers.lua
@@ -115,8 +115,10 @@ function M.applyTakePlaybackState(take, state, itemLen)
     local source = reaper.GetMediaItemTake_Source(take)
     local sourceLen = nil
     if source and reaper.GetMediaSourceLength then
-        local len = reaper.GetMediaSourceLength(source)
-        sourceLen = tonumber(len)
+        local len, lengthIsQN = reaper.GetMediaSourceLength(source)
+        if not lengthIsQN then
+            sourceLen = tonumber(len)
+        end
     end
 
     if sourceLen and itemLen and itemLen > 0 then

--- a/scripts/reaper/_internal/STEMwerk_Setup_Internal.lua
+++ b/scripts/reaper/_internal/STEMwerk_Setup_Internal.lua
@@ -262,10 +262,22 @@ quoteArg = function(s)
     return s
 end
 
+local function parseExecProcessResult(result)
+    if type(result) ~= "string" then
+        return nil, ""
+    end
+    local firstLine, rest = result:match("^([^\r\n]*)\r?\n?(.*)$")
+    local rc = tonumber(firstLine)
+    if rc == nil then
+        return nil, result
+    end
+    return rc, rest or ""
+end
+
 local function exec(cmd, timeoutMs)
     timeoutMs = timeoutMs or 1200000
     if reaper and reaper.ExecProcess then
-        local rc, out = reaper.ExecProcess(cmd, timeoutMs)
+        local rc, out = parseExecProcessResult(reaper.ExecProcess(cmd, timeoutMs))
         return tonumber(rc) or -1, out or ""
     end
     local ok = os.execute(cmd)

--- a/scripts/reaper/_internal/STEMwerk_System.lua
+++ b/scripts/reaper/_internal/STEMwerk_System.lua
@@ -114,13 +114,25 @@ function M.pathJoin(a, b)
     return a .. PATH_SEP .. b
 end
 
+function M.parseExecProcessResult(result)
+    if type(result) ~= "string" then
+        return nil, ""
+    end
+    local firstLine, rest = result:match("^([^\r\n]*)\r?\n?(.*)$")
+    local rc = tonumber(firstLine)
+    if rc == nil then
+        return nil, result
+    end
+    return rc, rest or ""
+end
+
 function M.exec_capture(cmd, timeoutMs)
     timeoutMs = timeoutMs or 8000
     if reaper and reaper.ExecProcess then
         if SW_LOG.isWindows() and SW_LOG.commandNeedsWindowsShell(cmd) then
             cmd = SW_LOG.wrapCmdForWindows(cmd)
         end
-        local rc, out = reaper.ExecProcess(cmd, timeoutMs)
+        local rc, out = M.parseExecProcessResult(reaper.ExecProcess(cmd, timeoutMs))
         out = out or ""
         SW_LOG.logExecResult(cmd, rc, out)
         if out ~= "" then
@@ -133,7 +145,7 @@ function M.exec_capture(cmd, timeoutMs)
             local cachePath = home .. sep .. ".cache" .. sep .. "stemwerk_exec_out.txt"
             local inner = "mkdir -p $HOME/.cache && " .. cmd .. " > $HOME/.cache/stemwerk_exec_out.txt 2>&1"
             local sandboxCmd = "sh -lc " .. M.shellQuoteSingle(inner)
-            local rc2 = reaper.ExecProcess(sandboxCmd, timeoutMs)
+            local rc2 = M.parseExecProcessResult(reaper.ExecProcess(sandboxCmd, timeoutMs))
             local f = io.open(cachePath, "r")
             local content = ""
             if f then
@@ -147,7 +159,7 @@ function M.exec_capture(cmd, timeoutMs)
             end
             debugLog("exec_capture: sandbox fallback empty -> flatpak-spawn host fallback")
             local hostCmd = "flatpak-spawn --host sh -lc " .. M.shellQuoteSingle(inner)
-            local rc3 = reaper.ExecProcess(hostCmd, timeoutMs)
+            local rc3 = M.parseExecProcessResult(reaper.ExecProcess(hostCmd, timeoutMs))
             local f2 = io.open(cachePath, "r")
             local content2 = ""
             if f2 then

--- a/scripts/reaper/_internal/STEMwerk_Workflow.lua
+++ b/scripts/reaper/_internal/STEMwerk_Workflow.lua
@@ -154,8 +154,10 @@ local function applyPlaybackStateToTake(take, playbackState)
     local source = reaper.GetMediaItemTake_Source(take)
     local sourceLen = nil
     if source and reaper.GetMediaSourceLength then
-        local len = reaper.GetMediaSourceLength(source)
-        sourceLen = tonumber(len)
+        local len, lengthIsQN = reaper.GetMediaSourceLength(source)
+        if not lengthIsQN then
+            sourceLen = tonumber(len)
+        end
     end
 
     local itemLen = nil


### PR DESCRIPTION
Small MCP-verified ReaScript API correctness fixes. Parses Lua ExecProcess single-string return correctly, removes non-existent GetSet_AudioAccessorStartTime/EndTime calls, and handles GetMediaSourceLength lengthIsQN so QN length is not treated as seconds. Manual Linux smoke passed: Setup/Check, Save Support Bundle, and short separation completed successfully.