### PR TITLE
ci: restore release gate in fast checks

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Validate version sync
         run: python tools/version_sync.py --check
 
+      - name: Run release gate
+        run: python tools/release_gate.py --check
+
       - name: Install test dependencies
         run: |
           python -m pip install pytest soundfile


### PR DESCRIPTION
Restore the CI Fast release-gate step from support/2.2.2.2 to prevent future public-main restores from dropping it again.\n\n- Re-adds to .github/workflows/ci-full.yml:\n  - name: Run release gate\n    run: python tools/release_gate.py --check\n- No VERSION/index.xml/runtime/payload changes.