### PR TITLE
fix(macos): fallback to ExtState ffmpegPath when FFMPEG_PATH is nil

### DIFF
--- a/scripts/reaper/STEMwerk.lua
+++ b/scripts/reaper/STEMwerk.lua
@@ -12484,7 +12484,7 @@ end
 -- Returns: ok(bool), ffmpegLogPath(string), exitCode(number|nil)
 local function runFfmpegExtract(sourceFile, offsetSec, durationSec, outputPath)
     local logPath = tostring(outputPath) .. ".ffmpeg.log"
-    local ffmpegBin = FFMPEG_PATH or "ffmpeg"
+    local ffmpegBin = FFMPEG_PATH or getExtStateValue("ffmpegPath") or "ffmpeg"
 
     local exitCode = nil
     if OS == "Windows" then


### PR DESCRIPTION
On macOS, reaper.ExecProcess does not capture stderr. Since ffmpeg writes version output to stderr rather than stdout, exec_capture receives empty output and the tryPath detection chain fails silently, leaving FFMPEG_PATH nil. runFfmpegExtract then falls back to bare "ffmpeg" which fails in REAPER's restricted shell environment regardless of what is on the system PATH.

Fix by reading the stored ExtState value at execution time, mirroring the pattern already used at line 16902. This means a valid ffmpegPath in ExtState (set either by the user or by a previous successful detection run) will be used even when runtime detection fails.

Note: the root cause is that ffmpeg -version in tryPath should redirect stderr with 2>&1 so exec_capture can actually read the output. That would make detection reliable and is worth a separate fix.