### PR TITLE
ci: run release gate in fast checks

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Validate version sync
         run: python tools/version_sync.py --check
 
+      - name: Run release gate
+        run: python tools/release_gate.py --check
+
       - name: Install test dependencies
         run: |
           python -m pip install pytest soundfile


### PR DESCRIPTION
Adds release gate verification to CI Fast so PR/main logs explicitly prove ReaPack payload/linkage checks.\n\n- adds `Run release gate` step to run `python tools/release_gate.py --check`\n- keeps existing fast checks intact\n- no runtime behavior changes