### PR TITLE
R&D: Direct Drum Kit Split with optional CPU/ROCm runtimes on Linux

### DIFF
--- a/docs/planning/ROADMAP_AFTER_2.2.2.md
+++ b/docs/planning/ROADMAP_AFTER_2.2.2.md
@@ -65,6 +65,18 @@ Purpose of this branch:
 - ReaPack payload validation.
 - Release asset naming validation.
 
+## Drum Kit Split Groundwork (R&D)
+
+- Branch groundwork exists on `feature/dks-direct-on-main`.
+- Direct route integration is in place: workflow `drumkit` with source route `dks_direct`.
+- Direct route correctly skips Demucs/stage1 and uses DrumSep model alias/catalog/cache resolution.
+- Current pinned runtime (`audio-separator==0.23.0`) reaches MDXC load but cannot run this DrumSep MDX23C model (`AttributeError: "'model'"` in MDXC loader path).
+- `audio-separator==0.44.2` is not a safe drop-in under current stack (probe segfault) and introduces high-risk dependency churn (`numpy>=2`, `onnx-weekly`, `onnx2torch-py313`, broader torch/runtime changes).
+- Next spike options:
+- 1. targeted STEMwerk-side MDXC YAML/config adapter
+- 2. dedicated audio-separator upgrade branch with full regression matrix for normal workflows
+- 3. alternative supported DrumSep/kit model
+
 ## Optional Native Bridge - Future Spike
 
 Recommended experimental branch: `feature/native-bridge-spike`

--- a/index.xml
+++ b/index.xml
@@ -45,6 +45,7 @@
         <source file="../_internal/STEMwerk_Runtime_Setup.lua" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/STEMwerk_Runtime_Setup.lua</source>
         <source file="../_internal/STEMwerk_Settings.lua" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/STEMwerk_Settings.lua</source>
         <source file="../_internal/STEMwerk_Setup_Internal.lua" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/STEMwerk_Setup_Internal.lua</source>
+        <source file="../_internal/stemwerk_drumsep_process.py" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/stemwerk_drumsep_process.py</source>
         <source file="../_internal/stemwerk_samplerate_guard.py" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/stemwerk_samplerate_guard.py</source>
         <source file="../_internal/STEMwerk_System.lua" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/STEMwerk_System.lua</source>
         <source file="../_internal/STEMwerk_Timing.lua" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/STEMwerk_Timing.lua</source>

--- a/index.xml
+++ b/index.xml
@@ -18,6 +18,7 @@
         <source file="../STEMwerk_All_Stems.lua" type="script">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/STEMwerk_All_Stems.lua</source>
         <source file="../STEMwerk_Vocals_Only.lua" type="script">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/STEMwerk_Vocals_Only.lua</source>
         <source file="../STEMwerk_Drums_Only.lua" type="script">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/STEMwerk_Drums_Only.lua</source>
+        <source file="../STEMwerk_Drum_Kit_Split.lua" type="script">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/STEMwerk_Drum_Kit_Split.lua</source>
         <source file="../STEMwerk_Bass_Only.lua" type="script">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/STEMwerk_Bass_Only.lua</source>
         <source file="../STEMwerk_Karaoke.lua" type="script">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/STEMwerk_Karaoke.lua</source>
 

--- a/index.xml
+++ b/index.xml
@@ -28,6 +28,7 @@
         <source file="../audio_separator_process.py" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/audio_separator_process.py</source>
 
         <source file="../_internal/STEMwerk_Devices.lua" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/STEMwerk_Devices.lua</source>
+        <source file="../_internal/STEMwerk_DrumKit_Workflow.lua" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/STEMwerk_DrumKit_Workflow.lua</source>
         <source file="../_internal/STEMwerk_ExtState.lua" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/STEMwerk_ExtState.lua</source>
         <source file="../_internal/STEMwerk_Glue_Helpers.lua" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/STEMwerk_Glue_Helpers.lua</source>
         <source file="../_internal/STEMwerk_Helpers.lua" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/STEMwerk_Helpers.lua</source>

--- a/scripts/reaper/STEMwerk.lua
+++ b/scripts/reaper/STEMwerk.lua
@@ -1421,9 +1421,35 @@ end
 
 local function buildKnownSeparationFailureMessage(logSnippet, exitCode, cmdLine, logPath, debugLogPath, stdoutSnippet)
     local lowerLog = string.lower(tostring(logSnippet or ""))
+    local lowerCmd = string.lower(tostring(cmdLine or ""))
+    local isDirectDksCmd = lowerCmd:find("workflow%-source", 1, false) and lowerCmd:find("dks_direct", 1, true)
+    local hasFallbackModelMissing = lowerLog:find("not found in supported model files", 1, true)
+        and lowerLog:find("model file", 1, true)
     if lowerLog:find("error_stage=stage2_preflight", 1, true)
         and lowerLog:find("error_reason=drumsep_model_missing", 1, true) then
         local requested = tostring(logSnippet or ""):match("requested_model=([^\r\n]+)") or DKS_WORKFLOW.DIRECT_DKS_MODEL
+        local msg = "Direct Drum Kit Split preflight failed.\n"
+            .. "Reason: drumsep_model_missing\n"
+            .. "Requested model: " .. tostring(requested)
+            .. "\nerror_stage=stage2_preflight\n"
+            .. "error_reason=drumsep_model_missing"
+            .. "\n\nThe current audio-separator model catalog/runtime cannot resolve this DrumSep model.\n"
+            .. "Update/repair the STEMwerk runtime model catalog, then retry."
+            .. "\n\nExit code: " .. tostring(exitCode or "unknown")
+            .. "\nCommand: " .. tostring(cmdLine or "unknown")
+            .. "\nPython log (" .. tostring(logPath or "unknown") .. "):\n"
+            .. tostring(logSnippet or "(no log output found)")
+            .. "\n\nDebug log: " .. tostring(debugLogPath or SW_LOG.getLogPath())
+        if stdoutSnippet and stdoutSnippet ~= "" then
+            msg = msg .. "\n\nStdout (first 1200 chars):\n" .. stdoutSnippet
+        end
+        return msg
+    end
+
+    if isDirectDksCmd and hasFallbackModelMissing then
+        local requested = tostring(logSnippet or ""):match("requested_model=([^\r\n]+)")
+            or tostring(cmdLine or ""):match("%-%-requested%-stage2%-model%s+['\"]?([^%s'\"]+)")
+            or DKS_WORKFLOW.DIRECT_DKS_MODEL
         local msg = "Direct Drum Kit Split preflight failed.\n"
             .. "Reason: drumsep_model_missing\n"
             .. "Requested model: " .. tostring(requested)

--- a/scripts/reaper/STEMwerk.lua
+++ b/scripts/reaper/STEMwerk.lua
@@ -1080,6 +1080,23 @@ STEMS = {
     { name = "Piano",  color = {255, 120, 200}, file = "piano.wav", selected = true, key = "6", sixStemOnly = true },
 }
 
