### PR TITLE
Limit normal workflow parallel job concurrency

### DIFF
--- a/scripts/reaper/STEMwerk.lua
+++ b/scripts/reaper/STEMwerk.lua
@@ -16405,8 +16405,14 @@ _sep.runSingleTrackSeparation = function(trackList)
             debugLog("Forcing sequential multi-track processing (directml_multi_track)")
         end
 
-        -- Respect user's Parallel choice even on CPU.
-        -- Only force sequential if device is "auto" AND we know for sure there is no GPU.
+        -- Explicit CPU requests should always run sequential to avoid unbounded CPU oversubscription.
+        if not multiTrackQueue.sequentialMode and (dev == "cpu" or dev:find("cpu", 1, true) ~= nil) then
+            multiTrackQueue.sequentialMode = true
+            multiTrackQueue.forceSequentialReason = "cpu"
+            debugLog("Forcing sequential multi-track processing (cpu)")
+        end
+
+        -- Only force sequential for AUTO if we know for sure there is no GPU.
         if not multiTrackQueue.sequentialMode and dev == "auto" and not hasRuntimeGpuBackends() then
             multiTrackQueue.sequentialMode = true
             multiTrackQueue.forceSequentialReason = "auto_no_gpu"
@@ -16418,8 +16424,13 @@ _sep.runSingleTrackSeparation = function(trackList)
     multiTrackQueue.totalAudioDuration = 0  -- Will be updated when jobs start
     SW_TIMING.beginRun({ mode = multiTrackQueue.sequentialMode and "sequential" or "parallel", job_count = #trackJobs, model = SETTINGS and SETTINGS.model or "", device = SETTINGS and SETTINGS.device or "" })
 
-    if not multiTrackQueue.sequentialMode and type(INTERNAL_PARALLEL_JOB_LIMIT) == "number" and INTERNAL_PARALLEL_JOB_LIMIT > 0 then
-        multiTrackQueue.parallelJobLimit = math.max(1, math.floor(INTERNAL_PARALLEL_JOB_LIMIT))
+    if not multiTrackQueue.sequentialMode then
+        -- Bounded default for normal workflow on GPU/auto-with-GPU.
+        local computedParallelLimit = 2
+        if type(INTERNAL_PARALLEL_JOB_LIMIT) == "number" and INTERNAL_PARALLEL_JOB_LIMIT > 0 then
+            computedParallelLimit = math.min(computedParallelLimit, math.max(1, math.floor(INTERNAL_PARALLEL_JOB_LIMIT)))
+        end
+        multiTrackQueue.parallelJobLimit = computedParallelLimit
     end
 
     if not multiTrackQueue.sequentialMode then


### PR DESCRIPTION
## Summary

This PR limits normal STEMwerk multi-track parallel processing to a safer bounded default.

Before this change, `parallelProcessing=1` could launch all selected normal workflow jobs at once unless an internal dev cap was set. That could oversubscribe CPU/GPU/VRAM on larger selections.

New policy:

- `parallelProcessing=0` → sequential
- explicit CPU → sequential
- auto with no GPU backend → sequential
- DirectML multi-track → sequential, preserving the existing safety path
- GPU / auto-with-GPU → bounded parallelism, max 2 jobs
- `INTERNAL_PARALLEL_JOB_LIMIT` remains an additional internal cap

## Scope

Changed file:

- `scripts/reaper/STEMwerk.lua`

No Drum Kit Split prototype/R&D files are included in this branch.

## Implementation notes

The normal multi-track queue now computes a bounded `multiTrackQueue.parallelJobLimit`.

For GPU / auto-with-GPU parallel mode, the default limit is `2`. If `INTERNAL_PARALLEL_JOB_LIMIT` is set, it is applied as an additional cap. The launch loop respects `multiTrackQueue.parallelJobLimit`, so the workflow no longer starts all queued jobs at once.

The existing DirectML multi-track forced-sequential branch is preserved.

## Validation

Checks run:

- `luac -p scripts/reaper/STEMwerk.lua`
- `luac -p scripts/reaper/STEMwerk_All_Stems.lua`
- `luac -p scripts/reaper/STEMwerk_AI_Separate.lua`
- `git diff --check`

`python -m py_compile scripts/reaper/audio_separator_process.py` was not needed for this split branch because `audio_separator_process.py` is outside the scope and unchanged.

Smoke:

- Normal All Stems async-aware smoke with 3 selected items
- `device=auto`
- `parallelProcessing=1`
- Output created successfully
- Undo restored baseline project state
- No Drum Kit output created

## Notes

Runtime artifacts for the normal workflow do not currently expose Drum Kit-style hard concurrency traces, so runtime max-active proof was not directly observable.

The static guarantee is localized in the normal multi-track queue logic: `multiTrackQueue.parallelJobLimit` is computed as `2` for GPU / auto-with-GPU parallel mode, optionally capped by `INTERNAL_PARALLEL_JOB_LIMIT`, and the launch loop respects that cap.