+local STANDARD_STEMS = STEMS
+local DRUMKIT_STEMS = {
+    { name = "Kick",   color = {230, 120, 70},  file = "kick.wav",   selected = true, key = "1", sixStemOnly = false },
+    { name = "Snare",  color = {240, 190, 80},  file = "snare.wav",  selected = true, key = "2", sixStemOnly = false },
+    { name = "Toms",   color = {120, 200, 120}, file = "toms.wav",   selected = true, key = "3", sixStemOnly = false },
+    { name = "Hi-Hat", color = {90, 190, 230},  file = "hi-hat.wav", selected = true, key = "4", sixStemOnly = false },
+    { name = "Ride",   color = {150, 130, 240}, file = "ride.wav",   selected = true, key = "5", sixStemOnly = false },
+    { name = "Crash",  color = {240, 120, 180}, file = "crash.wav",  selected = true, key = "6", sixStemOnly = false },
+}
+
+local function activateWorkflowStemSet(isDirectDKS)
+    STEMS = isDirectDKS and DRUMKIT_STEMS or STANDARD_STEMS
+    if SETTINGS_MOD and SETTINGS_MOD.configure then
+        SETTINGS_MOD.configure({ STEMS = STEMS })
+    end
+end
+
 -- Available processing devices
 DEVICES = {
     { id = "auto", name = "Auto", desc = "Automatically select best GPU" },
@@ -1467,6 +1484,27 @@ local function buildKnownSeparationFailureMessage(logSnippet, exitCode, cmdLine,
             .. (detail ~= "" and ("\nDetail: " .. tostring(detail)) or "")
             .. "\nerror_stage=stage2_runtime\n"
             .. "error_reason=" .. tostring(reason)
+            .. "\n\nExit code: " .. tostring(exitCode or "unknown")
+            .. "\nCommand: " .. tostring(cmdLine or "unknown")
+            .. "\nPython log (" .. tostring(logPath or "unknown") .. "):\n"
+            .. tostring(logSnippet or "(no log output found)")
+            .. "\n\nDebug log: " .. tostring(debugLogPath or SW_LOG.getLogPath())
+        if stdoutSnippet and stdoutSnippet ~= "" then
+            msg = msg .. "\n\nStdout (first 1200 chars):\n" .. stdoutSnippet
+        end
+        return msg
+    end
+
+    if lowerLog:find("error_reason=drumsep_helper_failed", 1, true)
+        or lowerLog:find("error_reason=drumsep_model_load_failed", 1, true)
+        or lowerLog:find("error_reason=drumsep_separate_failed", 1, true)
+        or lowerLog:find("error_reason=drumsep_output_count_mismatch", 1, true) then
+        local reason = tostring(logSnippet or ""):match("error_reason=([^\r\n]+)") or "drumsep_helper_failed"
+        local stage = tostring(logSnippet or ""):match("error_stage=([^\r\n]+)") or "stage2_separate"
+        local msg = "Drum Kit Split separation failed.\n"
+            .. "Reason: " .. tostring(reason)
+            .. "\nerror_stage=" .. tostring(stage)
+            .. "\nerror_reason=" .. tostring(reason)
             .. "\n\nExit code: " .. tostring(exitCode or "unknown")
             .. "\nCommand: " .. tostring(cmdLine or "unknown")
             .. "\nPython log (" .. tostring(logPath or "unknown") .. "):\n"
@@ -19364,6 +19402,7 @@ function runSeparationWorkflow()
         runOptions = DKS_WORKFLOW.buildDirectRunOptions()
         debugLog("Direct DKS mode active: skipping Demucs dependency guard")
     end
+    activateWorkflowStemSet(isDirectDKS)
     setWorkflowContextForRun(runOptions)
 
     if OS == "Windows" then

--- a/scripts/reaper/STEMwerk.lua
+++ b/scripts/reaper/STEMwerk.lua
@@ -1450,6 +1450,29 @@ local function buildKnownSeparationFailureMessage(logSnippet, exitCode, cmdLine,
         return msg
     end
 
+    if lowerLog:find("error_stage=stage2_model_load", 1, true)
+        and lowerLog:find("error_reason=drumsep_model_runtime_unsupported", 1, true) then
+        local requested = tostring(logSnippet or ""):match("requested_model=([^\r\n]+)") or DKS_WORKFLOW.DIRECT_DKS_MODEL
+        local resolved = tostring(logSnippet or ""):match("resolved_model=([^\r\n]+)") or ""
+        local msg = "Direct Drum Kit Split model load failed.\n"
+            .. "Reason: drumsep_model_runtime_unsupported\n"
+            .. "Requested model: " .. tostring(requested)
+            .. (resolved ~= "" and ("\nResolved model: " .. tostring(resolved)) or "")
+            .. "\nerror_stage=stage2_model_load\n"
+            .. "error_reason=drumsep_model_runtime_unsupported"
+            .. "\n\nThis DrumSep MDXC model is not compatible with the current audio-separator runtime.\n"
+            .. "Use a runtime/model combination that supports this MDXC config."
+            .. "\n\nExit code: " .. tostring(exitCode or "unknown")
+            .. "\nCommand: " .. tostring(cmdLine or "unknown")
+            .. "\nPython log (" .. tostring(logPath or "unknown") .. "):\n"
+            .. tostring(logSnippet or "(no log output found)")
+            .. "\n\nDebug log: " .. tostring(debugLogPath or SW_LOG.getLogPath())
+        if stdoutSnippet and stdoutSnippet ~= "" then
+            msg = msg .. "\n\nStdout (first 1200 chars):\n" .. stdoutSnippet
+        end
+        return msg
+    end
+
     if isDirectDksCmd and hasFallbackModelMissing then
         local requested = tostring(logSnippet or ""):match("requested_model=([^\r\n]+)")
             or tostring(cmdLine or ""):match("%-%-requested%-stage2%-model%s+['\"]?([^%s'\"]+)")

--- a/scripts/reaper/STEMwerk.lua
+++ b/scripts/reaper/STEMwerk.lua
@@ -1426,13 +1426,17 @@ local function buildKnownSeparationFailureMessage(logSnippet, exitCode, cmdLine,
     local hasFallbackModelMissing = lowerLog:find("not found in supported model files", 1, true)
         and lowerLog:find("model file", 1, true)
     if lowerLog:find("error_stage=stage2_preflight", 1, true)
-        and lowerLog:find("error_reason=drumsep_model_missing", 1, true) then
+        and (lowerLog:find("error_reason=drumsep_model_missing", 1, true)
+            or lowerLog:find("error_reason=drumsep_model_download_failed", 1, true)) then
+        local reason = tostring(logSnippet or ""):match("error_reason=([^\r\n]+)") or "drumsep_model_missing"
         local requested = tostring(logSnippet or ""):match("requested_model=([^\r\n]+)") or DKS_WORKFLOW.DIRECT_DKS_MODEL
+        local resolved = tostring(logSnippet or ""):match("resolved_model=([^\r\n]+)") or ""
         local msg = "Direct Drum Kit Split preflight failed.\n"
-            .. "Reason: drumsep_model_missing\n"
+            .. "Reason: " .. tostring(reason) .. "\n"
             .. "Requested model: " .. tostring(requested)
+            .. (resolved ~= "" and ("\nResolved model: " .. tostring(resolved)) or "")
             .. "\nerror_stage=stage2_preflight\n"
-            .. "error_reason=drumsep_model_missing"
+            .. "error_reason=" .. tostring(reason)
             .. "\n\nThe current audio-separator model catalog/runtime cannot resolve this DrumSep model.\n"
             .. "Update/repair the STEMwerk runtime model catalog, then retry."
             .. "\n\nExit code: " .. tostring(exitCode or "unknown")

--- a/scripts/reaper/STEMwerk.lua
+++ b/scripts/reaper/STEMwerk.lua
@@ -1452,10 +1452,13 @@ local function buildKnownSeparationFailureMessage(logSnippet, exitCode, cmdLine,
 
     if lowerLog:find("error_stage=stage2_runtime", 1, true)
         and (lowerLog:find("error_reason=drumsep_runtime_missing", 1, true)
-            or lowerLog:find("error_reason=drumsep_runtime_broken", 1, true)) then
+            or lowerLog:find("error_reason=drumsep_runtime_broken", 1, true)
+            or lowerLog:find("error_reason=drumsep_stage2_delegation_not_implemented", 1, true)) then
         local reason = tostring(logSnippet or ""):match("error_reason=([^\r\n]+)") or "drumsep_runtime_missing"
         local detail = tostring(logSnippet or ""):match("detail=([^\r\n]+)") or ""
-        local headline = reason == "drumsep_runtime_broken"
+        local headline = reason == "drumsep_stage2_delegation_not_implemented"
+            and "Drum Kit Split runtime is installed, but stage2 delegation is not implemented yet."
+            or reason == "drumsep_runtime_broken"
             and "Drum Kit Split runtime is broken."
             or "Drum Kit Split runtime is not installed."
         local msg = headline .. "\n"

--- a/scripts/reaper/STEMwerk.lua
+++ b/scripts/reaper/STEMwerk.lua
@@ -1450,6 +1450,31 @@ local function buildKnownSeparationFailureMessage(logSnippet, exitCode, cmdLine,
         return msg
     end
 
+    if lowerLog:find("error_stage=stage2_runtime", 1, true)
+        and (lowerLog:find("error_reason=drumsep_runtime_missing", 1, true)
+            or lowerLog:find("error_reason=drumsep_runtime_broken", 1, true)) then
+        local reason = tostring(logSnippet or ""):match("error_reason=([^\r\n]+)") or "drumsep_runtime_missing"
+        local detail = tostring(logSnippet or ""):match("detail=([^\r\n]+)") or ""
+        local headline = reason == "drumsep_runtime_broken"
+            and "Drum Kit Split runtime is broken."
+            or "Drum Kit Split runtime is not installed."
+        local msg = headline .. "\n"
+            .. "Run Setup/Repair Drum Kit Split runtime.\n"
+            .. "Reason: " .. tostring(reason)
+            .. (detail ~= "" and ("\nDetail: " .. tostring(detail)) or "")
+            .. "\nerror_stage=stage2_runtime\n"
+            .. "error_reason=" .. tostring(reason)
+            .. "\n\nExit code: " .. tostring(exitCode or "unknown")
+            .. "\nCommand: " .. tostring(cmdLine or "unknown")
+            .. "\nPython log (" .. tostring(logPath or "unknown") .. "):\n"
+            .. tostring(logSnippet or "(no log output found)")
+            .. "\n\nDebug log: " .. tostring(debugLogPath or SW_LOG.getLogPath())
+        if stdoutSnippet and stdoutSnippet ~= "" then
+            msg = msg .. "\n\nStdout (first 1200 chars):\n" .. stdoutSnippet
+        end
+        return msg
+    end
+
     if lowerLog:find("error_stage=stage2_model_load", 1, true)
         and lowerLog:find("error_reason=drumsep_model_runtime_unsupported", 1, true) then
         local requested = tostring(logSnippet or ""):match("requested_model=([^\r\n]+)") or DKS_WORKFLOW.DIRECT_DKS_MODEL

--- a/scripts/reaper/STEMwerk.lua
+++ b/scripts/reaper/STEMwerk.lua
@@ -1425,9 +1425,10 @@ local function buildKnownSeparationFailureMessage(logSnippet, exitCode, cmdLine,
         and lowerLog:find("error_reason=drumsep_model_missing", 1, true) then
         local requested = tostring(logSnippet or ""):match("requested_model=([^\r\n]+)") or DKS_WORKFLOW.DIRECT_DKS_MODEL
         local msg = "Direct Drum Kit Split preflight failed.\n"
-            .. "error_stage=stage2_preflight\n"
-            .. "error_reason=drumsep_model_missing\n"
-            .. "requested_model=" .. tostring(requested)
+            .. "Reason: drumsep_model_missing\n"
+            .. "Requested model: " .. tostring(requested)
+            .. "\nerror_stage=stage2_preflight\n"
+            .. "error_reason=drumsep_model_missing"
             .. "\n\nThe current audio-separator model catalog/runtime cannot resolve this DrumSep model.\n"
             .. "Update/repair the STEMwerk runtime model catalog, then retry."
             .. "\n\nExit code: " .. tostring(exitCode or "unknown")
@@ -13265,7 +13266,19 @@ local progressState = {
     nextFrameAt = 0,
     nextPollAt = 0,
     doneDetected = false,
+    workflowMode = "",
+    workflowSource = "",
 }
+
+local function isDrumKitWorkflowActive()
+    return tostring(progressState.workflowMode or "") == DKS_WORKFLOW.WORKFLOW_DRUMKIT
+end
+
+local function setWorkflowContextForRun(runOptions)
+    runOptions = runOptions or {}
+    progressState.workflowMode = tostring(runOptions.workflowMode or "")
+    progressState.workflowSource = tostring(runOptions.workflowSource or "")
+end
 
 UI_PROGRESS.configure({
     progressState               = progressState,
@@ -13331,7 +13344,7 @@ function showProcessingPlaceholderWindow(stage)
     local fillW = math.max(24, math.floor(barW * (0.18 + 0.22 * pulse)))
 
     gfx.setfont(1, "Arial", 20, string.byte('b'))
-    local title = "STEMwerk"
+    local title = isDrumKitWorkflowActive() and "Drum Kit Split" or "STEMwerk"
     local titleW = gfx.measurestr(title)
     gfx.set(text[1], text[2], text[3], 1)
     gfx.x = math.floor((w - titleW) / 2)
@@ -13676,6 +13689,8 @@ local function drawProgressWindow()
     local titleX = PS(25)
     local titleY = PS(28)
 
+    local drumKitMode = isDrumKitWorkflowActive()
+
     -- In multi-track mode, show which track
     if multiTrackQueue.active then
         gfx.set(THEME.text[1], THEME.text[2], THEME.text[3], 1)
@@ -13687,23 +13702,27 @@ local function drawProgressWindow()
         gfx.set(THEME.text[1], THEME.text[2], THEME.text[3], 1)
         gfx.x = titleX
         gfx.y = titleY
-        local singleTrackLabel = T("single_track") or "Single-Track"
-        gfx.drawstr(singleTrackLabel .. " ")
-        local aiW = gfx.measurestr(singleTrackLabel .. " ")
-        if utilityMode then
-            gfx.drawstr("STEMwerk")
+        if drumKitMode then
+            gfx.drawstr("Drum Kit Split")
         else
-            drawWavingStemwerkLogo({
-                x = titleX + aiW,
-                y = titleY,
-                fontSize = PS(18),
-                time = os.clock(),
-                amp = PS(2),
-                speed = 3,
-                phase = 0.5,
-                alphaStem = 1,
-                alphaRest = 1,
-            })
+            local singleTrackLabel = T("single_track") or "Single-Track"
+            gfx.drawstr(singleTrackLabel .. " ")
+            local aiW = gfx.measurestr(singleTrackLabel .. " ")
+            if utilityMode then
+                gfx.drawstr("STEMwerk")
+            else
+                drawWavingStemwerkLogo({
+                    x = titleX + aiW,
+                    y = titleY,
+                    fontSize = PS(18),
+                    time = os.clock(),
+                    amp = PS(2),
+                    speed = 3,
+                    phase = 0.5,
+                    alphaStem = 1,
+                    alphaRest = 1,
+                })
+            end
         end
     end
 
@@ -13712,23 +13731,41 @@ local function drawProgressWindow()
     local stemY = PS(63)
     local stemBoxSize = PS(14)
     gfx.setfont(1, "Arial", PS(11))
-    for _, stem in ipairs(STEMS) do
-        if stem.selected and (not stem.sixStemOnly or runIs6Stem) then
-            -- Stem marker box. REAPER Native keeps processing windows neutral.
+    if drumKitMode then
+        local kitLabels = DKS_WORKFLOW.KIT_STEMS or {}
+        for _, stemLabel in ipairs(kitLabels) do
             if utilityMode then
                 local ur, ug, ub = utilityProgressMutedColor()
                 gfx.set(ur, ug, ub, 1)
             else
-                gfx.set(stem.color[1]/255, stem.color[2]/255, stem.color[3]/255, 1)
+                gfx.set((THEME.accent[1] or 0.5), (THEME.accent[2] or 0.5), (THEME.accent[3] or 0.5), 1)
             end
             gfx.rect(stemX, stemY, stemBoxSize, stemBoxSize, 1)
-            -- Stem name
             gfx.set(THEME.textDim[1], THEME.textDim[2], THEME.textDim[3], 1)
             gfx.x = stemX + stemBoxSize + PS(6)
             gfx.y = stemY + PS(1)
-            local stemLabel = getStemDisplayName(stem)
             gfx.drawstr(stemLabel)
             stemX = stemX + stemBoxSize + gfx.measurestr(stemLabel) + PS(20)
+        end
+    else
+        for _, stem in ipairs(STEMS) do
+            if stem.selected and (not stem.sixStemOnly or runIs6Stem) then
+                -- Stem marker box. REAPER Native keeps processing windows neutral.
+                if utilityMode then
+                    local ur, ug, ub = utilityProgressMutedColor()
+                    gfx.set(ur, ug, ub, 1)
+                else
+                    gfx.set(stem.color[1]/255, stem.color[2]/255, stem.color[3]/255, 1)
+                end
+                gfx.rect(stemX, stemY, stemBoxSize, stemBoxSize, 1)
+                -- Stem name
+                gfx.set(THEME.textDim[1], THEME.textDim[2], THEME.textDim[3], 1)
+                gfx.x = stemX + stemBoxSize + PS(6)
+                gfx.y = stemY + PS(1)
+                local stemLabel = getStemDisplayName(stem)
+                gfx.drawstr(stemLabel)
+                stemX = stemX + stemBoxSize + gfx.measurestr(stemLabel) + PS(20)
+            end
         end
     end
 
@@ -19225,10 +19262,6 @@ function runSeparationWorkflow()
     debugLog("=== runSeparationWorkflow started ===")
     captureActiveRunConfig()
 
-    if OS == "Windows" then
-        showProcessingPlaceholderWindow(T("progress_checking_runtime") or "Checking runtime...")
-    end
-
     local trustedWindowsRuntime = nil
     if OS == "Windows" then
         trustedWindowsRuntime = getTrustedWindowsRuntimeState()
@@ -19236,20 +19269,31 @@ function runSeparationWorkflow()
     end
 
     local runOptions = nil
-    local quickModePreset = reaper.GetExtState(EXT_SECTION, "active_workflow_mode")
-    local isDirectDKS = DKS_WORKFLOW.isDirectPreset(quickModePreset)
-    if quickModePreset ~= "" then
+    local workflowModeState = tostring(reaper.GetExtState(EXT_SECTION, "active_workflow_mode") or "")
+    local workflowSourceState = tostring(reaper.GetExtState(EXT_SECTION, "active_workflow_source") or "")
+    local isDirectDKS = (workflowModeState == DKS_WORKFLOW.WORKFLOW_DRUMKIT)
+        and (workflowSourceState == DKS_WORKFLOW.SOURCE_DIRECT or DKS_WORKFLOW.isDirectPreset(workflowSourceState))
+    if workflowModeState ~= "" then
         reaper.DeleteExtState(EXT_SECTION, "active_workflow_mode", false)
+    end
+    if workflowSourceState ~= "" then
+        reaper.DeleteExtState(EXT_SECTION, "active_workflow_source", false)
     end
     if isDirectDKS then
         runOptions = DKS_WORKFLOW.buildDirectRunOptions()
         debugLog("Direct DKS mode active: skipping Demucs dependency guard")
+    end
+    setWorkflowContextForRun(runOptions)
+
+    if OS == "Windows" then
+        showProcessingPlaceholderWindow(T("progress_checking_runtime") or "Checking runtime...")
     end
 
     if (not trustedWindowsRuntime) and (not isDirectDKS) and (not ensureDependenciesInteractive()) then
         if OS == "Windows" and progressState.windowOpen then
             closeProcessingWindow()
         end
+        setWorkflowContextForRun(nil)
         isProcessingActive = false
         return
     end
@@ -19354,6 +19398,7 @@ function runSeparationWorkflow()
             closeProcessingWindow()
         end
         showMessage(T("no_stems_selected") or "No Stems Selected", T("please_select_stem") or "Please select at least one stem.", "warning")
+        setWorkflowContextForRun(nil)
         isProcessingActive = false
         return
     end
@@ -19363,6 +19408,7 @@ function runSeparationWorkflow()
             closeProcessingWindow()
         end
         showMessage(HELPERS.getStemFilesWarningTitle(), HELPERS.getStemFilesMissingCustomWarning(), "warning")
+        setWorkflowContextForRun(nil)
         isProcessingActive = false
         return
     end
@@ -19371,6 +19417,7 @@ function runSeparationWorkflow()
             closeProcessingWindow()
         end
         showMessage(HELPERS.getStemFilesWarningTitle(), HELPERS.getStemFilesProjectUnavailableWarning(), "warning")
+        setWorkflowContextForRun(nil)
         isProcessingActive = false
         return
     end
@@ -19432,6 +19479,7 @@ function runSeparationWorkflow()
                 closeProcessingWindow()
             end
             showMessage("No audible tracks", "All selected tracks are muted or not solo-audible.", "info", true)
+            setWorkflowContextForRun(nil)
             isProcessingActive = false
             return
         end
@@ -19529,6 +19577,7 @@ function runSeparationWorkflow()
         end
         local promptTitle, promptMessage = HELPERS.getSelectionMonitorPrompt()
         showMessage(promptTitle, promptMessage, "info", true)
+        setWorkflowContextForRun(nil)
         isProcessingActive = false
         return
     end
@@ -19763,6 +19812,7 @@ function runSeparationWorkflow()
                 showMessage(promptTitle, promptMessage, "info", true)
             end
         end)
+        setWorkflowContextForRun(nil)
         return
     end
 
@@ -19829,8 +19879,9 @@ function checkQuickPreset()
             STEMS[4].selected = false
         elseif preset == "all" then
             applyPresetAll()
-        elseif DKS_WORKFLOW.isDirectPreset(preset) then
-            reaper.SetExtState(EXT_SECTION, "active_workflow_mode", DKS_WORKFLOW.DIRECT_DKS_PRESET, false)
+        elseif preset == DKS_WORKFLOW.WORKFLOW_DRUMKIT or DKS_WORKFLOW.isDirectPreset(preset) then
+            reaper.SetExtState(EXT_SECTION, "active_workflow_mode", DKS_WORKFLOW.WORKFLOW_DRUMKIT, false)
+            reaper.SetExtState(EXT_SECTION, "active_workflow_source", DKS_WORKFLOW.SOURCE_DIRECT, false)
         end
 
         return true  -- Quick mode, skip dialog

--- a/scripts/reaper/STEMwerk.lua
+++ b/scripts/reaper/STEMwerk.lua
@@ -14183,7 +14183,7 @@ local function drawProgressWindow()
             gfx.setfont(1, "Courier", PS(10), string.byte('b'))
             gfx.x = displayX + PS(5)
             gfx.y = displayY + PS(3)
-            gfx.drawstr(T("terminal_output_title") or "DEMUCS OUTPUT")
+            gfx.drawstr(isDrumKitWorkflowActive() and "DRUMSEP OUTPUT" or (T("terminal_output_title") or "DEMUCS OUTPUT"))
 
             -- Read latest terminal output from stdout file
             local now = uiNow()
@@ -17846,7 +17846,7 @@ function drawMultiTrackProgressWindow()
         gfx.setfont(1, "Courier", PS(10), string.byte('b'))
         gfx.x = displayX + PS(5)
         gfx.y = displayY + PS(3)
-        gfx.drawstr(T("terminal_output_title") or "DEMUCS OUTPUT")
+        gfx.drawstr(isDrumKitWorkflowActive() and "DRUMSEP OUTPUT" or (T("terminal_output_title") or "DEMUCS OUTPUT"))
 
         local function tailFileLines(filePath, maxLines)
             if not filePath or filePath == "" then return {} end

--- a/scripts/reaper/STEMwerk.lua
+++ b/scripts/reaper/STEMwerk.lua
@@ -106,6 +106,7 @@ local function loadModule(path, label)
 end
 
 local SW_SETUP = dofile(script_path .. "_internal/STEMwerk_Runtime_Setup.lua")
+local DKS_WORKFLOW = dofile(script_path .. "_internal/STEMwerk_DrumKit_Workflow.lua")
 local SYSTEM = dofile(script_path .. "_internal/STEMwerk_System.lua")
 local getOS = SYSTEM.getOS
 local isAbsolutePath = SYSTEM.isAbsolutePath
@@ -1419,6 +1420,27 @@ local function isKnownMpsUnsupportedFailure(logSnippet)
 end
 
 local function buildKnownSeparationFailureMessage(logSnippet, exitCode, cmdLine, logPath, debugLogPath, stdoutSnippet)
+    local lowerLog = string.lower(tostring(logSnippet or ""))
+    if lowerLog:find("error_stage=stage2_preflight", 1, true)
+        and lowerLog:find("error_reason=drumsep_model_missing", 1, true) then
+        local requested = tostring(logSnippet or ""):match("requested_model=([^\r\n]+)") or DKS_WORKFLOW.DIRECT_DKS_MODEL
+        local msg = "Direct Drum Kit Split preflight failed.\n"
+            .. "error_stage=stage2_preflight\n"
+            .. "error_reason=drumsep_model_missing\n"
+            .. "requested_model=" .. tostring(requested)
+            .. "\n\nThe current audio-separator model catalog/runtime cannot resolve this DrumSep model.\n"
+            .. "Update/repair the STEMwerk runtime model catalog, then retry."
+            .. "\n\nExit code: " .. tostring(exitCode or "unknown")
+            .. "\nCommand: " .. tostring(cmdLine or "unknown")
+            .. "\nPython log (" .. tostring(logPath or "unknown") .. "):\n"
+            .. tostring(logSnippet or "(no log output found)")
+            .. "\n\nDebug log: " .. tostring(debugLogPath or SW_LOG.getLogPath())
+        if stdoutSnippet and stdoutSnippet ~= "" then
+            msg = msg .. "\n\nStdout (first 1200 chars):\n" .. stdoutSnippet
+        end
+        return msg
+    end
+
     local function modelCachePathHint()
         if OS == "macOS" then
             return "~/Library/Application Support/STEMwerk/models/"
@@ -19213,7 +19235,18 @@ function runSeparationWorkflow()
         applyTrustedWindowsRuntimeState(trustedWindowsRuntime)
     end
 
-    if (not trustedWindowsRuntime) and (not ensureDependenciesInteractive()) then
+    local runOptions = nil
+    local quickModePreset = reaper.GetExtState(EXT_SECTION, "active_workflow_mode")
+    local isDirectDKS = DKS_WORKFLOW.isDirectPreset(quickModePreset)
+    if quickModePreset ~= "" then
+        reaper.DeleteExtState(EXT_SECTION, "active_workflow_mode", false)
+    end
+    if isDirectDKS then
+        runOptions = DKS_WORKFLOW.buildDirectRunOptions()
+        debugLog("Direct DKS mode active: skipping Demucs dependency guard")
+    end
+
+    if (not trustedWindowsRuntime) and (not isDirectDKS) and (not ensureDependenciesInteractive()) then
         if OS == "Windows" and progressState.windowOpen then
             closeProcessingWindow()
         end
@@ -19764,7 +19797,11 @@ function runSeparationWorkflow()
     end
     -- Start separation with progress UI (async)
     writeTimingEvent(WORKFLOW_TEMP_DIR, "python_launch", "single", { mode = "single" })
-    WORKFLOW.runSeparationWithProgress(WORKFLOW_TEMP_INPUT, WORKFLOW_TEMP_DIR, SETTINGS.model)
+    local workflowModel = SETTINGS.model
+    if runOptions and runOptions.requestedStage2Model then
+        workflowModel = runOptions.requestedStage2Model
+    end
+    WORKFLOW.runSeparationWithProgress(WORKFLOW_TEMP_INPUT, WORKFLOW_TEMP_DIR, workflowModel, runOptions)
     debugLog("runSeparationWithProgress called")
 end
 
@@ -19792,6 +19829,8 @@ function checkQuickPreset()
             STEMS[4].selected = false
         elseif preset == "all" then
             applyPresetAll()
+        elseif DKS_WORKFLOW.isDirectPreset(preset) then
+            reaper.SetExtState(EXT_SECTION, "active_workflow_mode", DKS_WORKFLOW.DIRECT_DKS_PRESET, false)
         end
 
         return true  -- Quick mode, skip dialog

--- a/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
+++ b/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
@@ -22,6 +22,11 @@ DRUMSEP_ONNX2TORCH_PY313_VERSION="1.6.0"
 DRUMSEP_TORCH_VERSION="2.12.0"
 DRUMSEP_TORCHVISION_VERSION="0.27.0"
 DRUMSEP_NUMBA_VERSION="0.65.1"
+DRUMSEP_ROCM_TORCH_VERSION="2.9.1+rocm6.4"
+DRUMSEP_ROCM_TORCHVISION_VERSION="0.24.1+rocm6.4"
+DRUMSEP_ROCM_TORCHAUDIO_VERSION="2.9.1+rocm6.4"
+DRUMSEP_ROCM_TORCH_INDEX_URL="https://download.pytorch.org/whl/rocm6.4"
+DRUMSEP_ROCM_MIN_FREE_GB="20"
 DRUMSEP_MODEL_FILE="aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.ckpt"
 DRUMSEP_MODEL_YAML="aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.yaml"
 
@@ -86,6 +91,18 @@ drumsep_runtime_python() {
   printf "%s/.venv-drumsep/bin/python\n" "${RUNTIME_BASE}"
 }
 
+drumsep_rocm_state_file() {
+  printf "%s/state/drumsep_runtime_rocm.env\n" "${RUNTIME_BASE}"
+}
+
+drumsep_rocm_log_file() {
+  printf "%s/logs/drumsep_rocm_install.log\n" "${RUNTIME_BASE}"
+}
+
+drumsep_rocm_runtime_python() {
+  printf "%s/.venv-drumsep-rocm/bin/python\n" "${RUNTIME_BASE}"
+}
+
 write_drumsep_state() {
   _status="$1"
   _model_status="${2:-missing}"
@@ -140,6 +157,102 @@ PY
     echo "DRUMSEP_MODEL_STATUS=${_model_status}"
     echo "DRUMSEP_MODEL_FILE=${_model_file}"
     echo "DRUMSEP_MODEL_YAML=${_model_yaml}"
+  } > "${_state}"
+}
+
+write_drumsep_rocm_state() {
+  _status="$1"
+  _model_status="${2:-missing}"
+  _detail="${3:-}"
+  _py="$(drumsep_rocm_runtime_python)"
+  _state="$(drumsep_rocm_state_file)"
+  _model_dir="$(model_cache_dir)"
+  _model_file="${_model_dir}/${DRUMSEP_MODEL_FILE}"
+  _model_yaml="${_model_dir}/${DRUMSEP_MODEL_YAML}"
+  _last_check="$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date)"
+  _tmp_dir="${DRUMSEP_ROCM_TMPDIR:-}"
+
+  _versions=""
+  if [ -x "${_py}" ]; then
+    _versions="$("${_py}" - <<'PY' 2>/dev/null || true
+import importlib.metadata as metadata
+for env_key, dist_name in (
+    ("DRUMSEP_ROCM_AUDIO_SEPARATOR_VERSION", "audio-separator"),
+    ("DRUMSEP_ROCM_NUMPY_VERSION", "numpy"),
+    ("DRUMSEP_ROCM_TORCH_VERSION", "torch"),
+    ("DRUMSEP_ROCM_ONNX_VERSION", "onnx"),
+    ("DRUMSEP_ROCM_ONNXRUNTIME_VERSION", "onnxruntime"),
+    ("DRUMSEP_ROCM_ONNX2TORCH_VERSION", "onnx2torch"),
+):
+    try:
+        value = metadata.version(dist_name)
+    except Exception:
+        value = ""
+    print(f"{env_key}={value}")
+PY
+)"
+  fi
+
+  _gpu_probe=""
+  if [ -x "${_py}" ]; then
+    _gpu_probe="$("${_py}" - <<'PY' 2>/dev/null || true
+import json
+try:
+    import torch
+    hip = str(getattr(getattr(torch, "version", None), "hip", "") or "")
+    avail = bool(torch.cuda.is_available())
+    names = []
+    if avail:
+        for i in range(int(torch.cuda.device_count())):
+            try:
+                names.append(str(torch.cuda.get_device_name(i)))
+            except Exception:
+                pass
+    print(json.dumps({
+        "hip": hip,
+        "cuda_available": avail,
+        "device_names": names,
+    }))
+except Exception:
+    print("{}")
+PY
+)"
+  fi
+  _hip=""
+  _cuda_available="false"
+  _device_names=""
+  if [ -n "${_gpu_probe}" ]; then
+    _hip="$(printf "%s" "${_gpu_probe}" | sed -n 's/.*"hip"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | tail -n1)"
+    if printf "%s" "${_gpu_probe}" | grep -q '"cuda_available"[[:space:]]*:[[:space:]]*true'; then
+      _cuda_available="true"
+    fi
+    _device_names="$(printf "%s" "${_gpu_probe}" | sed -n 's/.*"device_names"[[:space:]]*:[[:space:]]*\[\(.*\)\].*/\1/p' | tail -n1 | tr -d '"' | tr ',' '|' | tr -d ' ')"
+  fi
+
+  {
+    echo "STATUS=${_status}"
+    [ -n "${_detail}" ] && echo "STATUS_REASON=${_detail}"
+    echo "DRUMSEP_ROCM_RUNTIME_STATUS=${_status}"
+    [ -n "${_detail}" ] && echo "DRUMSEP_ROCM_RUNTIME_DETAIL=${_detail}"
+    echo "DRUMSEP_ROCM_PYTHON=${_py}"
+    if [ -n "${_versions}" ]; then
+      printf "%s\n" "${_versions}"
+    else
+      echo "DRUMSEP_ROCM_AUDIO_SEPARATOR_VERSION="
+      echo "DRUMSEP_ROCM_NUMPY_VERSION="
+      echo "DRUMSEP_ROCM_TORCH_VERSION="
+      echo "DRUMSEP_ROCM_ONNX_VERSION="
+      echo "DRUMSEP_ROCM_ONNXRUNTIME_VERSION="
+      echo "DRUMSEP_ROCM_ONNX2TORCH_VERSION="
+    fi
+    echo "DRUMSEP_ROCM_TORCH_HIP=${_hip}"
+    echo "DRUMSEP_ROCM_CUDA_AVAILABLE=${_cuda_available}"
+    echo "DRUMSEP_ROCM_DEVICE_NAMES=${_device_names}"
+    echo "DRUMSEP_ROCM_LAST_CHECK_UTC=${_last_check}"
+    echo "DRUMSEP_ROCM_MODEL_STATUS=${_model_status}"
+    echo "DRUMSEP_ROCM_MODEL_FILE=${_model_file}"
+    echo "DRUMSEP_ROCM_MODEL_YAML=${_model_yaml}"
+    echo "DRUMSEP_ROCM_TEMP_DIR=${_tmp_dir}"
   } > "${_state}"
 }
 
@@ -516,6 +629,257 @@ PY
       return 1
       ;;
   esac
+}
+
+free_kb_for_path() {
+  _path="$1"
+  df -Pk "${_path}" 2>/dev/null | awk 'NR==2{print $4}'
+}
+
+resolve_drumsep_rocm_tmpdir() {
+  _required_kb="$1"
+  for _cand in \
+    "/mnt/PRODUCTION/TMP/stemwerk-rocm-tmp" \
+    "${RUNTIME_BASE}/tmp/stemwerk-rocm-tmp" \
+    "${HOME:-/tmp}/.cache/STEMwerk/tmp/stemwerk-rocm-tmp"
+  do
+    _parent="$(dirname "${_cand}")"
+    mkdir -p "${_parent}" >/dev/null 2>&1 || true
+    mkdir -p "${_cand}" >/dev/null 2>&1 || continue
+    if [ ! -w "${_cand}" ]; then
+      continue
+    fi
+    _avail_kb="$(free_kb_for_path "${_cand}")"
+    if [ -n "${_avail_kb}" ] && [ "${_avail_kb}" -ge "${_required_kb}" ]; then
+      printf "%s\n" "${_cand}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+drumsep_rocm_disk_preflight() {
+  _required_kb="$((DRUMSEP_ROCM_MIN_FREE_GB * 1024 * 1024))"
+  _target_dir="${RUNTIME_BASE}"
+  _target_avail_kb="$(free_kb_for_path "${_target_dir}")"
+  _target_avail_gb="0"
+  if [ -n "${_target_avail_kb}" ]; then
+    _target_avail_gb=$(( _target_avail_kb / 1024 / 1024 ))
+  fi
+  log_step "ROCm disk preflight target=${_target_dir} free_gb=${_target_avail_gb} required_gb=${DRUMSEP_ROCM_MIN_FREE_GB}"
+  if [ -z "${_target_avail_kb}" ] || [ "${_target_avail_kb}" -lt "${_required_kb}" ]; then
+    DRUMSEP_ROCM_PREFLIGHT_DETAIL="target_free_space_insufficient"
+    return 1
+  fi
+
+  DRUMSEP_ROCM_TMPDIR="$(resolve_drumsep_rocm_tmpdir "${_required_kb}" || true)"
+  if [ -z "${DRUMSEP_ROCM_TMPDIR}" ]; then
+    DRUMSEP_ROCM_PREFLIGHT_DETAIL="temp_dir_free_space_insufficient"
+    return 1
+  fi
+  _tmp_avail_kb="$(free_kb_for_path "${DRUMSEP_ROCM_TMPDIR}")"
+  _tmp_avail_gb=$(( _tmp_avail_kb / 1024 / 1024 ))
+  log_step "ROCm disk preflight tmp=${DRUMSEP_ROCM_TMPDIR} free_gb=${_tmp_avail_gb} required_gb=${DRUMSEP_ROCM_MIN_FREE_GB}"
+  return 0
+}
+
+verify_drumsep_rocm_runtime() {
+  _py="$(drumsep_rocm_runtime_python)"
+  _model_dir="$(model_cache_dir)"
+  _model_file="${_model_dir}/${DRUMSEP_MODEL_FILE}"
+  _model_yaml="${_model_dir}/${DRUMSEP_MODEL_YAML}"
+  if [ ! -x "${_py}" ]; then
+    write_drumsep_rocm_state "missing" "missing" "python_missing"
+    return 1
+  fi
+  "${_py}" - <<PY >> "$(drumsep_rocm_log_file)" 2>&1
+import importlib
+import importlib.metadata as metadata
+import os
+import sys
+
+expected = {
+    "audio-separator": "${DRUMSEP_AUDIO_SEPARATOR_VERSION}",
+    "numpy": "${DRUMSEP_NUMPY_VERSION}",
+    "onnxruntime": "${DRUMSEP_ONNXRUNTIME_VERSION}",
+    "onnx": "${DRUMSEP_ONNX_VERSION}",
+    "onnx2torch": "${DRUMSEP_ONNX2TORCH_VERSION}",
+    "numba": "${DRUMSEP_NUMBA_VERSION}",
+}
+modules = ["audio_separator", "numpy", "torch", "onnx", "onnxruntime", "onnx2torch"]
+errors = []
+for module_name in modules:
+    try:
+        importlib.import_module(module_name)
+    except Exception as exc:
+        errors.append(f"import_failed:{module_name}:{type(exc).__name__}:{exc}")
+
+for dist_name, wanted in expected.items():
+    try:
+        found = metadata.version(dist_name).split("+", 1)[0]
+    except Exception as exc:
+        errors.append(f"version_missing:{dist_name}:{type(exc).__name__}:{exc}")
+        continue
+    if found != wanted:
+        errors.append(f"version_mismatch:{dist_name}:expected={wanted}:found={found}")
+
+try:
+    import torch
+    torch_ver = str(getattr(torch, "__version__", ""))
+    hip = getattr(getattr(torch, "version", None), "hip", None)
+    cuda_available = bool(torch.cuda.is_available())
+    device_count = int(torch.cuda.device_count()) if cuda_available else 0
+    names = []
+    if cuda_available:
+        for i in range(device_count):
+            try:
+                names.append(str(torch.cuda.get_device_name(i)))
+            except Exception:
+                pass
+except Exception as exc:
+    errors.append(f"torch_probe_failed:{type(exc).__name__}:{exc}")
+    torch_ver = ""
+    hip = None
+    cuda_available = False
+    device_count = 0
+    names = []
+
+if "+rocm" not in torch_ver:
+    errors.append(f"rocm_torch_required:found={torch_ver}")
+if hip is None or str(hip).strip() == "":
+    errors.append("rocm_hip_missing")
+if not cuda_available:
+    errors.append("rocm_cuda_unavailable")
+if device_count <= 0:
+    errors.append("rocm_no_device")
+if not any(("amd" in n.lower() or "radeon" in n.lower() or "rx " in n.lower()) for n in names):
+    errors.append("rocm_amd_device_missing")
+
+model_file = "${_model_file}"
+model_yaml = "${_model_yaml}"
+if not os.path.isfile(model_file) or not os.path.isfile(model_yaml):
+    print("DRUMSEP_ROCM_VERIFY model_missing")
+    raise SystemExit(2)
+
+if errors:
+    print("DRUMSEP_ROCM_VERIFY broken " + ";".join(errors))
+    raise SystemExit(1)
+
+try:
+    from audio_separator.separator import Separator
+    sep = Separator(model_file_dir="${_model_dir}", output_dir=".", output_format="wav")
+    sep.load_model("${DRUMSEP_MODEL_FILE}")
+except Exception as exc:
+    print(f"DRUMSEP_ROCM_VERIFY load_failed {type(exc).__name__}: {exc}")
+    raise SystemExit(3)
+
+print("DRUMSEP_ROCM_VERIFY ok")
+PY
+  _rc=$?
+  case "${_rc}" in
+    0)
+      write_drumsep_rocm_state "ok" "ok" "ok"
+      return 0
+      ;;
+    2)
+      write_drumsep_rocm_state "model_missing" "missing" "model_missing"
+      return 0
+      ;;
+    3)
+      write_drumsep_rocm_state "broken" "load_failed" "model_load_failed"
+      return 1
+      ;;
+    *)
+      write_drumsep_rocm_state "broken" "missing" "verify_failed"
+      return 1
+      ;;
+  esac
+}
+
+install_drumsep_rocm_runtime() {
+  _log="$(drumsep_rocm_log_file)"
+  _py="$(drumsep_rocm_runtime_python)"
+  : > "${_log}" || true
+  log_stage "Installing optional DrumSep ROCm runtime"
+  log_step "DrumSep ROCm runtime path: ${RUNTIME_BASE}/.venv-drumsep-rocm"
+  log_step "DrumSep ROCm install log: ${_log}"
+
+  # Repair path: if runtime already exists and verifies, succeed without reinstall.
+  if [ -x "${_py}" ]; then
+    log_step "Existing DrumSep ROCm runtime detected; running verification before reinstall"
+    if verify_drumsep_rocm_runtime; then
+      log_step "Existing DrumSep ROCm runtime verified; skipping reinstall"
+      return 0
+    fi
+    log_step "Existing DrumSep ROCm runtime failed verification; rebuilding"
+  fi
+
+  if ! drumsep_rocm_disk_preflight; then
+    log_step "ROCm preflight failed: ${DRUMSEP_ROCM_PREFLIGHT_DETAIL:-unknown}"
+    write_drumsep_rocm_state "disk_space_insufficient" "missing" "${DRUMSEP_ROCM_PREFLIGHT_DETAIL:-disk_space_insufficient}"
+    return 1
+  fi
+  log_step "ROCm temp dir selected: ${DRUMSEP_ROCM_TMPDIR}"
+  export TMPDIR="${DRUMSEP_ROCM_TMPDIR}"
+
+  STEP_TOTAL="5"
+  set_progress "1" "${STEP_TOTAL}" "Creating DrumSep ROCm runtime"
+  rm -rf "${RUNTIME_BASE}/.venv-drumsep-rocm"
+  if ! "${PYTHON}" -m venv "${RUNTIME_BASE}/.venv-drumsep-rocm" >> "${_log}" 2>&1; then
+    write_drumsep_rocm_state "install_failed" "missing" "venv_create_failed"
+    return 1
+  fi
+  if [ ! -x "${_py}" ]; then
+    write_drumsep_rocm_state "install_failed" "missing" "python_missing_after_create"
+    return 1
+  fi
+
+  set_progress "2" "${STEP_TOTAL}" "Upgrading ROCm runtime pip"
+  if ! "${_py}" -m pip install --no-cache-dir --upgrade pip setuptools wheel >> "${_log}" 2>&1; then
+    write_drumsep_rocm_state "install_failed" "missing" "pip_upgrade_failed"
+    return 1
+  fi
+
+  set_progress "3" "${STEP_TOTAL}" "Installing ROCm torch stack"
+  if ! "${_py}" -m pip install --no-cache-dir --index-url "${DRUMSEP_ROCM_TORCH_INDEX_URL}" \
+    "torch==${DRUMSEP_ROCM_TORCH_VERSION}" \
+    "torchvision==${DRUMSEP_ROCM_TORCHVISION_VERSION}" \
+    "torchaudio==${DRUMSEP_ROCM_TORCHAUDIO_VERSION}" >> "${_log}" 2>&1; then
+    write_drumsep_rocm_state "install_failed" "missing" "rocm_torch_install_failed"
+    return 1
+  fi
+
+  set_progress "4" "${STEP_TOTAL}" "Installing DrumSep packages"
+  if ! "${_py}" -m pip install --no-cache-dir --no-deps \
+    "audio-separator==${DRUMSEP_AUDIO_SEPARATOR_VERSION}" >> "${_log}" 2>&1; then
+    write_drumsep_rocm_state "install_failed" "missing" "audio_separator_install_failed"
+    return 1
+  fi
+  if ! "${_py}" -m pip install --no-cache-dir \
+    "numpy==${DRUMSEP_NUMPY_VERSION}" \
+    "onnxruntime==${DRUMSEP_ONNXRUNTIME_VERSION}" \
+    "onnx==${DRUMSEP_ONNX_VERSION}" \
+    "onnx2torch==${DRUMSEP_ONNX2TORCH_VERSION}" \
+    "onnx2torch-py313==${DRUMSEP_ONNX2TORCH_PY313_VERSION}" \
+    "numba==${DRUMSEP_NUMBA_VERSION}" \
+    "beartype==0.18.5" "diffq==0.2.4" "einops==0.8.2" "julius==0.2.7" \
+    "librosa==0.11.0" "ml_collections==1.1.0" "pydub==0.25.1" "pyyaml==6.0.3" \
+    "requests==2.34.2" "resampy==0.4.3" "rotary-embedding-torch==0.6.5" \
+    "samplerate==0.1.0" "scipy==1.17.1" "six==1.17.0" "tqdm==4.67.3" >> "${_log}" 2>&1; then
+    write_drumsep_rocm_state "install_failed" "missing" "package_install_failed"
+    return 1
+  fi
+  if ! "${_py}" -m pip check >> "${_log}" 2>&1; then
+    write_drumsep_rocm_state "install_failed" "missing" "pip_check_failed"
+    return 1
+  fi
+
+  set_progress "5" "${STEP_TOTAL}" "Verifying DrumSep ROCm runtime"
+  if ! verify_drumsep_rocm_runtime; then
+    return 1
+  fi
+  log_step "DrumSep ROCm runtime verification complete"
+  return 0
 }
 
 install_drumsep_runtime() {
@@ -1113,6 +1477,10 @@ if [ -z "${PYTHON}" ]; then
       write_drumsep_state "install_failed" "missing" "python_missing"
       exit 1
     fi
+    if [ "${MODE}" = "drumsep-rocm-runtime" ]; then
+      write_drumsep_rocm_state "install_failed" "missing" "python_missing"
+      exit 1
+    fi
   else
     BACKEND_REASON="python_not_found"
     if [ "${MANAGED_PYTHON_ERROR}" = "unsupported_platform" ]; then
@@ -1131,6 +1499,10 @@ if [ -z "${PYTHON}" ]; then
       write_drumsep_state "install_failed" "missing" "python_missing"
       exit 1
     fi
+    if [ "${MODE}" = "drumsep-rocm-runtime" ]; then
+      write_drumsep_rocm_state "install_failed" "missing" "python_missing"
+      exit 1
+    fi
   fi
 else
   if [ "${MODE}" = "drumsep-runtime" ]; then
@@ -1142,6 +1514,16 @@ else
       exit 0
     fi
     log "DrumSep runtime install failed"
+    exit 1
+  elif [ "${MODE}" = "drumsep-rocm-runtime" ]; then
+    if install_drumsep_rocm_runtime; then
+      STATUS="ok"
+      STATUS_REASON=""
+      write_drumsep_rocm_state "ok" "ok" "ok"
+      log_stage "DrumSep ROCm runtime install finished"
+      exit 0
+    fi
+    log "DrumSep ROCm runtime install failed"
     exit 1
   fi
   log_stage "Creating venv"

--- a/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
+++ b/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
@@ -13,6 +13,17 @@ PINNED_NUMPY_VERSION="1.26.4"
 PINNED_NUMBA_VERSION="0.59.1"
 PINNED_LLVM_VERSION="0.42.0"
 PINNED_IMAGEIO_FFMPEG_VERSION="0.6.0"
+DRUMSEP_AUDIO_SEPARATOR_VERSION="0.34.1"
+DRUMSEP_NUMPY_VERSION="2.4.6"
+DRUMSEP_ONNXRUNTIME_VERSION="1.26.0"
+DRUMSEP_ONNX_VERSION="1.21.0"
+DRUMSEP_ONNX2TORCH_VERSION="1.5.15"
+DRUMSEP_ONNX2TORCH_PY313_VERSION="1.6.0"
+DRUMSEP_TORCH_VERSION="2.12.0"
+DRUMSEP_TORCHVISION_VERSION="0.27.0"
+DRUMSEP_NUMBA_VERSION="0.65.1"
+DRUMSEP_MODEL_FILE="aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.ckpt"
+DRUMSEP_MODEL_YAML="aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.yaml"
 
 RUNTIME_BASE=""
 STATE_FILE=""
@@ -61,6 +72,75 @@ model_cache_dir() {
   else
     printf "%s/.local/share/STEMwerk/models\n" "${HOME:-/tmp}"
   fi
+}
+
+drumsep_state_file() {
+  printf "%s/state/drumsep_runtime.env\n" "${RUNTIME_BASE}"
+}
+
+drumsep_log_file() {
+  printf "%s/logs/drumsep_install.log\n" "${RUNTIME_BASE}"
+}
+
+drumsep_runtime_python() {
+  printf "%s/.venv-drumsep/bin/python\n" "${RUNTIME_BASE}"
+}
+
+write_drumsep_state() {
+  _status="$1"
+  _model_status="${2:-missing}"
+  _detail="${3:-}"
+  _py="$(drumsep_runtime_python)"
+  _state="$(drumsep_state_file)"
+  _model_dir="$(model_cache_dir)"
+  _model_file="${_model_dir}/${DRUMSEP_MODEL_FILE}"
+  _model_yaml="${_model_dir}/${DRUMSEP_MODEL_YAML}"
+  _last_check="$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date)"
+
+  _versions=""
+  if [ -x "${_py}" ]; then
+    _versions="$("${_py}" - <<'PY' 2>/dev/null || true
+import importlib.metadata as metadata
+for env_key, dist_name in (
+    ("DRUMSEP_AUDIO_SEPARATOR_VERSION", "audio-separator"),
+    ("DRUMSEP_NUMPY_VERSION", "numpy"),
+    ("DRUMSEP_TORCH_VERSION", "torch"),
+    ("DRUMSEP_ONNX_VERSION", "onnx"),
+    ("DRUMSEP_ONNXRUNTIME_VERSION", "onnxruntime"),
+    ("DRUMSEP_ONNX2TORCH_VERSION", "onnx2torch"),
+    ("DRUMSEP_ONNX2TORCH_PY313_VERSION", "onnx2torch-py313"),
+):
+    try:
+        value = metadata.version(dist_name)
+    except Exception:
+        value = ""
+    print(f"{env_key}={value}")
+PY
+)"
+  fi
+
+  {
+    echo "STATUS=${_status}"
+    [ -n "${_detail}" ] && echo "STATUS_REASON=${_detail}"
+    echo "DRUMSEP_RUNTIME_STATUS=${_status}"
+    [ -n "${_detail}" ] && echo "DRUMSEP_RUNTIME_DETAIL=${_detail}"
+    echo "DRUMSEP_PYTHON=${_py}"
+    if [ -n "${_versions}" ]; then
+      printf "%s\n" "${_versions}"
+    else
+      echo "DRUMSEP_AUDIO_SEPARATOR_VERSION="
+      echo "DRUMSEP_NUMPY_VERSION="
+      echo "DRUMSEP_TORCH_VERSION="
+      echo "DRUMSEP_ONNX_VERSION="
+      echo "DRUMSEP_ONNXRUNTIME_VERSION="
+      echo "DRUMSEP_ONNX2TORCH_VERSION="
+      echo "DRUMSEP_ONNX2TORCH_PY313_VERSION="
+    fi
+    echo "DRUMSEP_LAST_CHECK_UTC=${_last_check}"
+    echo "DRUMSEP_MODEL_STATUS=${_model_status}"
+    echo "DRUMSEP_MODEL_FILE=${_model_file}"
+    echo "DRUMSEP_MODEL_YAML=${_model_yaml}"
+  } > "${_state}"
 }
 
 write_state() {
@@ -350,6 +430,140 @@ set_progress() {
   STEP_LABEL="$3"
   log "STEP ${STEP_INDEX}/${STEP_TOTAL}: ${STEP_LABEL}"
   write_state
+}
+
+verify_drumsep_runtime() {
+  _py="$(drumsep_runtime_python)"
+  _model_dir="$(model_cache_dir)"
+  _model_file="${_model_dir}/${DRUMSEP_MODEL_FILE}"
+  _model_yaml="${_model_dir}/${DRUMSEP_MODEL_YAML}"
+  if [ ! -x "${_py}" ]; then
+    write_drumsep_state "missing" "missing" "python_missing"
+    return 1
+  fi
+  "${_py}" - <<PY >> "$(drumsep_log_file)" 2>&1
+import importlib
+import importlib.metadata as metadata
+import os
+import sys
+
+expected = {
+    "audio-separator": "${DRUMSEP_AUDIO_SEPARATOR_VERSION}",
+    "numpy": "${DRUMSEP_NUMPY_VERSION}",
+    "torch": "${DRUMSEP_TORCH_VERSION}",
+    "onnx": "${DRUMSEP_ONNX_VERSION}",
+    "onnxruntime": "${DRUMSEP_ONNXRUNTIME_VERSION}",
+    "onnx2torch": "${DRUMSEP_ONNX2TORCH_VERSION}",
+    "onnx2torch-py313": "${DRUMSEP_ONNX2TORCH_PY313_VERSION}",
+    "numba": "${DRUMSEP_NUMBA_VERSION}",
+    "torchvision": "${DRUMSEP_TORCHVISION_VERSION}",
+}
+modules = ["audio_separator", "numpy", "torch", "onnx", "onnxruntime", "onnx2torch"]
+errors = []
+for module_name in modules:
+    try:
+        importlib.import_module(module_name)
+    except Exception as exc:
+        errors.append(f"import_failed:{module_name}:{type(exc).__name__}:{exc}")
+
+for dist_name, wanted in expected.items():
+    try:
+        found = metadata.version(dist_name).split("+", 1)[0]
+    except Exception as exc:
+        errors.append(f"version_missing:{dist_name}:{type(exc).__name__}:{exc}")
+        continue
+    if found != wanted:
+        errors.append(f"version_mismatch:{dist_name}:expected={wanted}:found={found}")
+
+model_file = "${_model_file}"
+model_yaml = "${_model_yaml}"
+if not os.path.isfile(model_file) or not os.path.isfile(model_yaml):
+    print("DRUMSEP_VERIFY model_missing")
+    raise SystemExit(2)
+
+if errors:
+    print("DRUMSEP_VERIFY broken " + ";".join(errors))
+    raise SystemExit(1)
+
+try:
+    import torch
+    torch.cuda.is_available = lambda: False
+    from audio_separator.separator import Separator
+    sep = Separator(model_file_dir="${_model_dir}", output_dir=".", output_format="wav")
+    sep.load_model("${DRUMSEP_MODEL_FILE}")
+except Exception as exc:
+    print(f"DRUMSEP_VERIFY load_failed {type(exc).__name__}: {exc}")
+    raise SystemExit(3)
+
+print("DRUMSEP_VERIFY ok")
+PY
+  _rc=$?
+  case "${_rc}" in
+    0)
+      write_drumsep_state "ok" "ok" "ok"
+      return 0
+      ;;
+    2)
+      write_drumsep_state "model_missing" "missing" "model_missing"
+      return 0
+      ;;
+    3)
+      write_drumsep_state "broken" "load_failed" "model_load_failed"
+      return 1
+      ;;
+    *)
+      write_drumsep_state "broken" "missing" "verify_failed"
+      return 1
+      ;;
+  esac
+}
+
+install_drumsep_runtime() {
+  _drumsep_log="$(drumsep_log_file)"
+  _drumsep_py="$(drumsep_runtime_python)"
+  : > "${_drumsep_log}" || true
+  log_stage "Installing optional DrumSep runtime"
+  log_step "DrumSep runtime path: ${RUNTIME_BASE}/.venv-drumsep"
+  log_step "DrumSep install log: ${_drumsep_log}"
+  STEP_TOTAL="4"
+  set_progress "1" "${STEP_TOTAL}" "Creating DrumSep runtime"
+  rm -rf "${RUNTIME_BASE}/.venv-drumsep"
+  if ! "${PYTHON}" -m venv "${RUNTIME_BASE}/.venv-drumsep" >> "${_drumsep_log}" 2>&1; then
+    write_drumsep_state "install_failed" "missing" "venv_create_failed"
+    return 1
+  fi
+  if [ ! -x "${_drumsep_py}" ]; then
+    write_drumsep_state "install_failed" "missing" "python_missing_after_create"
+    return 1
+  fi
+
+  set_progress "2" "${STEP_TOTAL}" "Upgrading DrumSep pip"
+  if ! "${_drumsep_py}" -m pip install --upgrade pip setuptools wheel >> "${_drumsep_log}" 2>&1; then
+    write_drumsep_state "install_failed" "missing" "pip_upgrade_failed"
+    return 1
+  fi
+
+  set_progress "3" "${STEP_TOTAL}" "Installing DrumSep packages"
+  if ! "${_drumsep_py}" -m pip install \
+    "audio-separator==${DRUMSEP_AUDIO_SEPARATOR_VERSION}" \
+    "numpy==${DRUMSEP_NUMPY_VERSION}" \
+    "onnxruntime==${DRUMSEP_ONNXRUNTIME_VERSION}" \
+    "onnx==${DRUMSEP_ONNX_VERSION}" \
+    "onnx2torch==${DRUMSEP_ONNX2TORCH_VERSION}" \
+    "onnx2torch-py313==${DRUMSEP_ONNX2TORCH_PY313_VERSION}" \
+    "torch==${DRUMSEP_TORCH_VERSION}" \
+    "torchvision==${DRUMSEP_TORCHVISION_VERSION}" \
+    "numba==${DRUMSEP_NUMBA_VERSION}" >> "${_drumsep_log}" 2>&1; then
+    write_drumsep_state "install_failed" "missing" "package_install_failed"
+    return 1
+  fi
+
+  set_progress "4" "${STEP_TOTAL}" "Verifying DrumSep runtime"
+  if ! verify_drumsep_runtime; then
+    return 1
+  fi
+  log_step "DrumSep runtime verification complete"
+  return 0
 }
 
 resolve_core_target() {
@@ -895,6 +1109,10 @@ if [ -z "${PYTHON}" ]; then
     log_step "${msg}"
     printf "%s\n" "${msg}" >&2
     set_status "missing_python" "managed_python_unavailable"
+    if [ "${MODE}" = "drumsep-runtime" ]; then
+      write_drumsep_state "install_failed" "missing" "python_missing"
+      exit 1
+    fi
   else
     BACKEND_REASON="python_not_found"
     if [ "${MANAGED_PYTHON_ERROR}" = "unsupported_platform" ]; then
@@ -909,8 +1127,23 @@ if [ -z "${PYTHON}" ]; then
     log_step "${msg}"
     printf "%s\n" "${msg}" >&2
     set_status "missing_python" "managed_python_unavailable"
+    if [ "${MODE}" = "drumsep-runtime" ]; then
+      write_drumsep_state "install_failed" "missing" "python_missing"
+      exit 1
+    fi
   fi
 else
+  if [ "${MODE}" = "drumsep-runtime" ]; then
+    if install_drumsep_runtime; then
+      STATUS="ok"
+      STATUS_REASON=""
+      write_drumsep_state "ok" "ok" "ok"
+      log_stage "DrumSep runtime install finished"
+      exit 0
+    fi
+    log "DrumSep runtime install failed"
+    exit 1
+  fi
   log_stage "Creating venv"
   log_step "Creating STEMwerk virtual environment..."
   if [ -x "${RUNTIME_BASE}/.venv/bin/python" ] && venv_torch_requires_rebuild "${RUNTIME_BASE}/.venv/bin/python"; then

--- a/scripts/reaper/STEMwerk_Drum_Kit_Split.lua
+++ b/scripts/reaper/STEMwerk_Drum_Kit_Split.lua
@@ -8,7 +8,9 @@
 local EXT_SECTION = "STEMwerk"
 
 reaper.SetExtState(EXT_SECTION, "quick_run", "1", false)
-reaper.SetExtState(EXT_SECTION, "quick_preset", "dks_direct", false)
+reaper.SetExtState(EXT_SECTION, "quick_preset", "drumkit", false)
+reaper.SetExtState(EXT_SECTION, "active_workflow_mode", "drumkit", false)
+reaper.SetExtState(EXT_SECTION, "active_workflow_source", "dks_direct", false)
 
 local info = debug.getinfo(1, "S")
 local script_path = info and info.source and info.source:match("@?(.*[/\\])") or ""

--- a/scripts/reaper/STEMwerk_Drum_Kit_Split.lua
+++ b/scripts/reaper/STEMwerk_Drum_Kit_Split.lua
@@ -1,0 +1,15 @@
+-- @description Stemwerk: Drum Kit Split
+-- @author flarkAUDIO <flarkaudio@pm.me>
+-- @version 2.2.2.2.11
+-- @changelog
+--   Quick preset: direct drum kit split.
+-- @link Repository https://github.com/flarkflarkflark/STEMwerk
+
+local EXT_SECTION = "STEMwerk"
+
+reaper.SetExtState(EXT_SECTION, "quick_run", "1", false)
+reaper.SetExtState(EXT_SECTION, "quick_preset", "dks_direct", false)
+
+local info = debug.getinfo(1, "S")
+local script_path = info and info.source and info.source:match("@?(.*[/\\])") or ""
+dofile(script_path .. "STEMwerk.lua")

--- a/scripts/reaper/STEMwerk_Save_Support_Bundle.lua
+++ b/scripts/reaper/STEMwerk_Save_Support_Bundle.lua
@@ -1243,6 +1243,312 @@ local function runPythonProbe(bundleDir, pythonPath)
     return result
 end
 
+local function readTailText(path, maxBytes)
+    local filePath = trim(path)
+    if filePath == "" or not fileExists(filePath) then
+        return ""
+    end
+    local cap = math.max(1024, tonumber(maxBytes) or (128 * 1024))
+    local size = fileSizeBytes(filePath) or 0
+    local f = io.open(filePath, "rb")
+    if not f then return "" end
+    if size > cap then
+        f:seek("end", -cap)
+    else
+        f:seek("set", 0)
+    end
+    local data = f:read("*a") or ""
+    f:close()
+    if size > cap then
+        data = "(tail excerpt; file truncated)\n" .. data
+    end
+    return data
+end
+
+local function toLowerSet(values)
+    local out = {}
+    for i = 1, #(values or {}) do
+        out[tostring(values[i]):lower()] = true
+    end
+    return out
+end
+
+local function buildDrumsepRuntimeProbe(runtimePython)
+    local result = {}
+    local py = trim(runtimePython)
+    if py == "" or not fileExists(py) then
+        result.error = "python_missing"
+        return result
+    end
+    if OS == "Windows" then
+        result.error = "probe_skipped_windows"
+        return result
+    end
+
+    local script = table.concat({
+        "import importlib",
+        "import importlib.metadata as metadata",
+        "",
+        "def emit(k, v):",
+        "    if isinstance(v, bool):",
+        "        v = 'true' if v else 'false'",
+        "    elif isinstance(v, (list, tuple)):",
+        "        v = '|'.join(str(x) for x in v)",
+        "    elif v is None:",
+        "        v = ''",
+        "    print(f'{k}={v}')",
+        "",
+        "def ver(mod_name, dist_name):",
+        "    try:",
+        "        m = importlib.import_module(mod_name)",
+        "        return getattr(m, '__version__', '') or metadata.version(dist_name)",
+        "    except Exception as exc:",
+        "        return f'error:{type(exc).__name__}'",
+        "",
+        "emit('audio_separator', ver('audio_separator', 'audio-separator'))",
+        "emit('numpy', ver('numpy', 'numpy'))",
+        "emit('torch', ver('torch', 'torch'))",
+        "emit('onnx', ver('onnx', 'onnx'))",
+        "emit('onnxruntime', ver('onnxruntime', 'onnxruntime'))",
+        "emit('onnx2torch', ver('onnx2torch', 'onnx2torch'))",
+        "try:",
+        "    import torch",
+        "    emit('torch_version_cuda', getattr(getattr(torch, 'version', None), 'cuda', ''))",
+        "    emit('torch_version_hip', getattr(getattr(torch, 'version', None), 'hip', ''))",
+        "    emit('torch_cuda_available', torch.cuda.is_available())",
+        "    count = torch.cuda.device_count() if torch.cuda.is_available() else 0",
+        "    emit('torch_cuda_device_count', count)",
+        "    names = []",
+        "    if count:",
+        "        for i in range(count):",
+        "            try:",
+        "                names.append(torch.cuda.get_device_name(i))",
+        "            except Exception as exc:",
+        "                names.append(f'error:{type(exc).__name__}')",
+        "    emit('torch_device_names', names)",
+        "except Exception as exc:",
+        "    emit('torch_error', f'{type(exc).__name__}:{exc}')",
+        "try:",
+        "    import onnxruntime as ort",
+        "    emit('onnxruntime_providers', ort.get_available_providers())",
+        "except Exception as exc:",
+        "    emit('onnxruntime_providers_error', f'{type(exc).__name__}:{exc}')",
+    }, "\n")
+
+    local probePath = joinPath(runtimePaths.base, "state", "_drumsep_support_probe.py")
+    if not writeFile(probePath, script, "wb") then
+        result.error = "probe_script_write_failed"
+        return result
+    end
+    local rc, out = execCommand(py, {probePath}, 12000)
+    if fileExists(probePath) then os.remove(probePath) end
+    result.rc = rc
+    result.output = out or ""
+    result.data = parseKeyValueText(result.output)
+    if rc ~= 0 then
+        result.error = "probe_failed_exit_" .. tostring(rc)
+    end
+    return result
+end
+
+local function appendDrumsepRuntimeBlock(lines, title, runtimePython, stateData, probe, modelFile, modelYaml)
+    appendLine(lines, title)
+    appendKey(lines, "python_path", sanitizePathValue(runtimePython))
+    appendKey(lines, "python_exists", fileExists(runtimePython) and "yes" or "no")
+    appendKey(lines, "runtime_status", trim(stateData.STATUS or stateData.DRUMSEP_RUNTIME_STATUS or stateData.DRUMSEP_ROCM_RUNTIME_STATUS) ~= "" and trim(stateData.STATUS or stateData.DRUMSEP_RUNTIME_STATUS or stateData.DRUMSEP_ROCM_RUNTIME_STATUS) or "unknown")
+    appendKey(lines, "runtime_reason", trim(stateData.STATUS_REASON or stateData.DRUMSEP_RUNTIME_DETAIL or stateData.DRUMSEP_ROCM_RUNTIME_DETAIL) ~= "" and trim(stateData.STATUS_REASON or stateData.DRUMSEP_RUNTIME_DETAIL or stateData.DRUMSEP_ROCM_RUNTIME_DETAIL) or "unknown")
+    if probe and probe.data then
+        appendKey(lines, "audio_separator_version", probe.data.audio_separator or "unknown")
+        appendKey(lines, "numpy_version", probe.data.numpy or "unknown")
+        appendKey(lines, "torch_version", probe.data.torch or "unknown")
+        appendKey(lines, "torch.version.cuda", probe.data.torch_version_cuda or "unknown")
+        appendKey(lines, "torch.version.hip", probe.data.torch_version_hip or "unknown")
+        appendKey(lines, "torch.cuda.is_available", probe.data.torch_cuda_available or "unknown")
+        appendKey(lines, "torch.cuda.device_count", probe.data.torch_cuda_device_count or "unknown")
+        appendKey(lines, "torch_device_names", probe.data.torch_device_names or "unknown")
+        appendKey(lines, "onnx_version", probe.data.onnx or "unknown")
+        appendKey(lines, "onnxruntime_version", probe.data.onnxruntime or "unknown")
+        appendKey(lines, "onnxruntime_providers", probe.data.onnxruntime_providers or probe.data.onnxruntime_providers_error or "unknown")
+        appendKey(lines, "onnx2torch_version", probe.data.onnx2torch or "unknown")
+        if trim(probe.error or "") ~= "" then
+            appendKey(lines, "probe_error", probe.error)
+        end
+    else
+        appendKey(lines, "probe_status", "not_run")
+    end
+    appendKey(lines, "model_status", trim(stateData.DRUMSEP_MODEL_STATUS or stateData.DRUMSEP_ROCM_MODEL_STATUS) ~= "" and trim(stateData.DRUMSEP_MODEL_STATUS or stateData.DRUMSEP_ROCM_MODEL_STATUS) or "unknown")
+    appendKey(lines, "model_file", sanitizePathValue(modelFile))
+    appendKey(lines, "model_file_exists", fileExists(modelFile) and "yes" or "no")
+    appendKey(lines, "model_file_size_bytes", tostring(fileSizeBytes(modelFile) or 0))
+    appendKey(lines, "model_yaml", sanitizePathValue(modelYaml))
+    appendKey(lines, "model_yaml_exists", fileExists(modelYaml) and "yes" or "no")
+    appendKey(lines, "model_yaml_size_bytes", tostring(fileSizeBytes(modelYaml) or 0))
+    if trim(stateData.DRUMSEP_ROCM_TEMP_DIR or "") ~= "" then
+        appendKey(lines, "rocm_temp_dir", stateData.DRUMSEP_ROCM_TEMP_DIR)
+    end
+    if trim(stateData.DRUMSEP_ROCM_LAST_CHECK_UTC or stateData.DRUMSEP_LAST_CHECK_UTC or "") ~= "" then
+        appendKey(lines, "last_check_utc", trim(stateData.DRUMSEP_ROCM_LAST_CHECK_UTC or stateData.DRUMSEP_LAST_CHECK_UTC or ""))
+    end
+    appendLine(lines, "")
+end
+
+local function collectLatestDksMarkers(cacheLogDir)
+    local markerKeys = toLowerSet({
+        "workflow_mode", "workflow_source", "error_stage", "error_reason",
+        "drumsep_runtime_selected", "drumsep_python", "drumsep_gpu_capable",
+        "drumsep_runtime_fallback_reason", "drumsep_torch_version", "drumsep_torch_hip",
+        "drumsep_device_names", "separate_start", "separate_end",
+        "stem_write_start", "stem_write_end", "python_done", "drumsep_helper_start",
+        "drumsep_helper_ok", "drumsep_helper_stdout", "drumsep_helper_stderr",
+    })
+    local sourceCandidates = {}
+    local addIfExists = function(path)
+        if trim(path) ~= "" and fileExists(path) then
+            sourceCandidates[#sourceCandidates + 1] = path
+        end
+    end
+
+    addIfExists(joinPath(cacheLogDir, "stdout.txt"))
+    addIfExists(joinPath(cacheLogDir, "separation_log.txt"))
+    addIfExists(joinPath(cacheLogDir, "stemwerk.log"))
+
+    local runsRoot = joinPath(cacheLogDir, "runs")
+    if pathExists(runsRoot) then
+        local runDirs = enumerateSubdirs(runsRoot)
+        table.sort(runDirs, function(a, b) return tostring(a) > tostring(b) end)
+        for i = 1, math.min(2, #runDirs) do
+            local runDir = joinPath(runsRoot, runDirs[i])
+            for _, jobName in ipairs(enumerateSubdirs(runDir)) do
+                addIfExists(joinPath(runDir, jobName, "stdout.txt"))
+                addIfExists(joinPath(runDir, jobName, "separation_log.txt"))
+                addIfExists(joinPath(runDir, jobName, "phase_events.jsonl"))
+            end
+        end
+    end
+
+    local tempBase = getTempBase()
+    if pathExists(tempBase) then
+        local tempRuns = {}
+        for _, name in ipairs(enumerateSubdirs(tempBase)) do
+            if tostring(name):lower():find("stemwerk_", 1, true) == 1 then
+                tempRuns[#tempRuns + 1] = name
+            end
+        end
+        table.sort(tempRuns, function(a, b) return tostring(a) > tostring(b) end)
+        for i = 1, math.min(2, #tempRuns) do
+            local runDir = joinPath(tempBase, tempRuns[i])
+            addIfExists(joinPath(runDir, "stdout.txt"))
+            addIfExists(joinPath(runDir, "stderr.txt"))
+            addIfExists(joinPath(runDir, "separation_log.txt"))
+            addIfExists(joinPath(runDir, "drumsep_helper_stdout.txt"))
+            addIfExists(joinPath(runDir, "drumsep_helper_stderr.txt"))
+            addIfExists(joinPath(runDir, "phase_events.jsonl"))
+        end
+    end
+
+    local markers = {}
+    local seen = {}
+    for i = 1, #sourceCandidates do
+        local src = sourceCandidates[i]
+        local tail = readTailText(src, 256 * 1024)
+        for line in tostring(tail or ""):gmatch("[^\r\n]+") do
+            local raw = trim(line)
+            local lower = raw:lower()
+            local key, value = raw:match("^%s*([%w%._%-%s/]+)%s*[:=]%s*(.-)%s*$")
+            key = key and trim(key):lower():gsub("%s+", "_") or nil
+            value = value and trim(value) or nil
+            if key and markerKeys[key] then
+                local composed = key .. "=" .. tostring(value)
+                if not seen[composed] then
+                    seen[composed] = true
+                    markers[#markers + 1] = composed .. "  [source=" .. basename(src) .. "]"
+                end
+            else
+                for marker, _ in pairs(markerKeys) do
+                    if lower:find(marker, 1, true) then
+                        local composed = raw .. "  [source=" .. basename(src) .. "]"
+                        if not seen[composed] then
+                            seen[composed] = true
+                            markers[#markers + 1] = composed
+                        end
+                        break
+                    end
+                end
+            end
+            if #markers >= 120 then
+                return markers
+            end
+        end
+    end
+    return markers
+end
+
+local function buildDrumsepRuntimeDiagnostics(runtimeBase, runtimeStateDir, runtimeLogDir, cacheLogDir)
+    local lines = {}
+    local modelDir = joinPath(runtimeBase, "models")
+    local modelFile = joinPath(modelDir, "aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.ckpt")
+    local modelYaml = joinPath(modelDir, "aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.yaml")
+
+    local cpuPy = OS == "Windows"
+        and joinPath(runtimeBase, ".venv-drumsep", "Scripts", "python.exe")
+        or joinPath(runtimeBase, ".venv-drumsep", "bin", "python")
+    local rocmPy = OS == "Windows"
+        and joinPath(runtimeBase, ".venv-drumsep-rocm", "Scripts", "python.exe")
+        or joinPath(runtimeBase, ".venv-drumsep-rocm", "bin", "python")
+
+    local cpuStatePath = joinPath(runtimeStateDir, "drumsep_runtime.env")
+    local rocmStatePath = joinPath(runtimeStateDir, "drumsep_runtime_rocm.env")
+    local cpuState = readEnvFile(cpuStatePath)
+    local rocmState = readEnvFile(rocmStatePath)
+    local cpuProbe = buildDrumsepRuntimeProbe(cpuPy)
+    local rocmProbe = buildDrumsepRuntimeProbe(rocmPy)
+
+    appendLine(lines, "DrumSep Runtime Diagnostics")
+    appendKey(lines, "runtime_base", runtimeBase)
+    appendKey(lines, "runtime_state_dir", runtimeStateDir)
+    appendKey(lines, "runtime_logs_dir", runtimeLogDir)
+    appendKey(lines, "model_cache_dir", modelDir)
+    appendLine(lines, "")
+
+    appendDrumsepRuntimeBlock(lines, "[CPU fallback runtime]", cpuPy, cpuState, cpuProbe, modelFile, modelYaml)
+    appendDrumsepRuntimeBlock(lines, "[ROCm runtime]", rocmPy, rocmState, rocmProbe, modelFile, modelYaml)
+
+    appendLine(lines, "[Selector status]")
+    appendKey(lines, "selected_runtime", trim(rocmState.DRUMSEP_SELECTED_RUNTIME or cpuState.DRUMSEP_SELECTED_RUNTIME or "") ~= "" and trim(rocmState.DRUMSEP_SELECTED_RUNTIME or cpuState.DRUMSEP_SELECTED_RUNTIME or "") or "unknown")
+    appendKey(lines, "gpu_capable", trim(rocmState.DRUMSEP_GPU_CAPABLE or cpuState.DRUMSEP_GPU_CAPABLE or "") ~= "" and trim(rocmState.DRUMSEP_GPU_CAPABLE or cpuState.DRUMSEP_GPU_CAPABLE or "") or "unknown")
+    appendLine(lines, "")
+
+    appendLine(lines, "[Latest Direct DKS markers]")
+    local markers = collectLatestDksMarkers(cacheLogDir)
+    if #markers == 0 then
+        appendLine(lines, "no Direct DKS markers found in recent logs")
+    else
+        for i = 1, #markers do
+            appendLine(lines, markers[i])
+        end
+    end
+    appendLine(lines, "")
+
+    appendLine(lines, "[Install log tails]")
+    local cpuInstallLog = joinPath(runtimeLogDir, "drumsep_install.log")
+    local rocmInstallLog = joinPath(runtimeLogDir, "drumsep_rocm_install.log")
+    appendKey(lines, "drumsep_install.log", fileExists(cpuInstallLog) and "present" or "missing")
+    appendKey(lines, "drumsep_rocm_install.log", fileExists(rocmInstallLog) and "present" or "missing")
+    appendLine(lines, "")
+    if fileExists(cpuInstallLog) then
+        appendLine(lines, "----- tail: drumsep_install.log -----")
+        appendLine(lines, readTailText(cpuInstallLog, 180 * 1024))
+        appendLine(lines, "")
+    end
+    if fileExists(rocmInstallLog) then
+        appendLine(lines, "----- tail: drumsep_rocm_install.log -----")
+        appendLine(lines, readTailText(rocmInstallLog, 180 * 1024))
+        appendLine(lines, "")
+    end
+
+    return lines
+end
+
 local function psLiteral(text)
     return "'" .. tostring(text or ""):gsub("'", "''") .. "'"
 end
@@ -3008,6 +3314,15 @@ local function performBundleCollection()
     phaseDone("collect_recent_runs", recentRunsStartedAt)
     appendLine(diagnostics, "")
 
+    local drumsepDiagnostics = buildDrumsepRuntimeDiagnostics(runtimePaths.base, runtimePaths.runtimeState, runtimePaths.runtimeLogs, cacheLogDir)
+    writeFile(joinPath(bundleDir, "drumsep_runtime_status.txt"), table.concat(drumsepDiagnostics, "\n"), "wb")
+    copiedFiles[#copiedFiles + 1] = "drumsep_runtime_status.txt"
+    appendLine(diagnostics, "DrumSep Runtime Diagnostics")
+    appendKey(diagnostics, "DrumSep runtime status file", "drumsep_runtime_status.txt")
+    appendKey(diagnostics, "CPU runtime state", fileExists(joinPath(runtimePaths.runtimeState, "drumsep_runtime.env")) and "present" or "missing")
+    appendKey(diagnostics, "ROCm runtime state", fileExists(joinPath(runtimePaths.runtimeState, "drumsep_runtime_rocm.env")) and "present" or "missing")
+    appendLine(diagnostics, "")
+
     appendLine(diagnostics, "Settings Snapshot")
     local selectedModel = trim(extStateValue("model"))
     if selectedModel == "" then selectedModel = "htdemucs" end
@@ -3105,6 +3420,7 @@ local function performBundleCollection()
         "- support_bundle_timings.txt with phase timing checkpoints",
         "- platform_details.txt with platform probe output",
         "- python_diagnostics.txt with dependency probe output when available",
+        "- drumsep_runtime_status.txt with DrumSep CPU/ROCm runtime diagnostics and recent Direct DKS markers",
         "- See processing_summary.txt for recent processing results and speed.",
         "",
         "Intentionally excluded:",

--- a/scripts/reaper/_internal/STEMwerk_DrumKit_Workflow.lua
+++ b/scripts/reaper/_internal/STEMwerk_DrumKit_Workflow.lua
@@ -1,0 +1,18 @@
+local M = {}
+
+M.DIRECT_DKS_PRESET = "dks_direct"
+M.DIRECT_DKS_MODE = "dks_direct"
+M.DIRECT_DKS_MODEL = "MDX23C-DrumSep-aufr33-jarredou.ckpt"
+
+function M.isDirectPreset(preset)
+    return tostring(preset or "") == M.DIRECT_DKS_PRESET
+end
+
+function M.buildDirectRunOptions()
+    return {
+        workflowMode = M.DIRECT_DKS_MODE,
+        requestedStage2Model = M.DIRECT_DKS_MODEL,
+    }
+end
+
+return M

--- a/scripts/reaper/_internal/STEMwerk_DrumKit_Workflow.lua
+++ b/scripts/reaper/_internal/STEMwerk_DrumKit_Workflow.lua
@@ -1,16 +1,20 @@
 local M = {}
 
-M.DIRECT_DKS_PRESET = "dks_direct"
-M.DIRECT_DKS_MODE = "dks_direct"
+M.WORKFLOW_DRUMKIT = "drumkit"
+M.SOURCE_DIRECT = "dks_direct"
+M.SOURCE_EXTRACT = "extract"
 M.DIRECT_DKS_MODEL = "MDX23C-DrumSep-aufr33-jarredou.ckpt"
+M.KIT_STEMS = { "Kick", "Snare", "Toms", "Hi-Hat", "Ride", "Crash" }
 
 function M.isDirectPreset(preset)
-    return tostring(preset or "") == M.DIRECT_DKS_PRESET
+    local v = tostring(preset or "")
+    return v == M.SOURCE_DIRECT or v == M.WORKFLOW_DRUMKIT
 end
 
 function M.buildDirectRunOptions()
     return {
-        workflowMode = M.DIRECT_DKS_MODE,
+        workflowMode = M.WORKFLOW_DRUMKIT,
+        workflowSource = M.SOURCE_DIRECT,
         requestedStage2Model = M.DIRECT_DKS_MODEL,
     }
 end

--- a/scripts/reaper/_internal/STEMwerk_Setup_Internal.lua
+++ b/scripts/reaper/_internal/STEMwerk_Setup_Internal.lua
@@ -5319,19 +5319,25 @@ end
 
 startLinuxSetup = function(runtime, separatorScript, mode)
     mode = tostring(mode or "repair")
-    if mode ~= "repair" and mode ~= "rebuild-venv" then
+    if mode ~= "repair" and mode ~= "rebuild-venv" and mode ~= "drumsep-runtime" then
         mode = "repair"
     end
-    local stateFile = runtime.runtimeState .. PATH_SEP .. "bootstrap.env"
-    local logFile = runtime.runtimeLogs .. PATH_SEP .. "bootstrap.log"
-    local pidFile = runtime.runtimeState .. PATH_SEP .. "bootstrap.pid"
+    local isDrumsepRuntime = mode == "drumsep-runtime"
+    local stateFile = runtime.runtimeState .. PATH_SEP .. (isDrumsepRuntime and "drumsep_runtime.env" or "bootstrap.env")
+    local logFile = runtime.runtimeLogs .. PATH_SEP .. (isDrumsepRuntime and "drumsep_install.log" or "bootstrap.log")
+    local pidFile = runtime.runtimeState .. PATH_SEP .. (isDrumsepRuntime and "drumsep_runtime.pid" or "bootstrap.pid")
     local capFile = runtime.runtimeState .. PATH_SEP .. "capabilities.env"
     local guardPath = PATH_HELPER.getBootstrapGuardPath(runtime.runtimeState, PATH_SEP)
     ensureDir(runtime.runtimeState)
     ensureDir(runtime.runtimeLogs)
 
     clearTransientSetupState(runtime)
-    if mode == "rebuild-venv" then
+    if mode == "drumsep-runtime" then
+        appendSetupLog(runtime, "Drum Kit Split runtime setup started (" .. setupUiLabel() .. ")", true)
+        appendSetupLog(runtime, "Mode: drumsep-runtime", false)
+        appendSetupLog(runtime, "Target runtime: " .. tostring(runtime.base .. PATH_SEP .. ".venv-drumsep"), false)
+        appendSetupLog(runtime, "Keeping main runtime unchanged: " .. tostring(runtime.venvDir), false)
+    elseif mode == "rebuild-venv" then
         appendSetupLog(runtime, "Setup run started (" .. setupUiLabel() .. ")", true)
         appendSetupLog(runtime, "Mode: rebuild-venv", false)
         appendSetupLog(runtime, "Keeping downloaded models: " .. getModelCacheDir(), false)
@@ -6131,7 +6137,7 @@ local function existingRuntimeSetupMenuTick()
                 gfx.quit()
                 verifyExistingSetup(runtime, separatorScript)
             end
-        elseif chosen == "repair" or chosen == "rebuild-venv" then
+        elseif chosen == "repair" or chosen == "rebuild-venv" or chosen == "drumsep-runtime" then
             if OS == "Windows" then
                 windowsVerifyStart(runtime, separatorScript, true)
             else
@@ -6176,6 +6182,7 @@ local function startExistingRuntimeSetupMenu(runtime, separatorScript)
         { id = "open-runtime", label = "Open runtime folder", sub = "Open runtime base", accent = { 0.35, 0.56, 0.82 } },
     }
     if OS ~= "Windows" then
+        choices[#choices + 1] = { id = "drumsep-runtime", label = "Drum Kit Split runtime", sub = "Install/repair optional DrumSep venv", accent = { 0.22, 0.62, 0.70 } }
         choices[#choices + 1] = { id = "delete-models",label = "Delete models...", sub = "Cache reset; re-download when needed",  accent = { 0.88, 0.28, 0.28 } }
         choices[#choices + 1] = { id = "delete-runtime",label = "Delete runtime...", sub = "Full reset; removes venv + models", accent = { 0.82, 0.22, 0.22 } }
     end

--- a/scripts/reaper/_internal/STEMwerk_Setup_Internal.lua
+++ b/scripts/reaper/_internal/STEMwerk_Setup_Internal.lua
@@ -5319,13 +5319,14 @@ end
 
 startLinuxSetup = function(runtime, separatorScript, mode)
     mode = tostring(mode or "repair")
-    if mode ~= "repair" and mode ~= "rebuild-venv" and mode ~= "drumsep-runtime" then
+    if mode ~= "repair" and mode ~= "rebuild-venv" and mode ~= "drumsep-runtime" and mode ~= "drumsep-rocm-runtime" then
         mode = "repair"
     end
     local isDrumsepRuntime = mode == "drumsep-runtime"
-    local stateFile = runtime.runtimeState .. PATH_SEP .. (isDrumsepRuntime and "drumsep_runtime.env" or "bootstrap.env")
-    local logFile = runtime.runtimeLogs .. PATH_SEP .. (isDrumsepRuntime and "drumsep_install.log" or "bootstrap.log")
-    local pidFile = runtime.runtimeState .. PATH_SEP .. (isDrumsepRuntime and "drumsep_runtime.pid" or "bootstrap.pid")
+    local isDrumsepRocmRuntime = mode == "drumsep-rocm-runtime"
+    local stateFile = runtime.runtimeState .. PATH_SEP .. ((isDrumsepRuntime and "drumsep_runtime.env") or (isDrumsepRocmRuntime and "drumsep_runtime_rocm.env") or "bootstrap.env")
+    local logFile = runtime.runtimeLogs .. PATH_SEP .. ((isDrumsepRuntime and "drumsep_install.log") or (isDrumsepRocmRuntime and "drumsep_rocm_install.log") or "bootstrap.log")
+    local pidFile = runtime.runtimeState .. PATH_SEP .. ((isDrumsepRuntime and "drumsep_runtime.pid") or (isDrumsepRocmRuntime and "drumsep_rocm_runtime.pid") or "bootstrap.pid")
     local capFile = runtime.runtimeState .. PATH_SEP .. "capabilities.env"
     local guardPath = PATH_HELPER.getBootstrapGuardPath(runtime.runtimeState, PATH_SEP)
     ensureDir(runtime.runtimeState)
@@ -5336,6 +5337,11 @@ startLinuxSetup = function(runtime, separatorScript, mode)
         appendSetupLog(runtime, "Drum Kit Split runtime setup started (" .. setupUiLabel() .. ")", true)
         appendSetupLog(runtime, "Mode: drumsep-runtime", false)
         appendSetupLog(runtime, "Target runtime: " .. tostring(runtime.base .. PATH_SEP .. ".venv-drumsep"), false)
+        appendSetupLog(runtime, "Keeping main runtime unchanged: " .. tostring(runtime.venvDir), false)
+    elseif mode == "drumsep-rocm-runtime" then
+        appendSetupLog(runtime, "Drum Kit Split ROCm runtime setup started (" .. setupUiLabel() .. ")", true)
+        appendSetupLog(runtime, "Mode: drumsep-rocm-runtime", false)
+        appendSetupLog(runtime, "Target runtime: " .. tostring(runtime.base .. PATH_SEP .. ".venv-drumsep-rocm"), false)
         appendSetupLog(runtime, "Keeping main runtime unchanged: " .. tostring(runtime.venvDir), false)
     elseif mode == "rebuild-venv" then
         appendSetupLog(runtime, "Setup run started (" .. setupUiLabel() .. ")", true)
@@ -6137,7 +6143,7 @@ local function existingRuntimeSetupMenuTick()
                 gfx.quit()
                 verifyExistingSetup(runtime, separatorScript)
             end
-        elseif chosen == "repair" or chosen == "rebuild-venv" or chosen == "drumsep-runtime" then
+        elseif chosen == "repair" or chosen == "rebuild-venv" or chosen == "drumsep-runtime" or chosen == "drumsep-rocm-runtime" then
             if OS == "Windows" then
                 windowsVerifyStart(runtime, separatorScript, true)
             else
@@ -6183,6 +6189,7 @@ local function startExistingRuntimeSetupMenu(runtime, separatorScript)
     }
     if OS ~= "Windows" then
         choices[#choices + 1] = { id = "drumsep-runtime", label = "Drum Kit Split runtime", sub = "Install/repair optional DrumSep venv", accent = { 0.22, 0.62, 0.70 } }
+        choices[#choices + 1] = { id = "drumsep-rocm-runtime", label = "Drum Kit Split ROCm runtime", sub = "Install/repair optional DrumSep ROCm venv", accent = { 0.16, 0.56, 0.78 } }
         choices[#choices + 1] = { id = "delete-models",label = "Delete models...", sub = "Cache reset; re-download when needed",  accent = { 0.88, 0.28, 0.28 } }
         choices[#choices + 1] = { id = "delete-runtime",label = "Delete runtime...", sub = "Full reset; removes venv + models", accent = { 0.82, 0.22, 0.22 } }
     end

--- a/scripts/reaper/_internal/STEMwerk_Workflow.lua
+++ b/scripts/reaper/_internal/STEMwerk_Workflow.lua
@@ -399,6 +399,7 @@ function WORKFLOW.startSeparationProcess(inputFile, outputDir, model, runOptions
         local requestedDeviceArg = SETTINGS.device or "auto"
         local deviceArg = normalizeRequestedDeviceForRuntime(requestedDeviceArg)
         local workflowModeArg = tostring((runOptions and runOptions.workflowMode) or "")
+        local workflowSourceArg = tostring((runOptions and runOptions.workflowSource) or "")
         local requestedStage2ModelArg = tostring((runOptions and runOptions.requestedStage2Model) or "")
         local pythonCmd = string.format(
             '%s -u %s %s %s --model %s --device %s',
@@ -411,6 +412,9 @@ function WORKFLOW.startSeparationProcess(inputFile, outputDir, model, runOptions
         )
         if workflowModeArg ~= "" then
             pythonCmd = pythonCmd .. " --workflow-mode " .. C.quoteArg(workflowModeArg)
+        end
+        if workflowSourceArg ~= "" then
+            pythonCmd = pythonCmd .. " --workflow-source " .. C.quoteArg(workflowSourceArg)
         end
         if requestedStage2ModelArg ~= "" then
             pythonCmd = pythonCmd .. " --requested-stage2-model " .. C.quoteArg(requestedStage2ModelArg)
@@ -440,6 +444,7 @@ function WORKFLOW.startSeparationProcess(inputFile, outputDir, model, runOptions
             local m = escPS(model)
             local dev = escPS(deviceArg)
             local workflowMode = escPS(workflowModeArg)
+            local workflowSource = escPS(workflowSourceArg)
             local requestedStage2Model = escPS(requestedStage2ModelArg)
             local stdoutF = escPS(stdoutFile)
             local stderrF = escPS(logFile)
@@ -468,9 +473,11 @@ function WORKFLOW.startSeparationProcess(inputFile, outputDir, model, runOptions
                 "$modelq=$dq + $model + $dq;" ..
                 "$devq=$dq + $dev + $dq;" ..
                 "$wm='" .. workflowMode .. "';" ..
+                "$ws='" .. workflowSource .. "';" ..
                 "$s2='" .. requestedStage2Model .. "';" ..
                 "$args=@('-u',$sepq,$inq,$outq,'--model',$modelq,'--device',$devq);" ..
                 "if ($wm -ne '') { $args += @('--workflow-mode',($dq + $wm + $dq)) };" ..
+                "if ($ws -ne '') { $args += @('--workflow-source',($dq + $ws + $dq)) };" ..
                 "if ($s2 -ne '') { $args += @('--requested-stage2-model',($dq + $s2 + $dq)) };" ..
                 "$p = Start-Process -FilePath $py -ArgumentList $args -WorkingDirectory '" .. outD .. "' -WindowStyle Hidden -PassThru -RedirectStandardOutput '" .. stdoutF .. "' -RedirectStandardError '" .. stderrF .. "'; " ..
                 "Set-Content -Path '" .. pidF .. "' -Value $p.Id -Encoding ascii; " ..
@@ -504,6 +511,7 @@ function WORKFLOW.startSeparationProcess(inputFile, outputDir, model, runOptions
         local deviceArg = normalizeRequestedDeviceForRuntime(requestedDeviceArg)
         local modelArg  = tostring(model or SETTINGS.model or "htdemucs")
         local workflowModeArg = tostring((runOptions and runOptions.workflowMode) or "")
+        local workflowSourceArg = tostring((runOptions and runOptions.workflowSource) or "")
         local requestedStage2ModelArg = tostring((runOptions and runOptions.requestedStage2Model) or "")
         local pythonCmd = string.format(
             '%s -u %s %s %s --model %s --device %s',
@@ -516,6 +524,9 @@ function WORKFLOW.startSeparationProcess(inputFile, outputDir, model, runOptions
         )
         if workflowModeArg ~= "" then
             pythonCmd = pythonCmd .. " --workflow-mode " .. C.quoteArg(workflowModeArg)
+        end
+        if workflowSourceArg ~= "" then
+            pythonCmd = pythonCmd .. " --workflow-source " .. C.quoteArg(workflowSourceArg)
         end
         if requestedStage2ModelArg ~= "" then
             pythonCmd = pythonCmd .. " --requested-stage2-model " .. C.quoteArg(requestedStage2ModelArg)
@@ -572,6 +583,7 @@ function WORKFLOW.startSeparationProcess(inputFile, outputDir, model, runOptions
             script:write("MODEL=" .. C.quoteArg(modelArg) .. "\n")
             script:write("DEVICE=" .. C.quoteArg(deviceArg) .. "\n")
             script:write("WORKFLOW_MODE=" .. C.quoteArg(workflowModeArg) .. "\n")
+            script:write("WORKFLOW_SOURCE=" .. C.quoteArg(workflowSourceArg) .. "\n")
             script:write("REQUESTED_STAGE2_MODEL=" .. C.quoteArg(requestedStage2ModelArg) .. "\n")
             script:write("STDOUT=" .. C.quoteArg(stdoutFile) .. "\n")
             script:write("STDERR=" .. C.quoteArg(logFile) .. "\n")
@@ -593,6 +605,7 @@ function WORKFLOW.startSeparationProcess(inputFile, outputDir, model, runOptions
             script:write("(\n")
             script:write('  set -- "$PY" -u "$SEP" "$IN" "$OUT" --model "$MODEL" --device "$DEVICE"\n')
             script:write('  if [ -n "$WORKFLOW_MODE" ]; then set -- "$@" --workflow-mode "$WORKFLOW_MODE"; fi\n')
+            script:write('  if [ -n "$WORKFLOW_SOURCE" ]; then set -- "$@" --workflow-source "$WORKFLOW_SOURCE"; fi\n')
             script:write('  if [ -n "$REQUESTED_STAGE2_MODEL" ]; then set -- "$@" --requested-stage2-model "$REQUESTED_STAGE2_MODEL"; fi\n')
             script:write('  "$@" >"$STDOUT" 2>"$STDERR" &\n')
             script:write('  worker_pid=$!\n')
@@ -618,6 +631,9 @@ function WORKFLOW.startSeparationProcess(inputFile, outputDir, model, runOptions
             local extraArgs = ""
             if workflowModeArg ~= "" then
                 extraArgs = extraArgs .. " --workflow-mode " .. C.quoteArg(workflowModeArg)
+            end
+            if workflowSourceArg ~= "" then
+                extraArgs = extraArgs .. " --workflow-source " .. C.quoteArg(workflowSourceArg)
             end
             if requestedStage2ModelArg ~= "" then
                 extraArgs = extraArgs .. " --requested-stage2-model " .. C.quoteArg(requestedStage2ModelArg)

--- a/scripts/reaper/_internal/STEMwerk_Workflow.lua
+++ b/scripts/reaper/_internal/STEMwerk_Workflow.lua
@@ -235,7 +235,7 @@ function WORKFLOW.checkSeparationDone()
 end
 
 -- Start separation process in background (Windows)
-function WORKFLOW.startSeparationProcess(inputFile, outputDir, model)
+function WORKFLOW.startSeparationProcess(inputFile, outputDir, model, runOptions)
         append_diag_log("[workflow] start")
         append_diag_log("[workflow] outputDir=" .. tostring(outputDir))
         append_diag_log("[workflow] stdoutFile=" .. tostring(outputDir .. PATH_SEP .. "stdout.txt"))
@@ -398,6 +398,8 @@ function WORKFLOW.startSeparationProcess(inputFile, outputDir, model)
         -- Use WMI Win32_Process.Create to get a PID for proper cancel.
         local requestedDeviceArg = SETTINGS.device or "auto"
         local deviceArg = normalizeRequestedDeviceForRuntime(requestedDeviceArg)
+        local workflowModeArg = tostring((runOptions and runOptions.workflowMode) or "")
+        local requestedStage2ModelArg = tostring((runOptions and runOptions.requestedStage2Model) or "")
         local pythonCmd = string.format(
             '%s -u %s %s %s --model %s --device %s',
             C.quoteArg(PYTHON_PATH),
@@ -407,6 +409,12 @@ function WORKFLOW.startSeparationProcess(inputFile, outputDir, model)
             C.quoteArg(model),
             C.quoteArg(deviceArg)
         )
+        if workflowModeArg ~= "" then
+            pythonCmd = pythonCmd .. " --workflow-mode " .. C.quoteArg(workflowModeArg)
+        end
+        if requestedStage2ModelArg ~= "" then
+            pythonCmd = pythonCmd .. " --requested-stage2-model " .. C.quoteArg(requestedStage2ModelArg)
+        end
         C.progressState.lastCmd = pythonCmd
         SW_LOG.logExecResult("LAUNCH: " .. pythonCmd, nil, "")
         if tostring(deviceArg) ~= tostring(requestedDeviceArg) then
@@ -431,6 +439,8 @@ function WORKFLOW.startSeparationProcess(inputFile, outputDir, model)
             local outD = escPS(outputDir)
             local m = escPS(model)
             local dev = escPS(deviceArg)
+            local workflowMode = escPS(workflowModeArg)
+            local requestedStage2Model = escPS(requestedStage2ModelArg)
             local stdoutF = escPS(stdoutFile)
             local stderrF = escPS(logFile)
             local pidF = escPS(pidFile)
@@ -457,7 +467,12 @@ function WORKFLOW.startSeparationProcess(inputFile, outputDir, model)
                 "$outq=$dq + $out + $dq;" ..
                 "$modelq=$dq + $model + $dq;" ..
                 "$devq=$dq + $dev + $dq;" ..
-                "$p = Start-Process -FilePath $py -ArgumentList @('-u',$sepq,$inq,$outq,'--model',$modelq,'--device',$devq) -WorkingDirectory '" .. outD .. "' -WindowStyle Hidden -PassThru -RedirectStandardOutput '" .. stdoutF .. "' -RedirectStandardError '" .. stderrF .. "'; " ..
+                "$wm='" .. workflowMode .. "';" ..
+                "$s2='" .. requestedStage2Model .. "';" ..
+                "$args=@('-u',$sepq,$inq,$outq,'--model',$modelq,'--device',$devq);" ..
+                "if ($wm -ne '') { $args += @('--workflow-mode',($dq + $wm + $dq)) };" ..
+                "if ($s2 -ne '') { $args += @('--requested-stage2-model',($dq + $s2 + $dq)) };" ..
+                "$p = Start-Process -FilePath $py -ArgumentList $args -WorkingDirectory '" .. outD .. "' -WindowStyle Hidden -PassThru -RedirectStandardOutput '" .. stdoutF .. "' -RedirectStandardError '" .. stderrF .. "'; " ..
                 "Set-Content -Path '" .. pidF .. "' -Value $p.Id -Encoding ascii; " ..
                 "Wait-Process -Id $p.Id; " ..
                 "$ec=$p.ExitCode; Set-Content -Path '" .. exitF .. "' -Value $ec -Encoding ascii; " ..
@@ -488,6 +503,8 @@ function WORKFLOW.startSeparationProcess(inputFile, outputDir, model)
         local requestedDeviceArg = tostring(SETTINGS.device or "auto")
         local deviceArg = normalizeRequestedDeviceForRuntime(requestedDeviceArg)
         local modelArg  = tostring(model or SETTINGS.model or "htdemucs")
+        local workflowModeArg = tostring((runOptions and runOptions.workflowMode) or "")
+        local requestedStage2ModelArg = tostring((runOptions and runOptions.requestedStage2Model) or "")
         local pythonCmd = string.format(
             '%s -u %s %s %s --model %s --device %s',
             C.quoteArg(PYTHON_PATH),
@@ -497,6 +514,12 @@ function WORKFLOW.startSeparationProcess(inputFile, outputDir, model)
             C.quoteArg(modelArg),
             C.quoteArg(deviceArg)
         )
+        if workflowModeArg ~= "" then
+            pythonCmd = pythonCmd .. " --workflow-mode " .. C.quoteArg(workflowModeArg)
+        end
+        if requestedStage2ModelArg ~= "" then
+            pythonCmd = pythonCmd .. " --requested-stage2-model " .. C.quoteArg(requestedStage2ModelArg)
+        end
         C.progressState.lastCmd = pythonCmd
         SW_LOG.logExecResult("LAUNCH: " .. pythonCmd, nil, "")
         if tostring(deviceArg) ~= tostring(requestedDeviceArg) then
@@ -548,6 +571,8 @@ function WORKFLOW.startSeparationProcess(inputFile, outputDir, model)
             script:write("OUT=" .. C.quoteArg(outputDir) .. "\n")
             script:write("MODEL=" .. C.quoteArg(modelArg) .. "\n")
             script:write("DEVICE=" .. C.quoteArg(deviceArg) .. "\n")
+            script:write("WORKFLOW_MODE=" .. C.quoteArg(workflowModeArg) .. "\n")
+            script:write("REQUESTED_STAGE2_MODEL=" .. C.quoteArg(requestedStage2ModelArg) .. "\n")
             script:write("STDOUT=" .. C.quoteArg(stdoutFile) .. "\n")
             script:write("STDERR=" .. C.quoteArg(logFile) .. "\n")
             script:write("DONE=" .. C.quoteArg(doneFile) .. "\n")
@@ -566,7 +591,10 @@ function WORKFLOW.startSeparationProcess(inputFile, outputDir, model)
             script:write("  export LD_LIBRARY_PATH\n")
             script:write("fi\n")
             script:write("(\n")
-            script:write('  "$PY" -u "$SEP" "$IN" "$OUT" --model "$MODEL" --device "$DEVICE" >"$STDOUT" 2>"$STDERR" &\n')
+            script:write('  set -- "$PY" -u "$SEP" "$IN" "$OUT" --model "$MODEL" --device "$DEVICE"\n')
+            script:write('  if [ -n "$WORKFLOW_MODE" ]; then set -- "$@" --workflow-mode "$WORKFLOW_MODE"; fi\n')
+            script:write('  if [ -n "$REQUESTED_STAGE2_MODEL" ]; then set -- "$@" --requested-stage2-model "$REQUESTED_STAGE2_MODEL"; fi\n')
+            script:write('  "$@" >"$STDOUT" 2>"$STDERR" &\n')
             script:write('  worker_pid=$!\n')
             script:write('  echo "$worker_pid" > "$PIDFILE"\n')
             script:write('  wait "$worker_pid"\n')
@@ -587,14 +615,22 @@ function WORKFLOW.startSeparationProcess(inputFile, outputDir, model)
             end -- if OS == "Windows"
         else
             -- If we couldn't write the launcher, fall back to a direct foreground run (old behavior).
+            local extraArgs = ""
+            if workflowModeArg ~= "" then
+                extraArgs = extraArgs .. " --workflow-mode " .. C.quoteArg(workflowModeArg)
+            end
+            if requestedStage2ModelArg ~= "" then
+                extraArgs = extraArgs .. " --requested-stage2-model " .. C.quoteArg(requestedStage2ModelArg)
+            end
             local cmd = string.format(
-                '%s -u %s %s %s --model %s --device %s >%s 2>%s && echo DONE > %s',
+                '%s -u %s %s %s --model %s --device %s%s >%s 2>%s && echo DONE > %s',
                 C.quoteArg(PYTHON_PATH),
                 C.quoteArg(SEPARATOR_SCRIPT),
                 C.quoteArg(inputFile),
                 C.quoteArg(outputDir),
                 C.quoteArg(modelArg),
                 C.quoteArg(deviceArg),
+                extraArgs,
                 C.quoteArg(stdoutFile),
                 C.quoteArg(logFile),
                 C.quoteArg(doneFile)
@@ -807,7 +843,7 @@ function WORKFLOW.finishSeparationCallback()
 end
 
 -- Run separation with progress UI
-function WORKFLOW.runSeparationWithProgress(inputFile, outputDir, model)
+function WORKFLOW.runSeparationWithProgress(inputFile, outputDir, model, runOptions)
     -- Load settings to get current theme
     C.loadSettings()
     C.updateTheme()
@@ -817,7 +853,7 @@ function WORKFLOW.runSeparationWithProgress(inputFile, outputDir, model)
     end
 
     -- Start the process
-    local ok = WORKFLOW.startSeparationProcess(inputFile, outputDir, model)
+    local ok = WORKFLOW.startSeparationProcess(inputFile, outputDir, model, runOptions)
     if ok == false then
         if OS == "Windows" and C.progressState.windowOpen then
             closeProcessingWindow()

--- a/scripts/reaper/_internal/stemwerk_drumsep_process.py
+++ b/scripts/reaper/_internal/stemwerk_drumsep_process.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Isolated DrumSep stage2 helper for STEMwerk Direct Drum Kit Split."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import shutil
+import sys
+import traceback
+from pathlib import Path
+from typing import Any
+
+
+EXPECTED_STEMS = ("kick", "snare", "toms", "hihat", "ride", "crash")
+REAPER_FILENAMES = {
+    "kick": "kick.wav",
+    "snare": "snare.wav",
+    "toms": "toms.wav",
+    "hihat": "hi-hat.wav",
+    "ride": "ride.wav",
+    "crash": "crash.wav",
+}
+
+
+def normalize_stem_name(value: str | Path) -> str | None:
+    text = Path(value).stem if isinstance(value, Path) else str(value or "")
+    normalized = "".join(ch for ch in text.lower() if ch.isalnum())
+    if "kick" in normalized:
+        return "kick"
+    if "snare" in normalized:
+        return "snare"
+    if "toms" in normalized or normalized.endswith("tom") or "tomtom" in normalized:
+        return "toms"
+    if normalized in {"hh", "hihat", "hat"} or "hihat" in normalized or "hihat" in normalized.replace("hh", "hihat"):
+        return "hihat"
+    if "ride" in normalized:
+        return "ride"
+    if "crash" in normalized:
+        return "crash"
+    return None
+
+
+def _json_default(value: Any) -> str:
+    return str(value)
+
+
+def write_result(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True, default=_json_default) + "\n", encoding="utf-8")
+
+
+def _candidate_paths(output_dir: Path, raw_outputs: Any, before: set[Path]) -> list[Path]:
+    candidates: list[Path] = []
+    if isinstance(raw_outputs, (list, tuple, set)):
+        for item in raw_outputs:
+            try:
+                p = Path(str(item))
+            except Exception:
+                continue
+            if not p.is_absolute():
+                p = output_dir / p
+            candidates.append(p)
+
+    for p in sorted(output_dir.glob("*.wav")):
+        if p.resolve() not in before:
+            candidates.append(p)
+
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for p in candidates:
+        key = str(p.resolve())
+        if key not in seen:
+            seen.add(key)
+            unique.append(p)
+    return unique
+
+
+def normalize_outputs(output_dir: Path, raw_outputs: Any, before: set[Path]) -> tuple[dict[str, str], list[str]]:
+    stems: dict[str, str] = {}
+    raw_paths: list[str] = []
+    for path in _candidate_paths(output_dir, raw_outputs, before):
+        raw_paths.append(str(path))
+        stem_key = normalize_stem_name(path)
+        if not stem_key:
+            continue
+        if not path.exists():
+            continue
+        target = output_dir / REAPER_FILENAMES[stem_key]
+        if path.resolve() != target.resolve():
+            if target.exists():
+                target.unlink()
+            shutil.move(str(path), str(target))
+        stems[stem_key] = str(target)
+    return stems, raw_paths
+
+
+def _error_payload(reason: str, stage: str, message: str, **extra: Any) -> dict[str, Any]:
+    payload = {
+        "ok": False,
+        "error_stage": stage,
+        "error_reason": reason,
+        "message": message,
+    }
+    payload.update(extra)
+    return payload
+
+
+def run(args: argparse.Namespace) -> int:
+    input_path = Path(args.input).expanduser().resolve()
+    output_dir = Path(args.output_dir).expanduser().resolve()
+    model_dir = Path(args.model_dir).expanduser().resolve()
+    result_json = Path(args.result_json).expanduser().resolve()
+    model_name = str(args.model)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    before = {p.resolve() for p in output_dir.glob("*.wav")}
+
+    try:
+        from audio_separator.separator import Separator
+    except Exception as exc:
+        write_result(result_json, _error_payload("drumsep_helper_failed", "stage2_runtime", f"{type(exc).__name__}: {exc}"))
+        return 1
+
+    try:
+        print(f"drumsep_helper_start input={input_path}", file=sys.stderr)
+        print(f"drumsep_helper_model_dir={model_dir}", file=sys.stderr)
+        print(f"drumsep_helper_model={model_name}", file=sys.stderr)
+        print(f"drumsep_helper_output_dir={output_dir}", file=sys.stderr)
+        sep = Separator(model_file_dir=str(model_dir), output_dir=str(output_dir), output_format="WAV")
+        sep.load_model(model_name)
+    except Exception as exc:
+        write_result(
+            result_json,
+            _error_payload(
+                "drumsep_model_load_failed",
+                "stage2_model_load",
+                f"{type(exc).__name__}: {exc}",
+                traceback=traceback.format_exc(),
+            ),
+        )
+        return 1
+
+    try:
+        raw_outputs = sep.separate(str(input_path))
+    except Exception as exc:
+        write_result(
+            result_json,
+            _error_payload(
+                "drumsep_separate_failed",
+                "stage2_separate",
+                f"{type(exc).__name__}: {exc}",
+                traceback=traceback.format_exc(),
+            ),
+        )
+        return 1
+
+    stems, raw_paths = normalize_outputs(output_dir, raw_outputs, before)
+    missing = [name for name in EXPECTED_STEMS if name not in stems]
+    if missing or len(stems) != len(EXPECTED_STEMS):
+        write_result(
+            result_json,
+            _error_payload(
+                "drumsep_output_count_mismatch",
+                "stage2_output_validation",
+                f"expected {len(EXPECTED_STEMS)} stems, got {len(stems)}",
+                stems=stems,
+                missing=missing,
+                raw_outputs=raw_paths,
+            ),
+        )
+        return 1
+
+    write_result(result_json, {"ok": True, "stems": stems, "raw_outputs": raw_paths})
+    print("drumsep_helper_ok=true", file=sys.stderr)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run DrumSep MDX23C in the isolated STEMwerk DrumSep runtime.")
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--model-dir", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--result-json", required=True)
+    parser.add_argument("--log-file", default="")
+    args = parser.parse_args()
+
+    if args.log_file:
+        log_path = Path(args.log_file).expanduser().resolve()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8", errors="replace") as log_fh:
+            with contextlib.redirect_stderr(log_fh):
+                return run(args)
+    return run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -582,24 +582,58 @@ def _run_direct_dks_drumsep_helper(
         "--log-file",
         str(helper_log),
     ]
-    completed = subprocess.run(
-        cmd,
-        text=True,
-        capture_output=True,
-        timeout=60 * 60,
-        **_windows_no_window_kwargs(),
-    )
-    helper_stdout.write_text(completed.stdout or "", encoding="utf-8", errors="replace")
-    helper_stderr.write_text(completed.stderr or "", encoding="utf-8", errors="replace")
+    print("PROGRESS:1:Starting DrumSep runtime", flush=True)
 
-    print(f"drumsep_helper_returncode={completed.returncode}", file=sys.stderr)
-    if completed.stdout:
+    def helper_log_percent() -> Optional[int]:
+        try:
+            text = helper_log.read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            return None
+        matches = list(re.finditer(r"(\d{1,3})%\|", text))
+        if not matches:
+            return None
+        return max(0, min(99, int(matches[-1].group(1))))
+
+    with helper_stdout.open("w", encoding="utf-8", errors="replace") as stdout_fh, helper_stderr.open(
+        "w", encoding="utf-8", errors="replace"
+    ) as stderr_fh:
+        process = subprocess.Popen(
+            cmd,
+            text=True,
+            stdout=stdout_fh,
+            stderr=stderr_fh,
+            **_windows_no_window_kwargs(),
+        )
+        start_time = time.monotonic()
+        last_percent = -1
+        while True:
+            rc = process.poll()
+            percent = helper_log_percent()
+            if percent is None:
+                elapsed = int(time.monotonic() - start_time)
+                percent = min(12, 1 + elapsed // 10)
+            if percent != last_percent:
+                print(f"PROGRESS:{percent}:DrumSep stage2 separating kit stems", flush=True)
+                last_percent = percent
+            if rc is not None:
+                break
+            if time.monotonic() - start_time > 60 * 60:
+                process.kill()
+                return False, {}, "drumsep_helper_failed", "helper timeout after 3600 seconds"
+            time.sleep(2.0)
+
+    completed_returncode = process.returncode
+
+    helper_stdout_text = helper_stdout.read_text(encoding="utf-8", errors="replace") if helper_stdout.exists() else ""
+    helper_stderr_text = helper_stderr.read_text(encoding="utf-8", errors="replace") if helper_stderr.exists() else ""
+    print(f"drumsep_helper_returncode={completed_returncode}", file=sys.stderr)
+    if helper_stdout_text:
         print("drumsep_helper_stdout_begin", file=sys.stderr)
-        print(completed.stdout.rstrip(), file=sys.stderr)
+        print(helper_stdout_text.rstrip(), file=sys.stderr)
         print("drumsep_helper_stdout_end", file=sys.stderr)
-    if completed.stderr:
+    if helper_stderr_text:
         print("drumsep_helper_stderr_begin", file=sys.stderr)
-        print(completed.stderr.rstrip(), file=sys.stderr)
+        print(helper_stderr_text.rstrip(), file=sys.stderr)
         print("drumsep_helper_stderr_end", file=sys.stderr)
 
     try:
@@ -607,7 +641,7 @@ def _run_direct_dks_drumsep_helper(
     except Exception as exc:
         return False, {}, "drumsep_helper_failed", f"failed reading helper result JSON: {type(exc).__name__}: {exc}"
 
-    if completed.returncode != 0 or not result_data.get("ok"):
+    if completed_returncode != 0 or not result_data.get("ok"):
         reason = str(result_data.get("error_reason") or "drumsep_helper_failed")
         detail = str(result_data.get("message") or result_data)
         return False, {}, reason, detail

--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -48,6 +48,12 @@ def _is_direct_dks_mode(workflow_mode: Optional[str]) -> bool:
     return str(workflow_mode or "").strip().lower() == "dks_direct"
 
 
+def _is_direct_dks_source(workflow_mode: Optional[str], workflow_source: Optional[str]) -> bool:
+    mode = str(workflow_mode or "").strip().lower()
+    source = str(workflow_source or "").strip().lower()
+    return source == "dks_direct" or mode == "dks_direct"
+
+
 def _resolve_run_model(args: argparse.Namespace) -> str:
     if _is_direct_dks_mode(getattr(args, "workflow_mode", "")):
         requested = str(getattr(args, "requested_stage2_model", "") or "").strip()
@@ -979,7 +985,9 @@ def main():
     parser.add_argument("--list-devices-machine", action="store_true",
                         help="List available devices in a machine-readable format (for REAPER UIs)")
     parser.add_argument("--workflow-mode", default="",
-                        help="Optional workflow mode (e.g. dks_direct)")
+                        help="Optional workflow mode")
+    parser.add_argument("--workflow-source", default="",
+                        help="Optional workflow source route (internal)")
     parser.add_argument("--requested-stage2-model", default="",
                         help="Optional stage2 model override for direct DKS")
 
@@ -1055,7 +1063,7 @@ def main():
 
     stems = _split_list(args.stems)
     run_model = _resolve_run_model(args)
-    if _is_direct_dks_mode(args.workflow_mode):
+    if _is_direct_dks_source(args.workflow_mode, args.workflow_source):
         emit_phase("stage2_preflight")
         try:
             StemSeparator(model=run_model, device="cpu")

--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -55,7 +55,7 @@ def _is_direct_dks_source(workflow_mode: Optional[str], workflow_source: Optiona
 
 
 def _resolve_run_model(args: argparse.Namespace) -> str:
-    if _is_direct_dks_mode(getattr(args, "workflow_mode", "")):
+    if _is_direct_dks_source(getattr(args, "workflow_mode", ""), getattr(args, "workflow_source", "")):
         requested = str(getattr(args, "requested_stage2_model", "") or "").strip()
         if requested:
             return requested
@@ -80,11 +80,14 @@ def _emit_direct_dks_model_missing_markers(model_name: str) -> None:
 
 
 def _direct_dks_preflight_check(model_name: str) -> Tuple[bool, Optional[str]]:
+    # Force an explicit model-catalog lookup before normal workflow setup.
+    # This prevents delayed failure in sep.separate()/load_model for known
+    # unresolved DrumSep model names.
     try:
-        sep = StemSeparator(model=model_name, device="cpu")
-        loader = getattr(getattr(sep, "separator", None), "load_model", None)
-        if callable(loader):
-            loader()
+        from audio_separator.separator import Separator as AudioSeparator
+
+        sep = AudioSeparator(model_file_dir=str(_configure_model_cache_runtime()), output_dir=".")
+        sep.download_model_files(model_name)
         return True, None
     except Exception as exc:
         if _is_known_drumsep_model_missing_error(exc):
@@ -1095,6 +1098,10 @@ def main():
     run_model = _resolve_run_model(args)
     if _is_direct_dks_source(args.workflow_mode, args.workflow_source):
         emit_phase("stage2_preflight")
+        print(
+            f"Direct Drum Kit Split route detected: workflow_mode={args.workflow_mode} workflow_source={args.workflow_source}",
+            file=sys.stderr,
+        )
         try:
             ok, known_err = _direct_dks_preflight_check(run_model)
             if not ok:

--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -62,6 +62,36 @@ def _resolve_run_model(args: argparse.Namespace) -> str:
     return str(getattr(args, "model", "htdemucs") or "htdemucs")
 
 
+def _is_known_drumsep_model_missing_error(exc: Exception) -> bool:
+    text = str(exc or "").lower()
+    return "not found in supported model files" in text and "model file" in text
+
+
+def _emit_direct_dks_model_missing_markers(model_name: str) -> None:
+    print("error_stage=stage2_preflight", file=sys.stderr)
+    print("error_reason=drumsep_model_missing", file=sys.stderr)
+    print(f"requested_model={model_name}", file=sys.stderr)
+    print("Direct Drum Kit Split preflight failed: drumsep_model_missing", file=sys.stderr)
+    print(f"Requested model: {model_name}", file=sys.stderr)
+    print(
+        "guidance=Update or repair runtime model catalog/audio-separator mapping for DrumSep and retry.",
+        file=sys.stderr,
+    )
+
+
+def _direct_dks_preflight_check(model_name: str) -> Tuple[bool, Optional[str]]:
+    try:
+        sep = StemSeparator(model=model_name, device="cpu")
+        loader = getattr(getattr(sep, "separator", None), "load_model", None)
+        if callable(loader):
+            loader()
+        return True, None
+    except Exception as exc:
+        if _is_known_drumsep_model_missing_error(exc):
+            return False, str(exc)
+        raise
+
+
 def _enforce_mps_demucs_cpu_policy(requested_device: str, resolved_device: str, model_name: str) -> str:
     if resolved_device != "mps":
         return resolved_device
@@ -1066,15 +1096,17 @@ def main():
     if _is_direct_dks_source(args.workflow_mode, args.workflow_source):
         emit_phase("stage2_preflight")
         try:
-            StemSeparator(model=run_model, device="cpu")
+            ok, known_err = _direct_dks_preflight_check(run_model)
+            if not ok:
+                _emit_direct_dks_model_missing_markers(run_model)
+                if known_err:
+                    print(f"DETAIL: {known_err}", file=sys.stderr)
+                emit_phase("python_error")
+                if write_done:
+                    write_done("ERROR")
+                return 1
         except Exception as exc:
-            print("error_stage=stage2_preflight", file=sys.stderr)
-            print("error_reason=drumsep_model_missing", file=sys.stderr)
-            print(f"requested_model={run_model}", file=sys.stderr)
-            print(
-                "guidance=Update or repair runtime model catalog/audio-separator mapping for DrumSep and retry.",
-                file=sys.stderr,
-            )
+            _emit_direct_dks_model_missing_markers(run_model)
             print(f"ERROR: {exc}", file=sys.stderr)
             emit_phase("python_error")
             if write_done:

--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -40,6 +40,7 @@ DIRECT_DKS_MODEL_FILENAME = "aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.
 DIRECT_DKS_MODEL_ENTRY_NAME = "MDX23C Model: DrumSep 6stem | (by aufr33 & jarredou)"
 DRUMSEP_RUNTIME_DIRNAME = ".venv-drumsep"
 DRUMSEP_RUNTIME_GUIDANCE = "Run Setup/Repair Drum Kit Split runtime."
+DRUMSEP_HELPER_RELATIVE = Path("_internal") / "stemwerk_drumsep_process.py"
 
 
 def _is_darwin_arm64() -> bool:
@@ -132,17 +133,23 @@ def _emit_direct_dks_stage2_runtime_markers(reason: str, python_path: Path, deta
     print(DRUMSEP_RUNTIME_GUIDANCE, file=sys.stderr)
 
 
-def _emit_direct_dks_stage2_delegation_pending_markers(python_path: Path, detail: str = "") -> None:
-    print("error_stage=stage2_runtime", file=sys.stderr)
-    print("error_reason=drumsep_stage2_delegation_not_implemented", file=sys.stderr)
-    print(f"drumsep_runtime_python={python_path}", file=sys.stderr)
+def _emit_direct_dks_helper_failure_markers(reason: str, stage: str, requested_model: str, resolved_model: str, detail: str = "") -> None:
+    print(f"error_stage={stage}", file=sys.stderr)
+    print(f"error_reason={reason}", file=sys.stderr)
+    print(f"requested_model={requested_model}", file=sys.stderr)
+    if resolved_model:
+        print(f"resolved_model={resolved_model}", file=sys.stderr)
     if detail:
         print(f"detail={detail}", file=sys.stderr)
-    print("Direct Drum Kit Split runtime verified; stage2 delegation is not implemented in this slice.", file=sys.stderr)
+    print(f"Direct Drum Kit Split helper failed: {reason}", file=sys.stderr)
 
 
 def _repository_root() -> Path:
     return Path(__file__).resolve().parents[2]
+
+
+def _drumsep_helper_path() -> Path:
+    return Path(__file__).resolve().parent / DRUMSEP_HELPER_RELATIVE
 
 
 def _find_repo_download_checks_path() -> Optional[Path]:
@@ -531,6 +538,110 @@ print(json.dumps({"ok": True, "versions": versions}, sort_keys=True))
     if completed.returncode != 0:
         return False, output[:1200] or f"verify_exit_{completed.returncode}"
     return True, output[:1200] or "ok"
+
+
+def _run_direct_dks_drumsep_helper(
+    input_path: Path,
+    output_root: Path,
+    model_cache_dir: Path,
+    drumsep_python: Path,
+    requested_model: str,
+    resolved_model: str,
+) -> Tuple[bool, Dict[str, str], str, str]:
+    helper_path = _drumsep_helper_path()
+    result_json = output_root / "drumsep_result.json"
+    helper_stdout = output_root / "drumsep_helper_stdout.txt"
+    helper_stderr = output_root / "drumsep_helper_stderr.txt"
+    helper_log = output_root / "drumsep_helper.log"
+
+    print("drumsep_helper_start", file=sys.stderr)
+    print(f"drumsep_helper_python={drumsep_python}", file=sys.stderr)
+    print(f"drumsep_helper_script={helper_path}", file=sys.stderr)
+    print(f"drumsep_helper_model={resolved_model}", file=sys.stderr)
+    print(f"drumsep_helper_output_dir={output_root}", file=sys.stderr)
+    print(f"drumsep_helper_result_json={result_json}", file=sys.stderr)
+    print(f"drumsep_helper_stdout={helper_stdout}", file=sys.stderr)
+    print(f"drumsep_helper_stderr={helper_stderr}", file=sys.stderr)
+
+    if not helper_path.exists():
+        return False, {}, "drumsep_helper_failed", f"helper script missing: {helper_path}"
+
+    cmd = [
+        str(drumsep_python),
+        str(helper_path),
+        "--input",
+        str(input_path),
+        "--output-dir",
+        str(output_root),
+        "--model-dir",
+        str(model_cache_dir),
+        "--model",
+        resolved_model,
+        "--result-json",
+        str(result_json),
+        "--log-file",
+        str(helper_log),
+    ]
+    completed = subprocess.run(
+        cmd,
+        text=True,
+        capture_output=True,
+        timeout=60 * 60,
+        **_windows_no_window_kwargs(),
+    )
+    helper_stdout.write_text(completed.stdout or "", encoding="utf-8", errors="replace")
+    helper_stderr.write_text(completed.stderr or "", encoding="utf-8", errors="replace")
+
+    print(f"drumsep_helper_returncode={completed.returncode}", file=sys.stderr)
+    if completed.stdout:
+        print("drumsep_helper_stdout_begin", file=sys.stderr)
+        print(completed.stdout.rstrip(), file=sys.stderr)
+        print("drumsep_helper_stdout_end", file=sys.stderr)
+    if completed.stderr:
+        print("drumsep_helper_stderr_begin", file=sys.stderr)
+        print(completed.stderr.rstrip(), file=sys.stderr)
+        print("drumsep_helper_stderr_end", file=sys.stderr)
+
+    try:
+        result_data = json.loads(result_json.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return False, {}, "drumsep_helper_failed", f"failed reading helper result JSON: {type(exc).__name__}: {exc}"
+
+    if completed.returncode != 0 or not result_data.get("ok"):
+        reason = str(result_data.get("error_reason") or "drumsep_helper_failed")
+        detail = str(result_data.get("message") or result_data)
+        return False, {}, reason, detail
+
+    raw_stems = result_data.get("stems") or {}
+    if not isinstance(raw_stems, dict):
+        return False, {}, "drumsep_output_count_mismatch", "helper result stems is not an object"
+
+    key_to_reaper = {
+        "kick": "kick",
+        "snare": "snare",
+        "toms": "toms",
+        "hihat": "hi-hat",
+        "ride": "ride",
+        "crash": "crash",
+    }
+    reaper_stems: Dict[str, str] = {}
+    for source_key, reaper_key in key_to_reaper.items():
+        value = raw_stems.get(source_key)
+        if not value:
+            return False, {}, "drumsep_output_count_mismatch", f"missing helper stem: {source_key}"
+        path = _resolve_stem_path(output_root, str(value))
+        if not path.exists():
+            return False, {}, "drumsep_output_count_mismatch", f"helper stem missing on disk: {path}"
+        target = output_root / f"{reaper_key}.wav"
+        if path.resolve() != target.resolve():
+            if target.exists():
+                target.unlink()
+            shutil.move(str(path), str(target))
+        reaper_stems[reaper_key] = str(target)
+        print(f"  {reaper_key}:  {target}", file=sys.stderr)
+
+    print("drumsep_helper_ok=true", file=sys.stderr)
+    return True, reaper_stems, "", ""
 
 
 def _prepend_path(path_value: str) -> None:
@@ -1387,11 +1498,6 @@ def main():
             if write_done:
                 write_done("ERROR")
             return 1
-        _emit_direct_dks_stage2_delegation_pending_markers(drumsep_python, runtime_detail)
-        emit_phase("python_error")
-        if write_done:
-            write_done("ERROR")
-        return 1
         try:
             ok, requested_model, resolved_model, known_err = _direct_dks_preflight_check(run_model, model_cache_dir)
             if not ok:
@@ -1415,6 +1521,42 @@ def main():
             if write_done:
                 write_done("ERROR")
             return 1
+        output_root = Path(args.output_dir).resolve()
+        output_root.mkdir(parents=True, exist_ok=True)
+        emit_phase("separate_start")
+        helper_ok, helper_stems, helper_reason, helper_detail = _run_direct_dks_drumsep_helper(
+            Path(args.input).resolve(),
+            output_root,
+            model_cache_dir,
+            drumsep_python,
+            requested_stage2_model,
+            run_model,
+        )
+        if not helper_ok:
+            stage = "stage2_separate"
+            if helper_reason == "drumsep_model_load_failed":
+                stage = "stage2_model_load"
+            elif helper_reason == "drumsep_output_count_mismatch":
+                stage = "stage2_output_validation"
+            _emit_direct_dks_helper_failure_markers(
+                helper_reason or "drumsep_helper_failed",
+                stage,
+                requested_stage2_model,
+                run_model,
+                helper_detail,
+            )
+            emit_phase("python_error")
+            if write_done:
+                write_done("ERROR")
+            return 1
+        emit_phase("separate_end")
+        emit_phase("stem_write_start")
+        print(json.dumps(helper_stems))
+        emit_phase("stem_write_end")
+        emit_phase("python_done")
+        if write_done:
+            write_done("DONE")
+        return 0
 
     resolved_device = device_preference
     if device_preference == "auto":

--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -72,6 +72,18 @@ def _is_known_drumsep_model_missing_error(exc: Exception) -> bool:
     return "not found in supported model files" in text and "model file" in text
 
 
+def _is_known_drumsep_runtime_unsupported_error(exc: Exception, traceback_text: str, model_name: str) -> bool:
+    text = f"{exc}\n{traceback_text}".lower()
+    model_text = str(model_name or "").lower()
+    if "drumsep" not in model_text and "mdx23c_ep_141" not in model_text:
+        return False
+    return (
+        ("mdxc_separator.py" in text or "mdxc_separator" in text)
+        and "attributeerror" in text
+        and ("'model'" in text or "\"model\"" in text)
+    )
+
+
 def _emit_direct_dks_preflight_markers(reason: str, requested_model: str, resolved_model: str = "", detail: str = "") -> None:
     print("error_stage=stage2_preflight", file=sys.stderr)
     print(f"error_reason={reason}", file=sys.stderr)
@@ -88,6 +100,20 @@ def _emit_direct_dks_preflight_markers(reason: str, requested_model: str, resolv
         "guidance=Update or repair runtime model catalog/audio-separator mapping for DrumSep and retry.",
         file=sys.stderr,
     )
+
+
+def _emit_direct_dks_runtime_unsupported_markers(requested_model: str, resolved_model: str, detail: str) -> None:
+    print("error_stage=stage2_model_load", file=sys.stderr)
+    print("error_reason=drumsep_model_runtime_unsupported", file=sys.stderr)
+    print(f"requested_model={requested_model}", file=sys.stderr)
+    if resolved_model:
+        print(f"resolved_model={resolved_model}", file=sys.stderr)
+    print("Direct Drum Kit Split model load failed: drumsep_model_runtime_unsupported", file=sys.stderr)
+    print(f"Requested model: {requested_model}", file=sys.stderr)
+    if resolved_model:
+        print(f"Resolved model: {resolved_model}", file=sys.stderr)
+    if detail:
+        print(f"Detail: {detail}", file=sys.stderr)
 
 
 def _repository_root() -> Path:
@@ -1253,6 +1279,7 @@ def main():
 
     stems = _split_list(args.stems)
     run_model = _resolve_run_model(args)
+    requested_stage2_model = run_model
     if _is_direct_dks_source(args.workflow_mode, args.workflow_source):
         emit_phase("stage2_preflight")
         print(
@@ -1274,6 +1301,7 @@ def main():
                 if write_done:
                     write_done("ERROR")
                 return 1
+            requested_stage2_model = requested_model or requested_stage2_model
             run_model = resolved_model or run_model
         except Exception as exc:
             _emit_direct_dks_preflight_markers("drumsep_model_download_failed", run_model, "", str(exc))
@@ -1378,6 +1406,16 @@ def main():
         import traceback
 
         traceback_text = traceback.format_exc()
+        if _is_direct_dks_source(args.workflow_mode, args.workflow_source) and _is_known_drumsep_runtime_unsupported_error(exc, traceback_text, run_model):
+            _emit_direct_dks_runtime_unsupported_markers(
+                requested_stage2_model or run_model,
+                run_model,
+                "audio_separator mdxc loader missing expected config field 'model'",
+            )
+            emit_phase("python_error")
+            if write_done:
+                write_done("ERROR")
+            return 1
         model_failure = _classify_model_failure_text(f"{exc}\n{traceback_text}")
         if model_failure:
             print(f"STEMWERK_ERROR_CLASS={model_failure['error_class']}", file=sys.stderr)

--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -39,6 +39,7 @@ DIRECT_DKS_MODEL_ALIAS = "MDX23C-DrumSep-aufr33-jarredou.ckpt"
 DIRECT_DKS_MODEL_FILENAME = "aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.ckpt"
 DIRECT_DKS_MODEL_ENTRY_NAME = "MDX23C Model: DrumSep 6stem | (by aufr33 & jarredou)"
 DRUMSEP_RUNTIME_DIRNAME = ".venv-drumsep"
+DRUMSEP_RUNTIME_ROCM_DIRNAME = ".venv-drumsep-rocm"
 DRUMSEP_RUNTIME_GUIDANCE = "Run Setup/Repair Drum Kit Split runtime."
 DRUMSEP_HELPER_RELATIVE = Path("_internal") / "stemwerk_drumsep_process.py"
 
@@ -481,15 +482,23 @@ def _drumsep_runtime_python_path(runtime_base: Optional[Path] = None) -> Path:
     return runtime_dir / "bin" / "python"
 
 
-def _verify_drumsep_runtime(python_path: Path) -> Tuple[bool, str]:
+def _drumsep_rocm_runtime_python_path(runtime_base: Optional[Path] = None) -> Path:
+    base = runtime_base or (_runtime_base_candidates()[0] if _runtime_base_candidates() else Path.home() / ".local" / "share" / "STEMwerk")
+    runtime_dir = base / DRUMSEP_RUNTIME_ROCM_DIRNAME
+    if os.name == "nt":
+        return runtime_dir / "Scripts" / "python.exe"
+    return runtime_dir / "bin" / "python"
+
+
+def _verify_drumsep_runtime(python_path: Path, require_gpu: bool = False) -> Tuple[bool, str, Dict[str, Any]]:
     try:
         exists = python_path.exists()
     except Exception:
         exists = False
     if not exists:
-        return False, "missing"
+        return False, "missing", {}
     if not os.access(str(python_path), os.X_OK):
-        return False, "not_executable"
+        return False, "not_executable", {}
 
     verify_code = r"""
 import importlib
@@ -520,7 +529,29 @@ for module_name in optional:
     except Exception as exc:
         versions[module_name + "_import_error"] = f"{type(exc).__name__}: {exc}"
 
-print(json.dumps({"ok": True, "versions": versions}, sort_keys=True))
+device_names = []
+torch_hip = ""
+torch_cuda_available = False
+try:
+    import torch
+    torch_hip = str(getattr(torch.version, "hip", "") or "")
+    torch_cuda_available = bool(torch.cuda.is_available())
+    if torch_cuda_available:
+        for idx in range(int(torch.cuda.device_count())):
+            try:
+                device_names.append(str(torch.cuda.get_device_name(idx)))
+            except Exception:
+                pass
+except Exception:
+    pass
+
+print(json.dumps({
+    "ok": True,
+    "versions": versions,
+    "torch_hip": torch_hip,
+    "torch_cuda_available": torch_cuda_available,
+    "device_names": device_names,
+}, sort_keys=True))
 """
     try:
         completed = subprocess.run(
@@ -532,12 +563,63 @@ print(json.dumps({"ok": True, "versions": versions}, sort_keys=True))
             **_windows_no_window_kwargs(),
         )
     except Exception as exc:
-        return False, f"verify_spawn_failed:{type(exc).__name__}:{exc}"
+        return False, f"verify_spawn_failed:{type(exc).__name__}:{exc}", {}
 
     output = " ".join(part.strip() for part in (completed.stdout, completed.stderr) if part and part.strip())
     if completed.returncode != 0:
-        return False, output[:1200] or f"verify_exit_{completed.returncode}"
-    return True, output[:1200] or "ok"
+        return False, output[:1200] or f"verify_exit_{completed.returncode}", {}
+
+    try:
+        payload = json.loads((completed.stdout or "").strip() or "{}")
+    except Exception:
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+
+    if require_gpu:
+        hip = str(payload.get("torch_hip") or "")
+        cuda_available = bool(payload.get("torch_cuda_available"))
+        device_names = payload.get("device_names") or []
+        if not isinstance(device_names, list):
+            device_names = []
+        if not hip:
+            return False, "rocm_no_hip", payload
+        if not cuda_available:
+            return False, "rocm_cuda_unavailable", payload
+        if len([d for d in device_names if str(d).strip()]) == 0:
+            return False, "rocm_no_device_names", payload
+
+    return True, output[:1200] or "ok", payload
+
+
+def _select_drumsep_runtime(runtime_base: Optional[Path] = None) -> Tuple[Optional[Path], str, Dict[str, Any]]:
+    rocm_python = _drumsep_rocm_runtime_python_path(runtime_base)
+    cpu_python = _drumsep_runtime_python_path(runtime_base)
+
+    rocm_ok, rocm_detail, rocm_payload = _verify_drumsep_runtime(rocm_python, require_gpu=True)
+    if rocm_ok:
+        info = dict(rocm_payload or {})
+        info["kind"] = "rocm"
+        info["detail"] = rocm_detail
+        info["fallback_reason"] = ""
+        return rocm_python, "rocm", info
+
+    cpu_ok, cpu_detail, cpu_payload = _verify_drumsep_runtime(cpu_python, require_gpu=False)
+    if cpu_ok:
+        info = dict(cpu_payload or {})
+        info["kind"] = "cpu"
+        info["detail"] = cpu_detail
+        info["fallback_reason"] = f"rocm_skipped:{rocm_detail}"
+        return cpu_python, "cpu", info
+
+    info = {
+        "rocm_detail": rocm_detail,
+        "cpu_detail": cpu_detail,
+        "rocm_python": str(rocm_python),
+        "cpu_python": str(cpu_python),
+    }
+    reason = "missing" if rocm_detail == "missing" and cpu_detail == "missing" else "broken"
+    return None, reason, info
 
 
 def _run_direct_dks_drumsep_helper(
@@ -1523,15 +1605,26 @@ def main():
             f"Direct Drum Kit Split route detected: workflow_mode={args.workflow_mode} workflow_source={args.workflow_source}",
             file=sys.stderr,
         )
-        drumsep_python = _drumsep_runtime_python_path()
-        runtime_ok, runtime_detail = _verify_drumsep_runtime(drumsep_python)
-        if not runtime_ok:
-            reason = "drumsep_runtime_missing" if runtime_detail == "missing" else "drumsep_runtime_broken"
-            _emit_direct_dks_stage2_runtime_markers(reason, drumsep_python, runtime_detail)
+        drumsep_python, runtime_kind, runtime_info = _select_drumsep_runtime()
+        if drumsep_python is None:
+            reason = "drumsep_runtime_missing" if runtime_kind == "missing" else "drumsep_runtime_broken"
+            runtime_path = _drumsep_rocm_runtime_python_path()
+            _emit_direct_dks_stage2_runtime_markers(reason, runtime_path, json.dumps(runtime_info, sort_keys=True))
             emit_phase("python_error")
             if write_done:
                 write_done("ERROR")
             return 1
+        versions = runtime_info.get("versions") if isinstance(runtime_info.get("versions"), dict) else {}
+        device_names = runtime_info.get("device_names") if isinstance(runtime_info.get("device_names"), list) else []
+        fallback_reason = str(runtime_info.get("fallback_reason") or "")
+        print(f"drumsep_runtime_selected={runtime_kind}", file=sys.stderr)
+        print(f"drumsep_python={drumsep_python}", file=sys.stderr)
+        print(f"drumsep_gpu_capable={'yes' if runtime_kind == 'rocm' else 'no'}", file=sys.stderr)
+        print(f"drumsep_torch_version={versions.get('torch', '')}", file=sys.stderr)
+        print(f"drumsep_torch_hip={runtime_info.get('torch_hip', '')}", file=sys.stderr)
+        print(f"drumsep_device_names={'|'.join(str(x) for x in device_names if str(x).strip())}", file=sys.stderr)
+        if fallback_reason:
+            print(f"drumsep_runtime_fallback_reason={fallback_reason}", file=sys.stderr)
         try:
             ok, requested_model, resolved_model, known_err = _direct_dks_preflight_check(run_model, model_cache_dir)
             if not ok:

--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -132,6 +132,15 @@ def _emit_direct_dks_stage2_runtime_markers(reason: str, python_path: Path, deta
     print(DRUMSEP_RUNTIME_GUIDANCE, file=sys.stderr)
 
 
+def _emit_direct_dks_stage2_delegation_pending_markers(python_path: Path, detail: str = "") -> None:
+    print("error_stage=stage2_runtime", file=sys.stderr)
+    print("error_reason=drumsep_stage2_delegation_not_implemented", file=sys.stderr)
+    print(f"drumsep_runtime_python={python_path}", file=sys.stderr)
+    if detail:
+        print(f"detail={detail}", file=sys.stderr)
+    print("Direct Drum Kit Split runtime verified; stage2 delegation is not implemented in this slice.", file=sys.stderr)
+
+
 def _repository_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
@@ -1378,6 +1387,11 @@ def main():
             if write_done:
                 write_done("ERROR")
             return 1
+        _emit_direct_dks_stage2_delegation_pending_markers(drumsep_python, runtime_detail)
+        emit_phase("python_error")
+        if write_done:
+            write_done("ERROR")
+        return 1
         try:
             ok, requested_model, resolved_model, known_err = _direct_dks_preflight_check(run_model, model_cache_dir)
             if not ok:

--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 import importlib
 import importlib.util
 import json
+import hashlib
 import os
 import platform
 import re
@@ -21,8 +22,9 @@ import shutil
 import subprocess
 import sys
 import time
+import urllib.request
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 StemSeparator = None
 get_available_devices = None
@@ -33,6 +35,9 @@ _core_loaded = False
 
 MPS_UNSUPPORTED_MARKER = "STEMWERK_MPS_UNSUPPORTED_OP output_channels_gt_65536"
 MPS_FALLBACK_ENV = "PYTORCH_ENABLE_MPS_FALLBACK"
+DIRECT_DKS_MODEL_ALIAS = "MDX23C-DrumSep-aufr33-jarredou.ckpt"
+DIRECT_DKS_MODEL_FILENAME = "aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.ckpt"
+DIRECT_DKS_MODEL_ENTRY_NAME = "MDX23C Model: DrumSep 6stem | (by aufr33 & jarredou)"
 
 
 def _is_darwin_arm64() -> bool:
@@ -67,31 +72,149 @@ def _is_known_drumsep_model_missing_error(exc: Exception) -> bool:
     return "not found in supported model files" in text and "model file" in text
 
 
-def _emit_direct_dks_model_missing_markers(model_name: str) -> None:
+def _emit_direct_dks_preflight_markers(reason: str, requested_model: str, resolved_model: str = "", detail: str = "") -> None:
     print("error_stage=stage2_preflight", file=sys.stderr)
-    print("error_reason=drumsep_model_missing", file=sys.stderr)
-    print(f"requested_model={model_name}", file=sys.stderr)
-    print("Direct Drum Kit Split preflight failed: drumsep_model_missing", file=sys.stderr)
-    print(f"Requested model: {model_name}", file=sys.stderr)
+    print(f"error_reason={reason}", file=sys.stderr)
+    print(f"requested_model={requested_model}", file=sys.stderr)
+    if resolved_model:
+        print(f"resolved_model={resolved_model}", file=sys.stderr)
+    print(f"Direct Drum Kit Split preflight failed: {reason}", file=sys.stderr)
+    print(f"Requested model: {requested_model}", file=sys.stderr)
+    if resolved_model:
+        print(f"Resolved model: {resolved_model}", file=sys.stderr)
+    if detail:
+        print(f"Detail: {detail}", file=sys.stderr)
     print(
         "guidance=Update or repair runtime model catalog/audio-separator mapping for DrumSep and retry.",
         file=sys.stderr,
     )
 
 
-def _direct_dks_preflight_check(model_name: str) -> Tuple[bool, Optional[str]]:
+def _repository_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _find_repo_download_checks_path() -> Optional[Path]:
+    payload_root = _repository_root() / "installer" / "windows" / "payload"
+    if not payload_root.exists():
+        return None
+    candidates = sorted(
+        payload_root.glob("models-*-allmodels/download_checks.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if candidates:
+        return candidates[0]
+    fallback = sorted(payload_root.glob("models-*/download_checks.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+    return fallback[0] if fallback else None
+
+
+def _read_json_file(path: Path) -> Dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _resolve_direct_dks_model_catalog_entry(requested_model: str) -> Tuple[str, Dict[str, str], Optional[Path]]:
+    requested = str(requested_model or "").strip()
+    if requested and requested != DIRECT_DKS_MODEL_ALIAS and requested != DIRECT_DKS_MODEL_FILENAME:
+        return requested, {}, None
+    checks_path = _find_repo_download_checks_path()
+    if not checks_path or not checks_path.exists():
+        return requested or DIRECT_DKS_MODEL_FILENAME, {}, checks_path
+    data = _read_json_file(checks_path)
+    other_network = data.get("other_network_list_new", {}) or {}
+    entry = other_network.get(DIRECT_DKS_MODEL_ENTRY_NAME, {}) or {}
+    if not isinstance(entry, dict):
+        return requested or DIRECT_DKS_MODEL_FILENAME, {}, checks_path
+    normalized = {str(k): str(v) for k, v in entry.items() if str(v).strip()}
+    resolved = DIRECT_DKS_MODEL_FILENAME if DIRECT_DKS_MODEL_FILENAME in normalized else requested or DIRECT_DKS_MODEL_FILENAME
+    return resolved, normalized, checks_path
+
+
+def _ensure_runtime_download_checks_has_drumsep(model_cache_dir: Path, entry_name: str, entry_payload: Dict[str, str], source_checks_path: Optional[Path]) -> Tuple[bool, str]:
+    checks_path = model_cache_dir / "download_checks.json"
+    checks_data: Dict[str, Any]
+    try:
+        if checks_path.exists():
+            checks_data = _read_json_file(checks_path)
+        elif source_checks_path and source_checks_path.exists():
+            checks_data = _read_json_file(source_checks_path)
+        else:
+            return False, "runtime_download_checks_missing"
+    except Exception as exc:
+        return False, f"download_checks_read_failed:{exc}"
+
+    changed = False
+    mdx23c = checks_data.setdefault("mdx23c_download_list", {})
+    if not isinstance(mdx23c, dict):
+        return False, "mdx23c_download_list_invalid"
+    current = mdx23c.get(entry_name)
+    if current != entry_payload:
+        mdx23c[entry_name] = dict(entry_payload)
+        changed = True
+
+    if changed or not checks_path.exists():
+        try:
+            checks_path.parent.mkdir(parents=True, exist_ok=True)
+            checks_path.write_text(json.dumps(checks_data, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+        except Exception as exc:
+            return False, f"download_checks_write_failed:{exc}"
+    return True, str(checks_path)
+
+
+def _download_direct_dks_assets(model_cache_dir: Path, asset_map: Dict[str, str]) -> Tuple[bool, str]:
+    for filename, url in asset_map.items():
+        target = model_cache_dir / filename
+        if target.exists():
+            continue
+        if not url:
+            return False, f"asset_url_missing:{filename}"
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with urllib.request.urlopen(url, timeout=120) as response:
+                data = response.read()
+            tmp = target.with_suffix(target.suffix + ".part")
+            tmp.write_bytes(data)
+            tmp.replace(target)
+            if target.suffix.lower() == ".ckpt":
+                digest = hashlib.sha256(target.read_bytes()).hexdigest()
+                print(f"drumsep_cache_sha256={digest}", file=sys.stderr)
+            print(f"drumsep_cache_asset={target}", file=sys.stderr)
+        except Exception as exc:
+            return False, f"asset_download_failed:{filename}:{exc}"
+    return True, "ok"
+
+
+def _direct_dks_preflight_check(model_name: str, model_cache_dir: Path) -> Tuple[bool, str, str, Optional[str]]:
     # Force an explicit model-catalog lookup before normal workflow setup.
     # This prevents delayed failure in sep.separate()/load_model for known
     # unresolved DrumSep model names.
+    requested_model = str(model_name or "").strip()
+    resolved_model, asset_map, source_path = _resolve_direct_dks_model_catalog_entry(requested_model)
+    if not asset_map:
+        return False, requested_model, resolved_model, "catalog_entry_missing"
+    ok, check_detail = _ensure_runtime_download_checks_has_drumsep(
+        model_cache_dir,
+        DIRECT_DKS_MODEL_ENTRY_NAME,
+        asset_map,
+        source_path,
+    )
+    if not ok:
+        return False, requested_model, resolved_model, check_detail
+    print(f"requested_model={requested_model}", file=sys.stderr)
+    print(f"resolved_model={resolved_model}", file=sys.stderr)
+    print(f"catalog_source={source_path if source_path else 'none'}", file=sys.stderr)
+    dl_ok, dl_detail = _download_direct_dks_assets(model_cache_dir, asset_map)
+    if not dl_ok:
+        return False, requested_model, resolved_model, dl_detail
     try:
         from audio_separator.separator import Separator as AudioSeparator
 
-        sep = AudioSeparator(model_file_dir=str(_configure_model_cache_runtime()), output_dir=".")
-        sep.download_model_files(model_name)
-        return True, None
+        sep = AudioSeparator(model_file_dir=str(model_cache_dir), output_dir=".")
+        sep.download_model_files(resolved_model)
+        return True, requested_model, resolved_model, None
     except Exception as exc:
         if _is_known_drumsep_model_missing_error(exc):
-            return False, str(exc)
+            return False, requested_model, resolved_model, str(exc)
         raise
 
 
@@ -1103,18 +1226,17 @@ def main():
             file=sys.stderr,
         )
         try:
-            ok, known_err = _direct_dks_preflight_check(run_model)
+            ok, requested_model, resolved_model, known_err = _direct_dks_preflight_check(run_model, model_cache_dir)
             if not ok:
-                _emit_direct_dks_model_missing_markers(run_model)
-                if known_err:
-                    print(f"DETAIL: {known_err}", file=sys.stderr)
+                reason = "drumsep_model_missing" if "not found in supported model files" in str(known_err or "").lower() or "catalog_entry_missing" in str(known_err or "").lower() else "drumsep_model_download_failed"
+                _emit_direct_dks_preflight_markers(reason, requested_model or run_model, resolved_model or "", str(known_err or ""))
                 emit_phase("python_error")
                 if write_done:
                     write_done("ERROR")
                 return 1
+            run_model = resolved_model or run_model
         except Exception as exc:
-            _emit_direct_dks_model_missing_markers(run_model)
-            print(f"ERROR: {exc}", file=sys.stderr)
+            _emit_direct_dks_preflight_markers("drumsep_model_download_failed", run_model, "", str(exc))
             emit_phase("python_error")
             if write_done:
                 write_done("ERROR")

--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -44,6 +44,18 @@ def _is_demucs_model(model_name: Optional[str]) -> bool:
     return name.startswith("htdemucs") or name.startswith("hdemucs")
 
 
+def _is_direct_dks_mode(workflow_mode: Optional[str]) -> bool:
+    return str(workflow_mode or "").strip().lower() == "dks_direct"
+
+
+def _resolve_run_model(args: argparse.Namespace) -> str:
+    if _is_direct_dks_mode(getattr(args, "workflow_mode", "")):
+        requested = str(getattr(args, "requested_stage2_model", "") or "").strip()
+        if requested:
+            return requested
+    return str(getattr(args, "model", "htdemucs") or "htdemucs")
+
+
 def _enforce_mps_demucs_cpu_policy(requested_device: str, resolved_device: str, model_name: str) -> str:
     if resolved_device != "mps":
         return resolved_device
@@ -966,6 +978,10 @@ def main():
                         help="List available compute devices")
     parser.add_argument("--list-devices-machine", action="store_true",
                         help="List available devices in a machine-readable format (for REAPER UIs)")
+    parser.add_argument("--workflow-mode", default="",
+                        help="Optional workflow mode (e.g. dks_direct)")
+    parser.add_argument("--requested-stage2-model", default="",
+                        help="Optional stage2 model override for direct DKS")
 
     args = parser.parse_args()
 
@@ -1038,6 +1054,24 @@ def main():
         device_preference = "auto"
 
     stems = _split_list(args.stems)
+    run_model = _resolve_run_model(args)
+    if _is_direct_dks_mode(args.workflow_mode):
+        emit_phase("stage2_preflight")
+        try:
+            StemSeparator(model=run_model, device="cpu")
+        except Exception as exc:
+            print("error_stage=stage2_preflight", file=sys.stderr)
+            print("error_reason=drumsep_model_missing", file=sys.stderr)
+            print(f"requested_model={run_model}", file=sys.stderr)
+            print(
+                "guidance=Update or repair runtime model catalog/audio-separator mapping for DrumSep and retry.",
+                file=sys.stderr,
+            )
+            print(f"ERROR: {exc}", file=sys.stderr)
+            emit_phase("python_error")
+            if write_done:
+                write_done("ERROR")
+            return 1
 
     resolved_device = device_preference
     if device_preference == "auto":
@@ -1065,12 +1099,12 @@ def main():
         output_root = Path(args.output_dir).resolve()
         output_root.mkdir(parents=True, exist_ok=True)
         _enable_mps_runtime_fallback(device_preference, resolved_device)
-        resolved_device = _enforce_mps_demucs_cpu_policy(device_preference, resolved_device, args.model)
+        resolved_device = _enforce_mps_demucs_cpu_policy(device_preference, resolved_device, run_model)
         runtime_env = _emit_runtime_diagnostics(resolved_device)
-        _enable_torch_weights_only_compat(args.model, resolved_device)
+        _enable_torch_weights_only_compat(run_model, resolved_device)
 
         emit_phase("model_setup_start")
-        sep = StemSeparator(model=args.model, device=resolved_device)
+        sep = StemSeparator(model=run_model, device=resolved_device)
         emit_phase("model_setup_end")
 
         def reaper_progress(pct: float, msg: str):
@@ -1149,7 +1183,7 @@ def main():
             traceback_text,
             device_preference,
             resolved_device,
-            args.model,
+            run_model,
             runtime_env,
         )
         if failure:

--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -113,21 +113,49 @@ def _read_json_file(path: Path) -> Dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def _resolve_direct_dks_model_catalog_entry(requested_model: str) -> Tuple[str, Dict[str, str], Optional[Path]]:
+def _runtime_download_checks_path(model_cache_dir: Path) -> Path:
+    return model_cache_dir / "download_checks.json"
+
+
+def _resolve_direct_dks_model_catalog_entry(requested_model: str, model_cache_dir: Path) -> Tuple[str, Dict[str, str], Optional[Path], List[str], str]:
     requested = str(requested_model or "").strip()
     if requested and requested != DIRECT_DKS_MODEL_ALIAS and requested != DIRECT_DKS_MODEL_FILENAME:
-        return requested, {}, None
-    checks_path = _find_repo_download_checks_path()
-    if not checks_path or not checks_path.exists():
-        return requested or DIRECT_DKS_MODEL_FILENAME, {}, checks_path
-    data = _read_json_file(checks_path)
-    other_network = data.get("other_network_list_new", {}) or {}
-    entry = other_network.get(DIRECT_DKS_MODEL_ENTRY_NAME, {}) or {}
-    if not isinstance(entry, dict):
-        return requested or DIRECT_DKS_MODEL_FILENAME, {}, checks_path
-    normalized = {str(k): str(v) for k, v in entry.items() if str(v).strip()}
-    resolved = DIRECT_DKS_MODEL_FILENAME if DIRECT_DKS_MODEL_FILENAME in normalized else requested or DIRECT_DKS_MODEL_FILENAME
-    return resolved, normalized, checks_path
+        return requested, {}, None, [], "unsupported_requested_model"
+
+    resolved_default = DIRECT_DKS_MODEL_FILENAME
+    checked_paths: List[str] = []
+    candidate_paths: List[Path] = []
+    runtime_checks = _runtime_download_checks_path(model_cache_dir)
+    candidate_paths.append(runtime_checks)
+    repo_checks = _find_repo_download_checks_path()
+    if repo_checks:
+        candidate_paths.append(repo_checks)
+
+    seen: Set[str] = set()
+    for path in candidate_paths:
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        checked_paths.append(key + (" [exists]" if path.exists() else " [missing]"))
+        if not path.exists():
+            continue
+        try:
+            data = _read_json_file(path)
+        except Exception:
+            continue
+        other_network = data.get("other_network_list_new", {}) or {}
+        if not isinstance(other_network, dict):
+            continue
+        entry = other_network.get(DIRECT_DKS_MODEL_ENTRY_NAME, {}) or {}
+        if not isinstance(entry, dict):
+            continue
+        normalized = {str(k): str(v) for k, v in entry.items() if str(v).strip()}
+        if not normalized:
+            return resolved_default, {}, path, checked_paths, "catalog_entry_empty"
+        return resolved_default, normalized, path, checked_paths, "ok"
+
+    return resolved_default, {}, None, checked_paths, "catalog_entry_missing"
 
 
 def _ensure_runtime_download_checks_has_drumsep(model_cache_dir: Path, entry_name: str, entry_payload: Dict[str, str], source_checks_path: Optional[Path]) -> Tuple[bool, str]:
@@ -189,9 +217,15 @@ def _direct_dks_preflight_check(model_name: str, model_cache_dir: Path) -> Tuple
     # This prevents delayed failure in sep.separate()/load_model for known
     # unresolved DrumSep model names.
     requested_model = str(model_name or "").strip()
-    resolved_model, asset_map, source_path = _resolve_direct_dks_model_catalog_entry(requested_model)
+    resolved_model, asset_map, source_path, checked_paths, lookup_status = _resolve_direct_dks_model_catalog_entry(
+        requested_model,
+        model_cache_dir,
+    )
+    if checked_paths:
+        print("catalog_paths_checked=" + " | ".join(checked_paths), file=sys.stderr)
+    print(f"catalog_lookup_status={lookup_status}", file=sys.stderr)
     if not asset_map:
-        return False, requested_model, resolved_model, "catalog_entry_missing"
+        return False, requested_model, resolved_model, lookup_status
     ok, check_detail = _ensure_runtime_download_checks_has_drumsep(
         model_cache_dir,
         DIRECT_DKS_MODEL_ENTRY_NAME,
@@ -1228,7 +1262,13 @@ def main():
         try:
             ok, requested_model, resolved_model, known_err = _direct_dks_preflight_check(run_model, model_cache_dir)
             if not ok:
-                reason = "drumsep_model_missing" if "not found in supported model files" in str(known_err or "").lower() or "catalog_entry_missing" in str(known_err or "").lower() else "drumsep_model_download_failed"
+                known_err_text = str(known_err or "").lower()
+                reason = (
+                    "drumsep_model_missing"
+                    if "not found in supported model files" in known_err_text
+                    or known_err_text.startswith("catalog_")
+                    else "drumsep_model_download_failed"
+                )
                 _emit_direct_dks_preflight_markers(reason, requested_model or run_model, resolved_model or "", str(known_err or ""))
                 emit_phase("python_error")
                 if write_done:

--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -38,6 +38,8 @@ MPS_FALLBACK_ENV = "PYTORCH_ENABLE_MPS_FALLBACK"
 DIRECT_DKS_MODEL_ALIAS = "MDX23C-DrumSep-aufr33-jarredou.ckpt"
 DIRECT_DKS_MODEL_FILENAME = "aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.ckpt"
 DIRECT_DKS_MODEL_ENTRY_NAME = "MDX23C Model: DrumSep 6stem | (by aufr33 & jarredou)"
+DRUMSEP_RUNTIME_DIRNAME = ".venv-drumsep"
+DRUMSEP_RUNTIME_GUIDANCE = "Run Setup/Repair Drum Kit Split runtime."
 
 
 def _is_darwin_arm64() -> bool:
@@ -114,6 +116,20 @@ def _emit_direct_dks_runtime_unsupported_markers(requested_model: str, resolved_
         print(f"Resolved model: {resolved_model}", file=sys.stderr)
     if detail:
         print(f"Detail: {detail}", file=sys.stderr)
+
+
+def _emit_direct_dks_stage2_runtime_markers(reason: str, python_path: Path, detail: str = "") -> None:
+    print("error_stage=stage2_runtime", file=sys.stderr)
+    print(f"error_reason={reason}", file=sys.stderr)
+    print(f"drumsep_runtime_python={python_path}", file=sys.stderr)
+    if detail:
+        print(f"detail={detail}", file=sys.stderr)
+    print(f"guidance={DRUMSEP_RUNTIME_GUIDANCE}", file=sys.stderr)
+    if reason == "drumsep_runtime_missing":
+        print("Direct Drum Kit Split runtime is not installed.", file=sys.stderr)
+    else:
+        print("Direct Drum Kit Split runtime is broken.", file=sys.stderr)
+    print(DRUMSEP_RUNTIME_GUIDANCE, file=sys.stderr)
 
 
 def _repository_root() -> Path:
@@ -439,6 +455,73 @@ def _runtime_base_candidates() -> List[Path]:
         add(Path.home() / ".local" / "share" / "STEMwerk")
 
     return candidates
+
+
+def _drumsep_runtime_python_path(runtime_base: Optional[Path] = None) -> Path:
+    base = runtime_base or (_runtime_base_candidates()[0] if _runtime_base_candidates() else Path.home() / ".local" / "share" / "STEMwerk")
+    runtime_dir = base / DRUMSEP_RUNTIME_DIRNAME
+    if os.name == "nt":
+        return runtime_dir / "Scripts" / "python.exe"
+    return runtime_dir / "bin" / "python"
+
+
+def _verify_drumsep_runtime(python_path: Path) -> Tuple[bool, str]:
+    try:
+        exists = python_path.exists()
+    except Exception:
+        exists = False
+    if not exists:
+        return False, "missing"
+    if not os.access(str(python_path), os.X_OK):
+        return False, "not_executable"
+
+    verify_code = r"""
+import importlib
+import importlib.metadata as metadata
+import json
+import sys
+
+required = ["audio_separator", "numpy", "torch", "onnx", "onnxruntime"]
+optional = ["onnx2torch"]
+versions = {}
+
+for module_name in required:
+    try:
+        importlib.import_module(module_name)
+    except Exception as exc:
+        print(json.dumps({"ok": False, "module": module_name, "error": f"{type(exc).__name__}: {exc}"}))
+        sys.exit(1)
+
+for dist_name in ["audio-separator", "numpy", "torch", "onnx", "onnxruntime", "onnx2torch", "onnx2torch-py313"]:
+    try:
+        versions[dist_name] = metadata.version(dist_name)
+    except Exception:
+        versions[dist_name] = ""
+
+for module_name in optional:
+    try:
+        importlib.import_module(module_name)
+    except Exception as exc:
+        versions[module_name + "_import_error"] = f"{type(exc).__name__}: {exc}"
+
+print(json.dumps({"ok": True, "versions": versions}, sort_keys=True))
+"""
+    try:
+        completed = subprocess.run(
+            [str(python_path), "-c", verify_code],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=30,
+            **_windows_no_window_kwargs(),
+        )
+    except Exception as exc:
+        return False, f"verify_spawn_failed:{type(exc).__name__}:{exc}"
+
+    output = " ".join(part.strip() for part in (completed.stdout, completed.stderr) if part and part.strip())
+    if completed.returncode != 0:
+        return False, output[:1200] or f"verify_exit_{completed.returncode}"
+    return True, output[:1200] or "ok"
 
 
 def _prepend_path(path_value: str) -> None:
@@ -1286,6 +1369,15 @@ def main():
             f"Direct Drum Kit Split route detected: workflow_mode={args.workflow_mode} workflow_source={args.workflow_source}",
             file=sys.stderr,
         )
+        drumsep_python = _drumsep_runtime_python_path()
+        runtime_ok, runtime_detail = _verify_drumsep_runtime(drumsep_python)
+        if not runtime_ok:
+            reason = "drumsep_runtime_missing" if runtime_detail == "missing" else "drumsep_runtime_broken"
+            _emit_direct_dks_stage2_runtime_markers(reason, drumsep_python, runtime_detail)
+            emit_phase("python_error")
+            if write_done:
+                write_done("ERROR")
+            return 1
         try:
             ok, requested_model, resolved_model, known_err = _direct_dks_preflight_check(run_model, model_cache_dir)
             if not ok:

--- a/tests/support/run_support_bundle_headless.lua
+++ b/tests/support/run_support_bundle_headless.lua
@@ -622,6 +622,7 @@ local function assertPresentScenario(bundleDir, context)
     assertf(fileExists(joinPath(bundleDir, "diagnostics.txt")), "diagnostics.txt missing")
     assertf(fileExists(joinPath(bundleDir, "platform_details.txt")), "platform_details.txt missing")
     assertf(fileExists(joinPath(bundleDir, "python_diagnostics.txt")), "python_diagnostics.txt missing")
+    assertf(fileExists(joinPath(bundleDir, "drumsep_runtime_status.txt")), "drumsep_runtime_status.txt missing")
     assertf(fileExists(joinPath(bundleDir, "temp_inventory.txt")), "temp_inventory.txt missing")
     assertf(fileExists(joinPath(bundleDir, "runtime_state", "bootstrap.env")), "bootstrap.env not copied")
     assertf(fileExists(joinPath(bundleDir, "runtime_state", "capabilities.env")), "capabilities.env not copied")
@@ -631,6 +632,7 @@ local function assertPresentScenario(bundleDir, context)
 
     local diagnostics = readFile(joinPath(bundleDir, "diagnostics.txt")) or ""
     local pythonDiagnostics = readFile(joinPath(bundleDir, "python_diagnostics.txt")) or ""
+    local drumsepDiagnostics = readFile(joinPath(bundleDir, "drumsep_runtime_status.txt")) or ""
     local tempInventory = readFile(joinPath(bundleDir, "temp_inventory.txt")) or ""
     local allText = readBundleText(bundleDir)
 
@@ -645,6 +647,9 @@ local function assertPresentScenario(bundleDir, context)
         assertf(diagnostics:find("FFmpeg version", 1, true) ~= nil and diagnostics:find("ffmpeg version 7.0-fake", 1, true) ~= nil, "diagnostics missing FFmpeg version")
     end
     assertf(trim(pythonDiagnostics) ~= "", "python_diagnostics.txt is empty")
+    assertf(drumsepDiagnostics:find("DrumSep Runtime Diagnostics", 1, true) ~= nil, "drumsep runtime diagnostics missing header")
+    assertf(drumsepDiagnostics:find("[CPU fallback runtime]", 1, true) ~= nil, "drumsep runtime diagnostics missing CPU section")
+    assertf(drumsepDiagnostics:find("[ROCm runtime]", 1, true) ~= nil, "drumsep runtime diagnostics missing ROCm section")
     if IS_WINDOWS then
         assertf(pythonDiagnostics:find("Python diagnostics skipped for speed.", 1, true) ~= nil,
             "Windows python diagnostics missing skip payload")
@@ -669,10 +674,12 @@ local function assertMissingScenario(bundleDir)
     assertf(fileExists(joinPath(bundleDir, "diagnostics.txt")), "diagnostics.txt missing")
     assertf(fileExists(joinPath(bundleDir, "platform_details.txt")), "platform_details.txt missing")
     assertf(fileExists(joinPath(bundleDir, "python_diagnostics.txt")), "python_diagnostics.txt missing")
+    assertf(fileExists(joinPath(bundleDir, "drumsep_runtime_status.txt")), "drumsep_runtime_status.txt missing")
     assertf(fileExists(joinPath(bundleDir, "temp_inventory.txt")), "temp_inventory.txt missing")
 
     local diagnostics = readFile(joinPath(bundleDir, "diagnostics.txt")) or ""
     local pythonDiagnostics = readFile(joinPath(bundleDir, "python_diagnostics.txt")) or ""
+    local drumsepDiagnostics = readFile(joinPath(bundleDir, "drumsep_runtime_status.txt")) or ""
 
     assertf(diagnostics:find("Python path", 1, true) ~= nil and diagnostics:find("missing", 1, true) ~= nil, "missing scenario did not report missing Python path")
     assertf(diagnostics:find("FFmpeg path", 1, true) ~= nil and diagnostics:find("missing", 1, true) ~= nil, "missing scenario did not report missing FFmpeg path")
@@ -685,6 +692,7 @@ local function assertMissingScenario(bundleDir)
         assertf(pythonDiagnostics:find("no Python path detected", 1, true) ~= nil or pythonDiagnostics:find("missing", 1, true) ~= nil,
             "missing scenario python diagnostics did not explain the failure")
     end
+    assertf(drumsepDiagnostics:find("DrumSep Runtime Diagnostics", 1, true) ~= nil, "missing scenario drumsep diagnostics missing header")
 
     assertNoForbiddenFiles(bundleDir)
     assertMaxFileSize(bundleDir, 1024 * 1024)

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -1441,9 +1441,14 @@ def test_drumkit_direct_dks_mode_wires_stage2_preflight_markers():
     assert 'parser.add_argument("--requested-stage2-model", default=""' in script
     assert "if _is_direct_dks_source(args.workflow_mode, args.workflow_source):" in script
     assert 'emit_phase("stage2_preflight")' in script
+    assert "def _direct_dks_preflight_check(model_name: str) -> Tuple[bool, Optional[str]]:" in script
+    assert "loader = getattr(getattr(sep, \"separator\", None), \"load_model\", None)" in script
     assert 'print("error_stage=stage2_preflight", file=sys.stderr)' in script
     assert 'print("error_reason=drumsep_model_missing", file=sys.stderr)' in script
-    assert 'print(f"requested_model={run_model}", file=sys.stderr)' in script
+    assert 'print(f"requested_model={model_name}", file=sys.stderr)' in script
+    assert 'print("Direct Drum Kit Split preflight failed: drumsep_model_missing", file=sys.stderr)' in script
+    assert "if not ok:" in script
+    assert 'emit_phase("model_setup_start")' in script
 
 
 def test_drumkit_direct_dks_mode_wires_lua_launch_and_failure_mapping():
@@ -1455,6 +1460,8 @@ def test_drumkit_direct_dks_mode_wires_lua_launch_and_failure_mapping():
     assert 'if (not trustedWindowsRuntime) and (not isDirectDKS) and (not ensureDependenciesInteractive()) then' in main_script
     assert "error_stage=stage2_preflight" in main_script
     assert "error_reason=drumsep_model_missing" in main_script
+    assert "not found in supported model files" in main_script
+    assert "workflow%-source" in main_script
     assert 'WORKFLOW.runSeparationWithProgress(WORKFLOW_TEMP_INPUT, WORKFLOW_TEMP_DIR, workflowModel, runOptions)' in main_script
     assert 'pythonCmd = pythonCmd .. " --workflow-mode " .. C.quoteArg(workflowModeArg)' in workflow_script
     assert 'pythonCmd = pythonCmd .. " --workflow-source " .. C.quoteArg(workflowSourceArg)' in workflow_script

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -1471,20 +1471,24 @@ def test_drumkit_direct_dks_mode_wires_stage2_preflight_markers():
     assert "Direct Drum Kit Split route detected: workflow_mode=" in script
     assert "workflow_source=" in script
     assert "DRUMSEP_RUNTIME_DIRNAME = \".venv-drumsep\"" in script
+    assert "DRUMSEP_RUNTIME_ROCM_DIRNAME = \".venv-drumsep-rocm\"" in script
     assert "DRUMSEP_RUNTIME_GUIDANCE = \"Run Setup/Repair Drum Kit Split runtime.\"" in script
     assert "def _drumsep_runtime_python_path(" in script
+    assert "def _drumsep_rocm_runtime_python_path(" in script
     assert "def _verify_drumsep_runtime(" in script
+    assert "def _select_drumsep_runtime(" in script
     assert "def _run_direct_dks_drumsep_helper(" in script
     assert "stemwerk_drumsep_process.py" in script
-    assert "drumsep_python = _drumsep_runtime_python_path()" in script
-    assert "runtime_ok, runtime_detail = _verify_drumsep_runtime(drumsep_python)" in script
-    assert "reason = \"drumsep_runtime_missing\" if runtime_detail == \"missing\" else \"drumsep_runtime_broken\"" in script
-    assert "_emit_direct_dks_stage2_runtime_markers(reason, drumsep_python, runtime_detail)" in script
+    assert "drumsep_python, runtime_kind, runtime_info = _select_drumsep_runtime()" in script
+    assert "reason = \"drumsep_runtime_missing\" if runtime_kind == \"missing\" else \"drumsep_runtime_broken\"" in script
+    assert "_emit_direct_dks_stage2_runtime_markers(reason, runtime_path, json.dumps(runtime_info, sort_keys=True))" in script
+    assert "drumsep_runtime_selected=" in script
+    assert "drumsep_runtime_fallback_reason=" in script
     assert "helper_ok, helper_stems, helper_reason, helper_detail = _run_direct_dks_drumsep_helper(" in script
     assert "drumsep_helper_python=" in script
     assert "drumsep_helper_ok=true" in script
     assert "_direct_dks_preflight_check(run_model, model_cache_dir)" in script
-    assert script.index("runtime_ok, runtime_detail = _verify_drumsep_runtime(drumsep_python)") < script.index("_direct_dks_preflight_check(run_model, model_cache_dir)")
+    assert script.index("drumsep_python, runtime_kind, runtime_info = _select_drumsep_runtime()") < script.index("_direct_dks_preflight_check(run_model, model_cache_dir)")
     assert script.index("_direct_dks_preflight_check(run_model, model_cache_dir)") < script.index("helper_ok, helper_stems, helper_reason, helper_detail = _run_direct_dks_drumsep_helper(")
     assert 'print("error_stage=stage2_preflight", file=sys.stderr)' in script
     assert 'print(f"error_reason={reason}", file=sys.stderr)' in script
@@ -1501,7 +1505,7 @@ def test_drumsep_runtime_missing_is_detected_before_stage2_model_load(tmp_path, 
     module = _load_audio_separator_process_module()
     missing_python = tmp_path / ".venv-drumsep" / "bin" / "python"
 
-    ok, detail = module._verify_drumsep_runtime(missing_python)
+    ok, detail, _payload = module._verify_drumsep_runtime(missing_python)
     module._emit_direct_dks_stage2_runtime_markers("drumsep_runtime_missing", missing_python, detail)
 
     captured = capsys.readouterr()
@@ -1520,10 +1524,67 @@ def test_drumsep_runtime_broken_reports_import_error(tmp_path):
     runtime_python.write_text("#!/bin/sh\necho 'ImportError: audio_separator missing' >&2\nexit 1\n", encoding="utf-8")
     runtime_python.chmod(0o755)
 
-    ok, detail = module._verify_drumsep_runtime(runtime_python)
+    ok, detail, _payload = module._verify_drumsep_runtime(runtime_python)
 
     assert ok is False
     assert "ImportError: audio_separator missing" in detail
+
+
+def test_drumsep_runtime_selector_prefers_rocm_when_gpu_capable(tmp_path):
+    module = _load_audio_separator_process_module()
+    base = tmp_path
+    rocm_python = base / ".venv-drumsep-rocm" / "bin" / "python"
+    cpu_python = base / ".venv-drumsep" / "bin" / "python"
+    rocm_python.parent.mkdir(parents=True, exist_ok=True)
+    cpu_python.parent.mkdir(parents=True, exist_ok=True)
+    rocm_python.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    cpu_python.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    rocm_python.chmod(0o755)
+    cpu_python.chmod(0o755)
+
+    def fake_verify(path, require_gpu=False):
+        if "drumsep-rocm" in str(path):
+            return (True, "ok", {"versions": {"torch": "2.9.1+rocm6.4"}, "torch_hip": "6.4", "device_names": ["AMD Radeon RX 9070"]})
+        return (True, "ok", {"versions": {"torch": "2.12.0+cu130"}, "torch_hip": "", "device_names": []})
+
+    module._verify_drumsep_runtime = fake_verify
+    selected, kind, info = module._select_drumsep_runtime(base)
+    assert selected == rocm_python
+    assert kind == "rocm"
+    assert info["torch_hip"] == "6.4"
+
+
+def test_drumsep_runtime_selector_falls_back_to_cpu_when_rocm_invalid(tmp_path):
+    module = _load_audio_separator_process_module()
+    base = tmp_path
+    rocm_python = base / ".venv-drumsep-rocm" / "bin" / "python"
+    cpu_python = base / ".venv-drumsep" / "bin" / "python"
+    rocm_python.parent.mkdir(parents=True, exist_ok=True)
+    cpu_python.parent.mkdir(parents=True, exist_ok=True)
+    rocm_python.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    cpu_python.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    rocm_python.chmod(0o755)
+    cpu_python.chmod(0o755)
+
+    def fake_verify(path, require_gpu=False):
+        if "drumsep-rocm" in str(path):
+            return (False, "rocm_no_hip", {})
+        return (True, "ok", {"versions": {"torch": "2.12.0+cu130"}, "torch_hip": "", "device_names": []})
+
+    module._verify_drumsep_runtime = fake_verify
+    selected, kind, info = module._select_drumsep_runtime(base)
+    assert selected == cpu_python
+    assert kind == "cpu"
+    assert info["fallback_reason"] == "rocm_skipped:rocm_no_hip"
+
+
+def test_drumsep_runtime_selector_reports_missing_when_both_absent(tmp_path):
+    module = _load_audio_separator_process_module()
+    selected, kind, info = module._select_drumsep_runtime(tmp_path)
+    assert selected is None
+    assert kind == "missing"
+    assert info["rocm_detail"] == "missing"
+    assert info["cpu_detail"] == "missing"
 
 
 def test_normal_stem_workflows_do_not_reference_drumsep_runtime():
@@ -1532,9 +1593,9 @@ def test_normal_stem_workflows_do_not_reference_drumsep_runtime():
     assert marker in script
     _, after_direct_dks = script.split(marker, 1)
 
-    assert "_verify_drumsep_runtime(" in after_direct_dks
-    assert after_direct_dks.index("_verify_drumsep_runtime(") < after_direct_dks.index("_direct_dks_preflight_check(run_model, model_cache_dir)")
-    assert after_direct_dks.index("_verify_drumsep_runtime(") < after_direct_dks.index('emit_phase("model_setup_start")')
+    assert "_select_drumsep_runtime(" in after_direct_dks
+    assert after_direct_dks.index("_select_drumsep_runtime(") < after_direct_dks.index("_direct_dks_preflight_check(run_model, model_cache_dir)")
+    assert after_direct_dks.index("_select_drumsep_runtime(") < after_direct_dks.index('emit_phase("model_setup_start")')
     assert after_direct_dks.index("helper_ok, helper_stems, helper_reason, helper_detail = _run_direct_dks_drumsep_helper(") < after_direct_dks.index('emit_phase("model_setup_start")')
     assert "_enable_torch_weights_only_compat(run_model, resolved_device)" in script
 
@@ -1679,6 +1740,8 @@ def test_direct_dks_helper_invocation_uses_optional_runtime_not_main_runtime():
     script = Path("scripts/reaper/audio_separator_process.py").read_text()
 
     assert 'DRUMSEP_RUNTIME_DIRNAME = ".venv-drumsep"' in script
+    assert 'DRUMSEP_RUNTIME_ROCM_DIRNAME = ".venv-drumsep-rocm"' in script
+    assert "drumsep_runtime_selected=" in script
     assert 'str(drumsep_python),' in script
     assert '"--result-json",' in script
     assert 'drumsep_helper_stdout.txt' in script

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -1474,10 +1474,12 @@ def test_drumkit_direct_dks_mode_wires_stage2_preflight_markers():
     assert "DRUMSEP_RUNTIME_GUIDANCE = \"Run Setup/Repair Drum Kit Split runtime.\"" in script
     assert "def _drumsep_runtime_python_path(" in script
     assert "def _verify_drumsep_runtime(" in script
+    assert "def _emit_direct_dks_stage2_delegation_pending_markers(" in script
     assert "drumsep_python = _drumsep_runtime_python_path()" in script
     assert "runtime_ok, runtime_detail = _verify_drumsep_runtime(drumsep_python)" in script
     assert "reason = \"drumsep_runtime_missing\" if runtime_detail == \"missing\" else \"drumsep_runtime_broken\"" in script
     assert "_emit_direct_dks_stage2_runtime_markers(reason, drumsep_python, runtime_detail)" in script
+    assert "_emit_direct_dks_stage2_delegation_pending_markers(drumsep_python, runtime_detail)" in script
     assert "_direct_dks_preflight_check(run_model, model_cache_dir)" in script
     assert script.index("runtime_ok, runtime_detail = _verify_drumsep_runtime(drumsep_python)") < script.index("_direct_dks_preflight_check(run_model, model_cache_dir)")
     assert 'print("error_stage=stage2_preflight", file=sys.stderr)' in script
@@ -1529,6 +1531,7 @@ def test_normal_stem_workflows_do_not_reference_drumsep_runtime():
     assert "_verify_drumsep_runtime(" in after_direct_dks
     assert after_direct_dks.index("_verify_drumsep_runtime(") < after_direct_dks.index("_direct_dks_preflight_check(run_model, model_cache_dir)")
     assert after_direct_dks.index("_verify_drumsep_runtime(") < after_direct_dks.index('emit_phase("model_setup_start")')
+    assert after_direct_dks.index("_emit_direct_dks_stage2_delegation_pending_markers") < after_direct_dks.index("_direct_dks_preflight_check(run_model, model_cache_dir)")
     assert "_enable_torch_weights_only_compat(run_model, resolved_device)" in script
 
 
@@ -1545,6 +1548,7 @@ def test_drumkit_direct_dks_mode_wires_lua_launch_and_failure_mapping():
     assert "error_stage=stage2_runtime" in main_script
     assert "error_reason=drumsep_runtime_missing" in main_script
     assert "error_reason=drumsep_runtime_broken" in main_script
+    assert "error_reason=drumsep_stage2_delegation_not_implemented" in main_script
     assert "Run Setup/Repair Drum Kit Split runtime." in main_script
     assert "error_stage=stage2_model_load" in main_script
     assert "error_reason=drumsep_model_runtime_unsupported" in main_script
@@ -1557,6 +1561,63 @@ def test_drumkit_direct_dks_mode_wires_lua_launch_and_failure_mapping():
     assert 'M.WORKFLOW_DRUMKIT = "drumkit"' in dks_script
     assert 'M.SOURCE_DIRECT = "dks_direct"' in dks_script
     assert 'M.DIRECT_DKS_MODEL = "MDX23C-DrumSep-aufr33-jarredou.ckpt"' in dks_script
+
+
+def test_linux_drumsep_runtime_installer_is_isolated_and_pinned():
+    script = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
+
+    assert 'DRUMSEP_AUDIO_SEPARATOR_VERSION="0.34.1"' in script
+    assert 'DRUMSEP_NUMPY_VERSION="2.4.6"' in script
+    assert 'DRUMSEP_ONNXRUNTIME_VERSION="1.26.0"' in script
+    assert 'DRUMSEP_ONNX_VERSION="1.21.0"' in script
+    assert 'DRUMSEP_ONNX2TORCH_VERSION="1.5.15"' in script
+    assert 'DRUMSEP_ONNX2TORCH_PY313_VERSION="1.6.0"' in script
+    assert 'DRUMSEP_TORCH_VERSION="2.12.0"' in script
+    assert 'DRUMSEP_TORCHVISION_VERSION="0.27.0"' in script
+    assert 'DRUMSEP_NUMBA_VERSION="0.65.1"' in script
+    assert 'printf "%s/.venv-drumsep/bin/python\\n" "${RUNTIME_BASE}"' in script
+    assert '"${PYTHON}" -m venv "${RUNTIME_BASE}/.venv-drumsep"' in script
+    assert '"${_drumsep_py}" -m pip install' in script
+    assert '"audio-separator==${DRUMSEP_AUDIO_SEPARATOR_VERSION}"' in script
+    assert '"numpy==${DRUMSEP_NUMPY_VERSION}"' in script
+    assert '"torch==${DRUMSEP_TORCH_VERSION}"' in script
+    assert "create_venv_with_selected_python" in script
+    assert script.index('if [ "${MODE}" = "drumsep-runtime" ]; then') < script.index('log_stage "Creating venv"')
+
+
+def test_linux_drumsep_runtime_state_fields_are_written():
+    script = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
+
+    for field in (
+        "DRUMSEP_RUNTIME_STATUS=",
+        "DRUMSEP_PYTHON=",
+        "DRUMSEP_AUDIO_SEPARATOR_VERSION=",
+        "DRUMSEP_NUMPY_VERSION=",
+        "DRUMSEP_TORCH_VERSION=",
+        "DRUMSEP_ONNX_VERSION=",
+        "DRUMSEP_ONNXRUNTIME_VERSION=",
+        "DRUMSEP_ONNX2TORCH_VERSION=",
+        "DRUMSEP_LAST_CHECK_UTC=",
+        "DRUMSEP_MODEL_STATUS=",
+        "DRUMSEP_MODEL_FILE=",
+        "DRUMSEP_MODEL_YAML=",
+    ):
+        assert field in script
+    assert 'printf "%s/state/drumsep_runtime.env\\n" "${RUNTIME_BASE}"' in script
+    assert 'printf "%s/logs/drumsep_install.log\\n" "${RUNTIME_BASE}"' in script
+
+
+def test_linux_setup_exposes_explicit_drumsep_runtime_action_without_normal_setup_autoinstall():
+    setup_internal = Path("scripts/reaper/_internal/STEMwerk_Setup_Internal.lua").read_text()
+    linux_bootstrap = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
+
+    assert 'mode ~= "repair" and mode ~= "rebuild-venv" and mode ~= "drumsep-runtime"' in setup_internal
+    assert 'isDrumsepRuntime and "drumsep_runtime.env" or "bootstrap.env"' in setup_internal
+    assert 'isDrumsepRuntime and "drumsep_install.log" or "bootstrap.log"' in setup_internal
+    assert '{ id = "drumsep-runtime", label = "Drum Kit Split runtime"' in setup_internal
+    assert 'startLinuxSetup(runtime, separatorScript, chosen)' in setup_internal
+    assert 'if [ "${MODE}" = "drumsep-runtime" ]; then' in linux_bootstrap
+    assert 'write_drumsep_state "install_failed" "missing" "python_missing"' in linux_bootstrap
 
 
 def test_drumkit_wrapper_selects_integrated_mode_and_direct_source():

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -1451,6 +1451,11 @@ def test_drumkit_direct_dks_mode_wires_stage2_preflight_markers():
     assert "def _ensure_runtime_download_checks_has_drumsep(" in script
     assert "mdx23c_download_list" in script
     assert "def _download_direct_dks_assets(" in script
+    assert "def _is_known_drumsep_runtime_unsupported_error(exc: Exception, traceback_text: str, model_name: str) -> bool:" in script
+    assert "def _emit_direct_dks_runtime_unsupported_markers(" in script
+    assert 'print("error_stage=stage2_model_load", file=sys.stderr)' in script
+    assert 'print("error_reason=drumsep_model_runtime_unsupported", file=sys.stderr)' in script
+    assert "audio_separator mdxc loader missing expected config field 'model'" in script
     assert "sep.download_model_files(resolved_model)" in script
     assert "resolved_model=" in script
     assert "Direct Drum Kit Split route detected: workflow_mode=" in script
@@ -1476,6 +1481,8 @@ def test_drumkit_direct_dks_mode_wires_lua_launch_and_failure_mapping():
     assert "error_stage=stage2_preflight" in main_script
     assert "error_reason=drumsep_model_missing" in main_script
     assert "error_reason=drumsep_model_download_failed" in main_script
+    assert "error_stage=stage2_model_load" in main_script
+    assert "error_reason=drumsep_model_runtime_unsupported" in main_script
     assert "not found in supported model files" in main_script
     assert "workflow%-source" in main_script
     assert 'WORKFLOW.runSeparationWithProgress(WORKFLOW_TEMP_INPUT, WORKFLOW_TEMP_DIR, workflowModel, runOptions)' in main_script

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -1,5 +1,6 @@
 """Regression smoke for the v2.2.2.1 macOS/Linux torch pin hotfix."""
 
+import importlib.util
 import json
 import platform
 import subprocess
@@ -15,6 +16,15 @@ EXPECTED_TORCH = "2.5.1"
 EXPECTED_TORCHVISION = "0.20.1"
 EXPECTED_TORCHAUDIO = "2.5.1"
 EXPECTED_AUDIO_SEPARATOR = "0.23.0"
+
+
+def _load_audio_separator_process_module():
+    path = Path("scripts/reaper/audio_separator_process.py")
+    spec = importlib.util.spec_from_file_location("audio_separator_process_dependency_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
 
 
 def _service_line_torch_runtime_status(torch_version, torchaudio_version="2.5.1"):
@@ -1460,6 +1470,16 @@ def test_drumkit_direct_dks_mode_wires_stage2_preflight_markers():
     assert "resolved_model=" in script
     assert "Direct Drum Kit Split route detected: workflow_mode=" in script
     assert "workflow_source=" in script
+    assert "DRUMSEP_RUNTIME_DIRNAME = \".venv-drumsep\"" in script
+    assert "DRUMSEP_RUNTIME_GUIDANCE = \"Run Setup/Repair Drum Kit Split runtime.\"" in script
+    assert "def _drumsep_runtime_python_path(" in script
+    assert "def _verify_drumsep_runtime(" in script
+    assert "drumsep_python = _drumsep_runtime_python_path()" in script
+    assert "runtime_ok, runtime_detail = _verify_drumsep_runtime(drumsep_python)" in script
+    assert "reason = \"drumsep_runtime_missing\" if runtime_detail == \"missing\" else \"drumsep_runtime_broken\"" in script
+    assert "_emit_direct_dks_stage2_runtime_markers(reason, drumsep_python, runtime_detail)" in script
+    assert "_direct_dks_preflight_check(run_model, model_cache_dir)" in script
+    assert script.index("runtime_ok, runtime_detail = _verify_drumsep_runtime(drumsep_python)") < script.index("_direct_dks_preflight_check(run_model, model_cache_dir)")
     assert 'print("error_stage=stage2_preflight", file=sys.stderr)' in script
     assert 'print(f"error_reason={reason}", file=sys.stderr)' in script
     assert 'print(f"requested_model={requested_model}", file=sys.stderr)' in script
@@ -1469,6 +1489,47 @@ def test_drumkit_direct_dks_mode_wires_stage2_preflight_markers():
     assert "if not ok:" in script
     assert 'emit_phase("model_setup_start")' in script
     assert '_is_direct_dks_source(getattr(args, "workflow_mode", ""), getattr(args, "workflow_source", ""))' in script
+
+
+def test_drumsep_runtime_missing_is_detected_before_stage2_model_load(tmp_path, capsys):
+    module = _load_audio_separator_process_module()
+    missing_python = tmp_path / ".venv-drumsep" / "bin" / "python"
+
+    ok, detail = module._verify_drumsep_runtime(missing_python)
+    module._emit_direct_dks_stage2_runtime_markers("drumsep_runtime_missing", missing_python, detail)
+
+    captured = capsys.readouterr()
+    assert ok is False
+    assert detail == "missing"
+    assert "error_stage=stage2_runtime" in captured.err
+    assert "error_reason=drumsep_runtime_missing" in captured.err
+    assert "guidance=Run Setup/Repair Drum Kit Split runtime." in captured.err
+    assert "stage2_model_load" not in captured.err
+
+
+def test_drumsep_runtime_broken_reports_import_error(tmp_path):
+    module = _load_audio_separator_process_module()
+    runtime_python = tmp_path / ".venv-drumsep" / "bin" / "python"
+    runtime_python.parent.mkdir(parents=True)
+    runtime_python.write_text("#!/bin/sh\necho 'ImportError: audio_separator missing' >&2\nexit 1\n", encoding="utf-8")
+    runtime_python.chmod(0o755)
+
+    ok, detail = module._verify_drumsep_runtime(runtime_python)
+
+    assert ok is False
+    assert "ImportError: audio_separator missing" in detail
+
+
+def test_normal_stem_workflows_do_not_reference_drumsep_runtime():
+    script = Path("scripts/reaper/audio_separator_process.py").read_text()
+    marker = 'if _is_direct_dks_source(args.workflow_mode, args.workflow_source):'
+    assert marker in script
+    _, after_direct_dks = script.split(marker, 1)
+
+    assert "_verify_drumsep_runtime(" in after_direct_dks
+    assert after_direct_dks.index("_verify_drumsep_runtime(") < after_direct_dks.index("_direct_dks_preflight_check(run_model, model_cache_dir)")
+    assert after_direct_dks.index("_verify_drumsep_runtime(") < after_direct_dks.index('emit_phase("model_setup_start")')
+    assert "_enable_torch_weights_only_compat(run_model, resolved_device)" in script
 
 
 def test_drumkit_direct_dks_mode_wires_lua_launch_and_failure_mapping():
@@ -1481,6 +1542,10 @@ def test_drumkit_direct_dks_mode_wires_lua_launch_and_failure_mapping():
     assert "error_stage=stage2_preflight" in main_script
     assert "error_reason=drumsep_model_missing" in main_script
     assert "error_reason=drumsep_model_download_failed" in main_script
+    assert "error_stage=stage2_runtime" in main_script
+    assert "error_reason=drumsep_runtime_missing" in main_script
+    assert "error_reason=drumsep_runtime_broken" in main_script
+    assert "Run Setup/Repair Drum Kit Split runtime." in main_script
     assert "error_stage=stage2_model_load" in main_script
     assert "error_reason=drumsep_model_runtime_unsupported" in main_script
     assert "not found in supported model files" in main_script

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -1812,6 +1812,20 @@ def test_support_bundle_prefers_newest_runtime_run_over_stale_timing_summary():
     assert "if not firstFromRuntimeRuns then" in script
 
 
+def test_support_bundle_includes_drumsep_runtime_diagnostics_sections_and_files():
+    script = Path("scripts/reaper/STEMwerk_Save_Support_Bundle.lua").read_text()
+
+    assert "buildDrumsepRuntimeDiagnostics(" in script
+    assert "drumsep_runtime_status.txt" in script
+    assert "[CPU fallback runtime]" in script
+    assert "[ROCm runtime]" in script
+    assert "[Latest Direct DKS markers]" in script
+    assert "drumsep_runtime_selected" in script
+    assert "drumsep_gpu_capable" in script
+    assert "drumsep_install.log" in script
+    assert "drumsep_rocm_install.log" in script
+
+
 def test_model_download_failure_reason_codes_are_wired_for_runtime_and_bundle():
     log_script = Path("scripts/reaper/_internal/STEMwerk_Log.lua").read_text()
     support_script = Path("scripts/reaper/STEMwerk_Save_Support_Bundle.lua").read_text()

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -1441,14 +1441,22 @@ def test_drumkit_direct_dks_mode_wires_stage2_preflight_markers():
     assert 'parser.add_argument("--requested-stage2-model", default=""' in script
     assert "if _is_direct_dks_source(args.workflow_mode, args.workflow_source):" in script
     assert 'emit_phase("stage2_preflight")' in script
-    assert "def _direct_dks_preflight_check(model_name: str) -> Tuple[bool, Optional[str]]:" in script
-    assert "sep.download_model_files(model_name)" in script
+    assert "DIRECT_DKS_MODEL_ALIAS = \"MDX23C-DrumSep-aufr33-jarredou.ckpt\"" in script
+    assert "DIRECT_DKS_MODEL_FILENAME = \"aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.ckpt\"" in script
+    assert "def _resolve_direct_dks_model_catalog_entry(requested_model: str)" in script
+    assert "other_network_list_new" in script
+    assert "def _ensure_runtime_download_checks_has_drumsep(" in script
+    assert "mdx23c_download_list" in script
+    assert "def _download_direct_dks_assets(" in script
+    assert "sep.download_model_files(resolved_model)" in script
+    assert "resolved_model=" in script
     assert "Direct Drum Kit Split route detected: workflow_mode=" in script
     assert "workflow_source=" in script
     assert 'print("error_stage=stage2_preflight", file=sys.stderr)' in script
-    assert 'print("error_reason=drumsep_model_missing", file=sys.stderr)' in script
-    assert 'print(f"requested_model={model_name}", file=sys.stderr)' in script
-    assert 'print("Direct Drum Kit Split preflight failed: drumsep_model_missing", file=sys.stderr)' in script
+    assert 'print(f"error_reason={reason}", file=sys.stderr)' in script
+    assert 'print(f"requested_model={requested_model}", file=sys.stderr)' in script
+    assert 'print(f"Direct Drum Kit Split preflight failed: {reason}", file=sys.stderr)' in script
+    assert "drumsep_model_download_failed" in script
     assert "if not ok:" in script
     assert 'emit_phase("model_setup_start")' in script
     assert '_is_direct_dks_source(getattr(args, "workflow_mode", ""), getattr(args, "workflow_source", ""))' in script
@@ -1463,6 +1471,7 @@ def test_drumkit_direct_dks_mode_wires_lua_launch_and_failure_mapping():
     assert 'if (not trustedWindowsRuntime) and (not isDirectDKS) and (not ensureDependenciesInteractive()) then' in main_script
     assert "error_stage=stage2_preflight" in main_script
     assert "error_reason=drumsep_model_missing" in main_script
+    assert "error_reason=drumsep_model_download_failed" in main_script
     assert "not found in supported model files" in main_script
     assert "workflow%-source" in main_script
     assert 'WORKFLOW.runSeparationWithProgress(WORKFLOW_TEMP_INPUT, WORKFLOW_TEMP_DIR, workflowModel, runOptions)' in main_script

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -1683,6 +1683,8 @@ def test_direct_dks_helper_invocation_uses_optional_runtime_not_main_runtime():
     assert '"--result-json",' in script
     assert 'drumsep_helper_stdout.txt' in script
     assert 'drumsep_helper_stderr.txt' in script
+    assert 'print("PROGRESS:1:Starting DrumSep runtime", flush=True)' in script
+    assert "DrumSep stage2 separating kit stems" in script
     assert 'error_reason=drumsep_stage2_delegation_not_implemented' not in script
     assert 'drumsep_output_count_mismatch' in script
 

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -1443,7 +1443,10 @@ def test_drumkit_direct_dks_mode_wires_stage2_preflight_markers():
     assert 'emit_phase("stage2_preflight")' in script
     assert "DIRECT_DKS_MODEL_ALIAS = \"MDX23C-DrumSep-aufr33-jarredou.ckpt\"" in script
     assert "DIRECT_DKS_MODEL_FILENAME = \"aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.ckpt\"" in script
-    assert "def _resolve_direct_dks_model_catalog_entry(requested_model: str)" in script
+    assert "def _resolve_direct_dks_model_catalog_entry(requested_model: str, model_cache_dir: Path)" in script
+    assert "catalog_paths_checked=" in script
+    assert "catalog_lookup_status=" in script
+    assert "resolved_default = DIRECT_DKS_MODEL_FILENAME" in script
     assert "other_network_list_new" in script
     assert "def _ensure_runtime_download_checks_has_drumsep(" in script
     assert "mdx23c_download_list" in script
@@ -1457,6 +1460,7 @@ def test_drumkit_direct_dks_mode_wires_stage2_preflight_markers():
     assert 'print(f"requested_model={requested_model}", file=sys.stderr)' in script
     assert 'print(f"Direct Drum Kit Split preflight failed: {reason}", file=sys.stderr)' in script
     assert "drumsep_model_download_failed" in script
+    assert "known_err_text.startswith(\"catalog_\")" in script
     assert "if not ok:" in script
     assert 'emit_phase("model_setup_start")' in script
     assert '_is_direct_dks_source(getattr(args, "workflow_mode", ""), getattr(args, "workflow_source", ""))' in script

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -1681,13 +1681,59 @@ def test_linux_setup_exposes_explicit_drumsep_runtime_action_without_normal_setu
     setup_internal = Path("scripts/reaper/_internal/STEMwerk_Setup_Internal.lua").read_text()
     linux_bootstrap = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
 
-    assert 'mode ~= "repair" and mode ~= "rebuild-venv" and mode ~= "drumsep-runtime"' in setup_internal
-    assert 'isDrumsepRuntime and "drumsep_runtime.env" or "bootstrap.env"' in setup_internal
-    assert 'isDrumsepRuntime and "drumsep_install.log" or "bootstrap.log"' in setup_internal
+    assert 'mode ~= "repair" and mode ~= "rebuild-venv" and mode ~= "drumsep-runtime" and mode ~= "drumsep-rocm-runtime"' in setup_internal
+    assert '((isDrumsepRuntime and "drumsep_runtime.env") or (isDrumsepRocmRuntime and "drumsep_runtime_rocm.env") or "bootstrap.env")' in setup_internal
+    assert '((isDrumsepRuntime and "drumsep_install.log") or (isDrumsepRocmRuntime and "drumsep_rocm_install.log") or "bootstrap.log")' in setup_internal
     assert '{ id = "drumsep-runtime", label = "Drum Kit Split runtime"' in setup_internal
+    assert '{ id = "drumsep-rocm-runtime", label = "Drum Kit Split ROCm runtime"' in setup_internal
     assert 'startLinuxSetup(runtime, separatorScript, chosen)' in setup_internal
     assert 'if [ "${MODE}" = "drumsep-runtime" ]; then' in linux_bootstrap
     assert 'write_drumsep_state "install_failed" "missing" "python_missing"' in linux_bootstrap
+    assert 'elif [ "${MODE}" = "drumsep-rocm-runtime" ]; then' in linux_bootstrap
+    assert 'write_drumsep_rocm_state "install_failed" "missing" "python_missing"' in linux_bootstrap
+
+
+def test_linux_drumsep_rocm_runtime_installer_has_disk_preflight_and_rocm_pins():
+    script = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
+
+    assert 'DRUMSEP_ROCM_TORCH_VERSION="2.9.1+rocm6.4"' in script
+    assert 'DRUMSEP_ROCM_TORCHVISION_VERSION="0.24.1+rocm6.4"' in script
+    assert 'DRUMSEP_ROCM_TORCHAUDIO_VERSION="2.9.1+rocm6.4"' in script
+    assert 'DRUMSEP_ROCM_TORCH_INDEX_URL="https://download.pytorch.org/whl/rocm6.4"' in script
+    assert 'DRUMSEP_ROCM_MIN_FREE_GB="20"' in script
+    assert "drumsep_rocm_disk_preflight()" in script
+    assert "resolve_drumsep_rocm_tmpdir()" in script
+    assert 'write_drumsep_rocm_state "disk_space_insufficient" "missing"' in script
+    assert '"${_py}" -m pip install --no-cache-dir --index-url "${DRUMSEP_ROCM_TORCH_INDEX_URL}"' in script
+    assert '"torch==${DRUMSEP_ROCM_TORCH_VERSION}"' in script
+    assert '"${_py}" -m pip install --no-cache-dir --no-deps' in script
+    assert '"audio-separator==${DRUMSEP_AUDIO_SEPARATOR_VERSION}"' in script
+    assert '"${_py}" -m pip check' in script
+    assert "verify_drumsep_rocm_runtime()" in script
+
+
+def test_linux_drumsep_rocm_state_fields_are_written():
+    script = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
+
+    for field in (
+        "DRUMSEP_ROCM_RUNTIME_STATUS=",
+        "DRUMSEP_ROCM_PYTHON=",
+        "DRUMSEP_ROCM_AUDIO_SEPARATOR_VERSION=",
+        "DRUMSEP_ROCM_TORCH_VERSION=",
+        "DRUMSEP_ROCM_TORCH_HIP=",
+        "DRUMSEP_ROCM_CUDA_AVAILABLE=",
+        "DRUMSEP_ROCM_DEVICE_NAMES=",
+        "DRUMSEP_ROCM_NUMPY_VERSION=",
+        "DRUMSEP_ROCM_ONNX_VERSION=",
+        "DRUMSEP_ROCM_ONNXRUNTIME_VERSION=",
+        "DRUMSEP_ROCM_ONNX2TORCH_VERSION=",
+        "DRUMSEP_ROCM_MODEL_STATUS=",
+        "DRUMSEP_ROCM_LAST_CHECK_UTC=",
+        "DRUMSEP_ROCM_TEMP_DIR=",
+    ):
+        assert field in script
+    assert 'printf "%s/state/drumsep_runtime_rocm.env\\n" "${RUNTIME_BASE}"' in script
+    assert 'printf "%s/logs/drumsep_rocm_install.log\\n" "${RUNTIME_BASE}"' in script
 
 
 def test_drumsep_helper_payload_and_stem_normalization():

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -1474,14 +1474,18 @@ def test_drumkit_direct_dks_mode_wires_stage2_preflight_markers():
     assert "DRUMSEP_RUNTIME_GUIDANCE = \"Run Setup/Repair Drum Kit Split runtime.\"" in script
     assert "def _drumsep_runtime_python_path(" in script
     assert "def _verify_drumsep_runtime(" in script
-    assert "def _emit_direct_dks_stage2_delegation_pending_markers(" in script
+    assert "def _run_direct_dks_drumsep_helper(" in script
+    assert "stemwerk_drumsep_process.py" in script
     assert "drumsep_python = _drumsep_runtime_python_path()" in script
     assert "runtime_ok, runtime_detail = _verify_drumsep_runtime(drumsep_python)" in script
     assert "reason = \"drumsep_runtime_missing\" if runtime_detail == \"missing\" else \"drumsep_runtime_broken\"" in script
     assert "_emit_direct_dks_stage2_runtime_markers(reason, drumsep_python, runtime_detail)" in script
-    assert "_emit_direct_dks_stage2_delegation_pending_markers(drumsep_python, runtime_detail)" in script
+    assert "helper_ok, helper_stems, helper_reason, helper_detail = _run_direct_dks_drumsep_helper(" in script
+    assert "drumsep_helper_python=" in script
+    assert "drumsep_helper_ok=true" in script
     assert "_direct_dks_preflight_check(run_model, model_cache_dir)" in script
     assert script.index("runtime_ok, runtime_detail = _verify_drumsep_runtime(drumsep_python)") < script.index("_direct_dks_preflight_check(run_model, model_cache_dir)")
+    assert script.index("_direct_dks_preflight_check(run_model, model_cache_dir)") < script.index("helper_ok, helper_stems, helper_reason, helper_detail = _run_direct_dks_drumsep_helper(")
     assert 'print("error_stage=stage2_preflight", file=sys.stderr)' in script
     assert 'print(f"error_reason={reason}", file=sys.stderr)' in script
     assert 'print(f"requested_model={requested_model}", file=sys.stderr)' in script
@@ -1531,7 +1535,7 @@ def test_normal_stem_workflows_do_not_reference_drumsep_runtime():
     assert "_verify_drumsep_runtime(" in after_direct_dks
     assert after_direct_dks.index("_verify_drumsep_runtime(") < after_direct_dks.index("_direct_dks_preflight_check(run_model, model_cache_dir)")
     assert after_direct_dks.index("_verify_drumsep_runtime(") < after_direct_dks.index('emit_phase("model_setup_start")')
-    assert after_direct_dks.index("_emit_direct_dks_stage2_delegation_pending_markers") < after_direct_dks.index("_direct_dks_preflight_check(run_model, model_cache_dir)")
+    assert after_direct_dks.index("helper_ok, helper_stems, helper_reason, helper_detail = _run_direct_dks_drumsep_helper(") < after_direct_dks.index('emit_phase("model_setup_start")')
     assert "_enable_torch_weights_only_compat(run_model, resolved_device)" in script
 
 
@@ -1548,7 +1552,12 @@ def test_drumkit_direct_dks_mode_wires_lua_launch_and_failure_mapping():
     assert "error_stage=stage2_runtime" in main_script
     assert "error_reason=drumsep_runtime_missing" in main_script
     assert "error_reason=drumsep_runtime_broken" in main_script
-    assert "error_reason=drumsep_stage2_delegation_not_implemented" in main_script
+    assert "error_reason=drumsep_helper_failed" in main_script
+    assert "error_reason=drumsep_model_load_failed" in main_script
+    assert "error_reason=drumsep_separate_failed" in main_script
+    assert "error_reason=drumsep_output_count_mismatch" in main_script
+    assert 'file = "hi-hat.wav"' in main_script
+    assert "activateWorkflowStemSet(isDirectDKS)" in main_script
     assert "Run Setup/Repair Drum Kit Split runtime." in main_script
     assert "error_stage=stage2_model_load" in main_script
     assert "error_reason=drumsep_model_runtime_unsupported" in main_script
@@ -1618,6 +1627,64 @@ def test_linux_setup_exposes_explicit_drumsep_runtime_action_without_normal_setu
     assert 'startLinuxSetup(runtime, separatorScript, chosen)' in setup_internal
     assert 'if [ "${MODE}" = "drumsep-runtime" ]; then' in linux_bootstrap
     assert 'write_drumsep_state "install_failed" "missing" "python_missing"' in linux_bootstrap
+
+
+def test_drumsep_helper_payload_and_stem_normalization():
+    helper_path = Path("scripts/reaper/_internal/stemwerk_drumsep_process.py")
+    index_xml = Path("index.xml").read_text()
+
+    assert helper_path.exists()
+    assert "_internal/stemwerk_drumsep_process.py" in index_xml
+
+    spec = importlib.util.spec_from_file_location("stemwerk_drumsep_process_test", helper_path)
+    helper = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(helper)
+
+    assert helper.normalize_stem_name("Kick") == "kick"
+    assert helper.normalize_stem_name("Snare") == "snare"
+    assert helper.normalize_stem_name("Toms") == "toms"
+    assert helper.normalize_stem_name("Hh") == "hihat"
+    assert helper.normalize_stem_name("Hi-Hat") == "hihat"
+    assert helper.normalize_stem_name("Ride") == "ride"
+    assert helper.normalize_stem_name("Crash") == "crash"
+    assert helper.REAPER_FILENAMES["hihat"] == "hi-hat.wav"
+
+
+def test_drumsep_helper_wrong_output_count_schema(tmp_path):
+    helper_path = Path("scripts/reaper/_internal/stemwerk_drumsep_process.py")
+    spec = importlib.util.spec_from_file_location("stemwerk_drumsep_process_count_test", helper_path)
+    helper = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(helper)
+
+    raw_file = tmp_path / "input_(Kick).wav"
+    raw_file.write_bytes(b"RIFF")
+    stems, raw_outputs = helper.normalize_outputs(tmp_path, [str(raw_file)], set())
+    payload = helper._error_payload(
+        "drumsep_output_count_mismatch",
+        "stage2_output_validation",
+        "expected 6 stems, got 1",
+        stems=stems,
+        raw_outputs=raw_outputs,
+    )
+
+    assert stems == {"kick": str(tmp_path / "kick.wav")}
+    assert payload["ok"] is False
+    assert payload["error_stage"] == "stage2_output_validation"
+    assert payload["error_reason"] == "drumsep_output_count_mismatch"
+
+
+def test_direct_dks_helper_invocation_uses_optional_runtime_not_main_runtime():
+    script = Path("scripts/reaper/audio_separator_process.py").read_text()
+
+    assert 'DRUMSEP_RUNTIME_DIRNAME = ".venv-drumsep"' in script
+    assert 'str(drumsep_python),' in script
+    assert '"--result-json",' in script
+    assert 'drumsep_helper_stdout.txt' in script
+    assert 'drumsep_helper_stderr.txt' in script
+    assert 'error_reason=drumsep_stage2_delegation_not_implemented' not in script
+    assert 'drumsep_output_count_mismatch' in script
 
 
 def test_drumkit_wrapper_selects_integrated_mode_and_direct_source():

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -1430,7 +1430,35 @@ def test_audio_separator_process_enables_torch26_demucs_checkpoint_compatibility
     assert 'if major < 2 or (major == 2 and minor < 6):' in script
     assert 'os.environ["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = "1"' in script
     assert "STEMWERK_DIAG torch_weights_only_compat=enabled mode=TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD" in script
-    assert "_enable_torch_weights_only_compat(args.model, resolved_device)" in script
+    assert "_enable_torch_weights_only_compat(run_model, resolved_device)" in script
+
+
+def test_drumkit_direct_dks_mode_wires_stage2_preflight_markers():
+    script = Path("scripts/reaper/audio_separator_process.py").read_text()
+
+    assert 'parser.add_argument("--workflow-mode", default=""' in script
+    assert 'parser.add_argument("--requested-stage2-model", default=""' in script
+    assert "if _is_direct_dks_mode(args.workflow_mode):" in script
+    assert 'emit_phase("stage2_preflight")' in script
+    assert 'print("error_stage=stage2_preflight", file=sys.stderr)' in script
+    assert 'print("error_reason=drumsep_model_missing", file=sys.stderr)' in script
+    assert 'print(f"requested_model={run_model}", file=sys.stderr)' in script
+
+
+def test_drumkit_direct_dks_mode_wires_lua_launch_and_failure_mapping():
+    main_script = Path("scripts/reaper/STEMwerk.lua").read_text()
+    workflow_script = Path("scripts/reaper/_internal/STEMwerk_Workflow.lua").read_text()
+    dks_script = Path("scripts/reaper/_internal/STEMwerk_DrumKit_Workflow.lua").read_text()
+
+    assert 'local DKS_WORKFLOW = dofile(script_path .. "_internal/STEMwerk_DrumKit_Workflow.lua")' in main_script
+    assert 'if (not trustedWindowsRuntime) and (not isDirectDKS) and (not ensureDependenciesInteractive()) then' in main_script
+    assert "error_stage=stage2_preflight" in main_script
+    assert "error_reason=drumsep_model_missing" in main_script
+    assert 'WORKFLOW.runSeparationWithProgress(WORKFLOW_TEMP_INPUT, WORKFLOW_TEMP_DIR, workflowModel, runOptions)' in main_script
+    assert 'pythonCmd = pythonCmd .. " --workflow-mode " .. C.quoteArg(workflowModeArg)' in workflow_script
+    assert 'pythonCmd = pythonCmd .. " --requested-stage2-model " .. C.quoteArg(requestedStage2ModelArg)' in workflow_script
+    assert 'M.DIRECT_DKS_PRESET = "dks_direct"' in dks_script
+    assert 'M.DIRECT_DKS_MODEL = "MDX23C-DrumSep-aufr33-jarredou.ckpt"' in dks_script
 
 
 def test_support_bundle_prefers_newest_runtime_run_over_stale_timing_summary():

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -1437,8 +1437,9 @@ def test_drumkit_direct_dks_mode_wires_stage2_preflight_markers():
     script = Path("scripts/reaper/audio_separator_process.py").read_text()
 
     assert 'parser.add_argument("--workflow-mode", default=""' in script
+    assert 'parser.add_argument("--workflow-source", default=""' in script
     assert 'parser.add_argument("--requested-stage2-model", default=""' in script
-    assert "if _is_direct_dks_mode(args.workflow_mode):" in script
+    assert "if _is_direct_dks_source(args.workflow_mode, args.workflow_source):" in script
     assert 'emit_phase("stage2_preflight")' in script
     assert 'print("error_stage=stage2_preflight", file=sys.stderr)' in script
     assert 'print("error_reason=drumsep_model_missing", file=sys.stderr)' in script
@@ -1456,9 +1457,18 @@ def test_drumkit_direct_dks_mode_wires_lua_launch_and_failure_mapping():
     assert "error_reason=drumsep_model_missing" in main_script
     assert 'WORKFLOW.runSeparationWithProgress(WORKFLOW_TEMP_INPUT, WORKFLOW_TEMP_DIR, workflowModel, runOptions)' in main_script
     assert 'pythonCmd = pythonCmd .. " --workflow-mode " .. C.quoteArg(workflowModeArg)' in workflow_script
+    assert 'pythonCmd = pythonCmd .. " --workflow-source " .. C.quoteArg(workflowSourceArg)' in workflow_script
     assert 'pythonCmd = pythonCmd .. " --requested-stage2-model " .. C.quoteArg(requestedStage2ModelArg)' in workflow_script
-    assert 'M.DIRECT_DKS_PRESET = "dks_direct"' in dks_script
+    assert 'M.WORKFLOW_DRUMKIT = "drumkit"' in dks_script
+    assert 'M.SOURCE_DIRECT = "dks_direct"' in dks_script
     assert 'M.DIRECT_DKS_MODEL = "MDX23C-DrumSep-aufr33-jarredou.ckpt"' in dks_script
+
+
+def test_drumkit_wrapper_selects_integrated_mode_and_direct_source():
+    wrapper = Path("scripts/reaper/STEMwerk_Drum_Kit_Split.lua").read_text()
+    assert 'reaper.SetExtState(EXT_SECTION, "quick_preset", "drumkit", false)' in wrapper
+    assert 'reaper.SetExtState(EXT_SECTION, "active_workflow_mode", "drumkit", false)' in wrapper
+    assert 'reaper.SetExtState(EXT_SECTION, "active_workflow_source", "dks_direct", false)' in wrapper
 
 
 def test_support_bundle_prefers_newest_runtime_run_over_stale_timing_summary():

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -1442,13 +1442,16 @@ def test_drumkit_direct_dks_mode_wires_stage2_preflight_markers():
     assert "if _is_direct_dks_source(args.workflow_mode, args.workflow_source):" in script
     assert 'emit_phase("stage2_preflight")' in script
     assert "def _direct_dks_preflight_check(model_name: str) -> Tuple[bool, Optional[str]]:" in script
-    assert "loader = getattr(getattr(sep, \"separator\", None), \"load_model\", None)" in script
+    assert "sep.download_model_files(model_name)" in script
+    assert "Direct Drum Kit Split route detected: workflow_mode=" in script
+    assert "workflow_source=" in script
     assert 'print("error_stage=stage2_preflight", file=sys.stderr)' in script
     assert 'print("error_reason=drumsep_model_missing", file=sys.stderr)' in script
     assert 'print(f"requested_model={model_name}", file=sys.stderr)' in script
     assert 'print("Direct Drum Kit Split preflight failed: drumsep_model_missing", file=sys.stderr)' in script
     assert "if not ok:" in script
     assert 'emit_phase("model_setup_start")' in script
+    assert '_is_direct_dks_source(getattr(args, "workflow_mode", ""), getattr(args, "workflow_source", ""))' in script
 
 
 def test_drumkit_direct_dks_mode_wires_lua_launch_and_failure_mapping():


### PR DESCRIPTION
## Status
Draft / R&D reference only. Not ready for mainline merge as-is.

## What this proves
- Linux Direct Drum Kit Split route works.
- Direct DKS skips Demucs/stage1.
- DrumSep MDX23C produces six kit stems.
- Optional isolated CPU runtime works.
- Optional isolated ROCm runtime works.
- Selector prefers ROCm and falls back to CPU.
- RX 9070 ROCm path verified.
- Support bundle diagnostics added.

## Runtime architecture
- `main .venv`: normal STEMwerk workflows
- `.venv-drumsep`: Drum Kit Split CPU fallback
- `.venv-drumsep-rocm`: Drum Kit Split AMD/ROCm GPU

## Verified outputs
- `kick.wav`
- `snare.wav`
- `toms.wav`
- `hi-hat.wav`
- `ride.wav`
- `crash.wav`

## ROCm proof
- `torch 2.9.1+rocm6.4`
- `torch.version.hip=6.4.43484-123eb5128`
- `torch.cuda.is_available=True`
- devices include `AMD Radeon RX 9070`
- helper/main Direct DKS with known-good input returns six outputs
- earlier `rocm-smi` sample showed RX 9070 active during helper run

## Support bundle
- `drumsep_runtime_status.txt`
- CPU fallback section
- ROCm section
- selector status
- latest Direct DKS markers
- install log tails
- excludes audio/model/venv payloads

## Known limitations
- Linux-only.
- ROCm installer is explicit, not automatic.
- Windows/macOS not implemented.
- ROCm proof currently on RX 9070/gfx1201 host.
- Requires large disk space; preflight added.
- MCP/REAPER bridge can be blocked by REAPER modal/task-control state.
- Branch is large R&D spike; not ideal as direct merge.
- Production integration should be cherry-picked/refactored into a clean branch from current `origin/main`.

## Important audit note
A final audit smoke initially reported `stage2_output_validation / drumsep_output_count_mismatch (expected 6 stems, got 0)`. This was a false alarm caused by smoke input selection: it picked a support-bundle headless fake fixture `input.wav` instead of a known-good DrumSep input. Re-running helper-only and main-process Direct DKS with a known-good input passed (`drumsep_runtime_selected=rocm`, `drumsep_gpu_capable=yes`, helper `returncode=0`, six outputs present).

## Recommended integration plan
1. Keep this PR as draft R&D reference.
2. Create a clean integration branch from current `origin/main`.
3. Cherry-pick/refactor in small production slices:
   - Direct DKS action/workflow shell
   - helper delegation
   - CPU optional runtime
   - ROCm selector
   - ROCm install action
   - support bundle diagnostics
4. Re-run Linux smoke after each slice.
5. Only then open/mark ready a mainline integration PR.
