### PR TITLE
registry: add model registry v2 metadata layer

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -28,6 +28,7 @@ STEMwerk 2.3.0.4 - DrumSep timeout hotfix and docs/helper update
         <source file="../STEMwerk_Bootstrap_Linux.sh" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/STEMwerk_Bootstrap_Linux.sh</source>
         <source file="../STEMwerk_Bootstrap_Linux_Launcher.sh" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/STEMwerk_Bootstrap_Linux_Launcher.sh</source>
         <source file="../audio_separator_process.py" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/audio_separator_process.py</source>
+        <source file="../models.json" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/models.json</source>
 
         <source file="../_internal/STEMwerk_Devices.lua" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/STEMwerk_Devices.lua</source>
         <source file="../_internal/STEMwerk_DrumKit_Workflow.lua" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/STEMwerk_DrumKit_Workflow.lua</source>
@@ -40,6 +41,7 @@ STEMwerk 2.3.0.4 - DrumSep timeout hotfix and docs/helper update
         <source file="../_internal/STEMwerk_Managed_Python.lua" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/STEMwerk_Managed_Python.lua</source>
         <source file="../_internal/STEMwerk_Managed_Python.sh" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/STEMwerk_Managed_Python.sh</source>
         <source file="../_internal/STEMwerk_Messages.lua" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/STEMwerk_Messages.lua</source>
+        <source file="../_internal/STEMwerk_Model_Registry.lua" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/STEMwerk_Model_Registry.lua</source>
         <source file="../_internal/STEMwerk_Path_Helper.lua" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/STEMwerk_Path_Helper.lua</source>
         <source file="../_internal/STEMwerk_Platform.lua" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/STEMwerk_Platform.lua</source>
         <source file="../_internal/STEMwerk_Progress_Render.lua" type="file">https://raw.githubusercontent.com/flarkflarkflark/STEMwerk-reaper/main/scripts/reaper/_internal/STEMwerk_Progress_Render.lua</source>

--- a/scripts/reaper/STEMwerk.lua
+++ b/scripts/reaper/STEMwerk.lua
@@ -128,6 +128,13 @@ exec_capture = SYSTEM.exec_capture
 dofile(script_path .. "_internal/STEMwerk_Log.lua")
 dofile(script_path .. "_internal/STEMwerk_Timing.lua")
 
+-- Model registry (schema v2, metadata-only). Hard-failt bij kapotte/ontbrekende
+-- models.json conform registry_policy; runtime-gedrag leest de registry niet.
+-- Global (zoals SETTINGS/MODEL_AVAILABILITY): de main chunk zit op de
+-- Lua-limiet van 200 locals, een extra local compileert niet.
+MODEL_REGISTRY = dofile(script_path .. "_internal/STEMwerk_Model_Registry.lua")
+MODEL_REGISTRY.validate_preset_stages()
+
 SELF_CHECK_LOGGED = false
 function logSelfCheckOnce()
     if SELF_CHECK_LOGGED then return end
@@ -1326,12 +1333,16 @@ RUNTIME_DEVICE_PROBE = nil
 RUNTIME_DEVICE_UI_SEED_SOURCE = nil
 RUNTIME_DEVICE_UI_REFRESH_REASON = nil
 
--- Available models
-local MODELS = {
-    { id = "htdemucs", name = "Fast", desc = "htdemucs - Fastest model, good quality (4 stems)" },
-    { id = "htdemucs_ft", name = "Quality", desc = "htdemucs_ft - Best quality, slower (4 stems)" },
-    { id = "htdemucs_6s", name = "6-Stem", desc = "htdemucs_6s - Adds Guitar & Piano separation" },
-}
+-- Available models -- opgebouwd uit de registry (scripts/reaper/models.json).
+-- name komt uit ui.fallback_label (identiek aan de vorige literals); het
+-- voormalige desc-veld werd nergens gelezen en is vervallen.
+local MODELS = {}
+for _, regModel in ipairs(MODEL_REGISTRY.models()) do
+    MODELS[#MODELS + 1] = {
+        id = regModel.id,
+        name = (regModel.ui and regModel.ui.fallback_label) or regModel.id,
+    }
+end
 
 MODEL_AVAILABILITY = {
     bundledLimited = false,
@@ -1339,11 +1350,10 @@ MODEL_AVAILABILITY = {
 }
 
 do
-    local KNOWN_MODEL_IDS = {
-        htdemucs = true,
-        htdemucs_ft = true,
-        htdemucs_6s = true,
-    }
+    local KNOWN_MODEL_IDS = {}
+    for _, regModel in ipairs(MODEL_REGISTRY.models()) do
+        KNOWN_MODEL_IDS[regModel.id] = true
+    end
 
     local function parseModelAllowlist(raw)
         if not raw or raw == "" then return nil end
@@ -12670,11 +12680,11 @@ function renderMainColumns(ctx)
     local modelBtnFontSize = _ubfs
 
     local modelY = contentTop + S(20)
-    local modelDescKeys = {
-        htdemucs = "model_fast_desc",
-        htdemucs_ft = "model_quality_desc",
-        htdemucs_6s = "model_6stem_desc",
-    }
+    local modelDescKeys = {}
+    for _, regModel in ipairs(MODEL_REGISTRY.models()) do
+        modelDescKeys[regModel.id] = regModel.ui and regModel.ui.tooltip_key
+    end
+    -- Sneltoetsen blijven bewust lokaal (backlog: ui.shortcut in registry-schema).
     local modelShortcutKeys = {
         htdemucs = "F",
         htdemucs_ft = "Q",

--- a/scripts/reaper/_internal/STEMwerk_Model_Registry.lua
+++ b/scripts/reaper/_internal/STEMwerk_Model_Registry.lua
@@ -1,0 +1,418 @@
+--[[
+  STEMwerk_Model_Registry.lua — registry schema v2 (commit 2)
+  ------------------------------------------------------------
+  Metadata-only toegang tot scripts/reaper/models.json.
+
+  HARD-FAIL POLICY (registry_policy in models.json):
+    * onbekend model-id            -> error(), na SW_LOG-entry indien beschikbaar
+    * ontbrekend output_contract   -> error()
+    * ontbrekende/foute manifest   -> error() bij eerste gebruik
+    * GEEN stille fallback naar 4-stem Demucs of naar de default, nergens
+
+  Laden (conform bestaande _internal conventie):
+    local Registry = dofile(script_path .. "_internal/STEMwerk_Model_Registry.lua")
+
+  Deze module raakt geen runtime: geen device-keuzes, geen process-spawn,
+  geen settings-writes. Zij levert uitsluitend metadata; audio_separator_process.py
+  en de DKS-runtime blijven leidend voor al het gedrag.
+]]
+
+local Registry = {}
+
+-- ---------------------------------------------------------------------------
+-- Logging + hard fail
+-- ---------------------------------------------------------------------------
+
+local function log_line(msg)
+    -- SW_LOG is een global zodra STEMwerk_Log.lua geladen is; registry werkt
+    -- ook headless (tests) zonder SW_LOG.
+    local ok = pcall(function()
+        if SW_LOG and SW_LOG.logExecResult then
+            SW_LOG.logExecResult("lua_model_registry_error=" .. tostring(msg), nil, "")
+        end
+    end)
+    return ok
+end
+
+local function fail(msg)
+    log_line(msg)
+    error("STEMwerk_Model_Registry: " .. tostring(msg), 3)
+end
+
+-- ---------------------------------------------------------------------------
+-- Minimale JSON-decoder (alleen wat models.json nodig heeft:
+-- object/array/string/number/true/false/null, string-escapes incl. \uXXXX)
+-- ---------------------------------------------------------------------------
+
+local json_decode
+do
+    local ESCAPES = { ['"'] = '"', ["\\"] = "\\", ["/"] = "/",
+                      b = "\b", f = "\f", n = "\n", r = "\r", t = "\t" }
+
+    local function decode_error(str, pos, why)
+        local line = 1
+        for _ in str:sub(1, pos):gmatch("\n") do line = line + 1 end
+        fail(("JSON-fout op regel %d (pos %d): %s"):format(line, pos, why))
+    end
+
+    local function skip_ws(str, pos)
+        local _, e = str:find("^[ \t\r\n]*", pos)
+        return e + 1
+    end
+
+    local decode_value
+
+    local function decode_string(str, pos)
+        local out, i = {}, pos + 1
+        while true do
+            local c = str:sub(i, i)
+            if c == "" then decode_error(str, i, "onafgesloten string") end
+            if c == '"' then
+                return table.concat(out), i + 1
+            elseif c == "\\" then
+                local esc = str:sub(i + 1, i + 1)
+                if esc == "u" then
+                    local hex = str:sub(i + 2, i + 5)
+                    if not hex:match("^%x%x%x%x$") then
+                        decode_error(str, i, "ongeldige \\u escape")
+                    end
+                    local code = tonumber(hex, 16)
+                    -- basis-multilingual plane volstaat voor models.json
+                    if code < 0x80 then
+                        out[#out + 1] = string.char(code)
+                    elseif code < 0x800 then
+                        out[#out + 1] = string.char(0xC0 | (code >> 6), 0x80 | (code & 0x3F))
+                    else
+                        out[#out + 1] = string.char(0xE0 | (code >> 12),
+                                                    0x80 | ((code >> 6) & 0x3F),
+                                                    0x80 | (code & 0x3F))
+                    end
+                    i = i + 6
+                else
+                    local mapped = ESCAPES[esc]
+                    if not mapped then decode_error(str, i, "ongeldige escape \\" .. esc) end
+                    out[#out + 1] = mapped
+                    i = i + 2
+                end
+            else
+                out[#out + 1] = c
+                i = i + 1
+            end
+        end
+    end
+
+    local function decode_number(str, pos)
+        local num_str = str:match("^-?%d+%.?%d*[eE]?[+%-]?%d*", pos)
+        local num = tonumber(num_str)
+        if not num then decode_error(str, pos, "ongeldig getal") end
+        return num, pos + #num_str
+    end
+
+    local function decode_array(str, pos)
+        local arr = {}
+        pos = skip_ws(str, pos + 1)
+        if str:sub(pos, pos) == "]" then return arr, pos + 1 end
+        while true do
+            local value
+            value, pos = decode_value(str, pos)
+            arr[#arr + 1] = value
+            pos = skip_ws(str, pos)
+            local c = str:sub(pos, pos)
+            if c == "]" then return arr, pos + 1 end
+            if c ~= "," then decode_error(str, pos, "',' of ']' verwacht") end
+            pos = skip_ws(str, pos + 1)
+        end
+    end
+
+    local function decode_object(str, pos)
+        local obj = {}
+        pos = skip_ws(str, pos + 1)
+        if str:sub(pos, pos) == "}" then return obj, pos + 1 end
+        while true do
+            if str:sub(pos, pos) ~= '"' then decode_error(str, pos, "object-key verwacht") end
+            local key
+            key, pos = decode_string(str, pos)
+            pos = skip_ws(str, pos)
+            if str:sub(pos, pos) ~= ":" then decode_error(str, pos, "':' verwacht") end
+            local value
+            value, pos = decode_value(str, skip_ws(str, pos + 1))
+            obj[key] = value
+            pos = skip_ws(str, pos)
+            local c = str:sub(pos, pos)
+            if c == "}" then return obj, pos + 1 end
+            if c ~= "," then decode_error(str, pos, "',' of '}' verwacht") end
+            pos = skip_ws(str, pos + 1)
+        end
+    end
+
+    decode_value = function(str, pos)
+        pos = skip_ws(str, pos)
+        local c = str:sub(pos, pos)
+        if c == "{" then return decode_object(str, pos) end
+        if c == "[" then return decode_array(str, pos) end
+        if c == '"' then return decode_string(str, pos) end
+        if c == "-" or c:match("%d") then return decode_number(str, pos) end
+        if str:sub(pos, pos + 3) == "true" then return true, pos + 4 end
+        if str:sub(pos, pos + 4) == "false" then return false, pos + 5 end
+        if str:sub(pos, pos + 3) == "null" then return nil, pos + 4 end
+        decode_error(str, pos, "onverwacht teken '" .. c .. "'")
+    end
+
+    json_decode = function(str)
+        local value, pos = decode_value(str, 1)
+        pos = skip_ws(str, pos)
+        if pos <= #str then decode_error(str, pos, "data na einde JSON") end
+        return value
+    end
+end
+
+-- ---------------------------------------------------------------------------
+-- Manifest laden + schema-check
+-- ---------------------------------------------------------------------------
+
+local PATH_SEP = package.config:sub(1, 1)
+
+local function module_dir()
+    local src = debug.getinfo(1, "S").source:sub(2)
+    return src:match("(.*[/\\])") or ("." .. PATH_SEP)
+end
+
+-- _internal/ -> parent (scripts/reaper/) waar models.json naast STEMwerk.lua staat
+local DEFAULT_MANIFEST_PATH = module_dir() .. ".." .. PATH_SEP .. "models.json"
+
+local _state = { manifest = nil, by_id = nil, path = nil }
+
+--- Optioneel: expliciet pad zetten (tests / afwijkende layouts). Moet vóór
+--- eerste gebruik; daarna hard fail om halfslachtige herlaad-states te voorkomen.
+function Registry.set_manifest_path(path)
+    if _state.manifest then
+        fail("set_manifest_path na laden is niet toegestaan")
+    end
+    _state.path = path
+end
+
+local function validate_manifest(data, path)
+    if type(data) ~= "table" then
+        fail("manifest is geen JSON-object: " .. path)
+    end
+    if data.schema_version ~= 2 then
+        fail(("schema_version %s wordt niet ondersteund (verwacht 2): %s")
+            :format(tostring(data.schema_version), path))
+    end
+    if type(data.models) ~= "table" or #data.models == 0 then
+        fail("manifest bevat geen models[]: " .. path)
+    end
+    local policy = data.registry_policy or {}
+    if policy.unknown_model_id ~= "hard_fail" or policy.silent_fallback_to_default ~= false then
+        fail("registry_policy ontbreekt of staat niet op hard_fail: " .. path)
+    end
+end
+
+local function load_manifest()
+    if _state.manifest then return _state.manifest end
+    local path = _state.path or DEFAULT_MANIFEST_PATH
+    local fh, err = io.open(path, "r")
+    if not fh then
+        fail("models.json niet gevonden: " .. tostring(err))
+    end
+    local raw = fh:read("*a")
+    fh:close()
+    local ok, data = pcall(json_decode, raw)
+    if not ok then
+        -- json_decode faalt zelf al via fail(); dit vangt onverwachte errors
+        error(data, 0)
+    end
+    validate_manifest(data, path)
+
+    local by_id = {}
+    for _, model in ipairs(data.models) do
+        if type(model.id) ~= "string" or model.id == "" then
+            fail("model zonder geldig id in manifest")
+        end
+        if by_id[model.id] then
+            fail("duplicaat model-id: " .. model.id)
+        end
+        by_id[model.id] = model
+    end
+
+    _state.manifest = data
+    _state.by_id = by_id
+    _state.path = path
+    return data
+end
+
+local function contract_of(model)
+    local contract = model.output_contract
+    if type(contract) ~= "table"
+        or type(contract.stems) ~= "table"
+        or #contract.stems == 0
+        or type(contract.stem_semantics) ~= "string"
+        or type(contract.expected_outputs) ~= "number" then
+        fail("output_contract ontbreekt of is onvolledig voor model: " .. model.id)
+    end
+    if contract.expected_outputs ~= #contract.stems then
+        fail("output_contract inconsistent (expected_outputs != #stems) voor model: " .. model.id)
+    end
+    return contract
+end
+
+-- ---------------------------------------------------------------------------
+-- Publieke API — alles hard-failend, geen stille fallbacks
+-- ---------------------------------------------------------------------------
+
+--- Model op id. HARD FAIL bij onbekend id.
+function Registry.get(id)
+    load_manifest()
+    local model = _state.by_id[id]
+    if not model then
+        fail("onbekend model-id: " .. tostring(id))
+    end
+    return model
+end
+
+--- Bestaans-check zonder fail. Uitsluitend voor expliciete probes
+--- (bv. settings-migratie); NOOIT gebruiken om stil op iets anders
+--- terug te vallen.
+function Registry.exists(id)
+    load_manifest()
+    return _state.by_id[id] ~= nil
+end
+
+--- Actieve (hidden == false) modellen, gesorteerd op ui.order.
+function Registry.models()
+    local data = load_manifest()
+    local out = {}
+    for _, model in ipairs(data.models) do
+        if model.hidden ~= true then
+            out[#out + 1] = model
+        end
+    end
+    table.sort(out, function(a, b)
+        return ((a.ui or {}).order or 0) < ((b.ui or {}).order or 0)
+    end)
+    return out
+end
+
+--- Id van het actieve default-model. HARD FAIL bij nul of meerdere defaults —
+--- geen fallback naar een hardcoded modelnaam.
+function Registry.default_id()
+    local found = nil
+    for _, model in ipairs(Registry.models()) do
+        if model.default == true then
+            if found then
+                fail("meerdere actieve default-modellen: " .. found .. ", " .. model.id)
+            end
+            found = model.id
+        end
+    end
+    if not found then
+        fail("geen actief default-model in manifest")
+    end
+    return found
+end
+
+--- Stems van een model. HARD FAIL bij onbekend id of ontbrekend contract.
+--- Dit vervangt elke `model == "htdemucs_6s"` check.
+--- Retourneert een KOPIE zodat callers de registry-state niet kunnen muteren.
+local function copy_array(t)
+    local out = {}
+    for i = 1, #t do out[i] = t[i] end
+    return out
+end
+
+function Registry.stems(id)
+    return copy_array(contract_of(Registry.get(id)).stems)
+end
+
+function Registry.has_stem(id, stem)
+    for _, s in ipairs(Registry.stems(id)) do
+        if s == stem then return true end
+    end
+    return false
+end
+
+function Registry.expected_outputs(id)
+    return contract_of(Registry.get(id)).expected_outputs
+end
+
+--- stem_semantics van een model ("full_mix_decomposition" | "complement" | "split").
+--- Dit vervangt is_two_stem()-achtige helpers: de UI kiest layout op semantiek.
+function Registry.stem_semantics(id)
+    local semantics = contract_of(Registry.get(id)).stem_semantics
+    local known = (load_manifest().stem_semantics_types or {})
+    if known[semantics] == nil then
+        fail("onbekende stem_semantics '" .. tostring(semantics) .. "' voor model: " .. id)
+    end
+    return semantics
+end
+
+--- Backend-metadata voor de bestaande runtime-aanroep.
+--- Levert alleen door wat in het manifest staat; geen device/engine-keuzes hier.
+function Registry.backend(id)
+    local model = Registry.get(id)
+    return {
+        engine = model.engine,
+        architecture = model.architecture,
+        family = model.family,
+        backend_arg = model.backend_arg,
+        kind = model.kind,
+    }
+end
+
+--- UI-metadata; caller resolvet label_key/tooltip_key via trSafeValue,
+--- fallback_label alleen als laatste redmiddel (zelfde patroon als i18n nu).
+function Registry.ui(id)
+    local model = Registry.get(id)
+    local ui = model.ui or {}
+    return {
+        label_key = ui.label_key,
+        tooltip_key = ui.tooltip_key,
+        fallback_label = ui.fallback_label,
+        tier = ui.tier,
+        order = ui.order,
+    }
+end
+
+function Registry.runtime(id)
+    local model = Registry.get(id)
+    local rt = model.runtime
+    if type(rt) ~= "table" or type(rt.profiles) ~= "table" then
+        fail("runtime-blok ontbreekt voor model: " .. id)
+    end
+    return rt
+end
+
+--- Presets (workflows). HARD FAIL bij onbekend preset-id.
+function Registry.presets()
+    return load_manifest().presets or {}
+end
+
+function Registry.preset(id)
+    for _, preset in ipairs(Registry.presets()) do
+        if preset.id == id then return preset end
+    end
+    fail("onbekend preset-id: " .. tostring(id))
+end
+
+--- Valideert dat elke stage in elke preset naar een bestaand internal_stage
+--- model verwijst. Bedoeld voor een load-time sanity call vanuit STEMwerk.lua;
+--- HARD FAIL bij schending.
+function Registry.validate_preset_stages()
+    for _, preset in ipairs(Registry.presets()) do
+        for _, stage in ipairs((preset.workflow or {}).stages or {}) do
+            local model = Registry.get(stage.stage) -- hard fail bij onbekend
+            if model.kind ~= "internal_stage" then
+                fail(("preset '%s' verwijst naar stage '%s' die geen internal_stage is")
+                    :format(preset.id, stage.stage))
+            end
+        end
+    end
+    return true
+end
+
+function Registry.manifest_path()
+    load_manifest()
+    return _state.path
+end
+
+return Registry

--- a/scripts/reaper/models.json
+++ b/scripts/reaper/models.json
@@ -1,0 +1,533 @@
+{
+  "schema_version": 2,
+  "$comment": "STEMwerk model registry — schema v2, geverifieerd tegen STEMwerk-reaper-2.3.0.3. Uitsluitend metadata: runtime-beslissingen (device-selectie, scheduler/cap-policy, cancellation, validation-uitvoering, support-bundle logging, DKS runtime-isolatie) blijven in audio_separator_process.py en stemwerk_drumsep_process.py. UI-labels komen uit dit bestand via i18n-keys; runtime-gedrag leest dit bestand NIET voor device/backend-keuzes.",
+  "registry_policy": {
+    "unknown_model_id": "hard_fail",
+    "missing_output_contract": "hard_fail",
+    "missing_validation_block": "hard_fail_for_active",
+    "silent_fallback_to_default": false
+  },
+  "paths": {
+    "$comment": "1-op-1 overgenomen uit _default_model_cache_dir() in audio_separator_process.py. Env-override AUDIO_SEPARATOR_MODEL_DIR blijft leidend; de registry documenteert alleen de bestaande conventie.",
+    "model_file_dir": {
+      "env_override": "AUDIO_SEPARATOR_MODEL_DIR",
+      "windows": "%LOCALAPPDATA%/STEMwerk/models",
+      "macos": "~/Library/Application Support/STEMwerk/models",
+      "linux": {
+        "xdg_env": "XDG_DATA_HOME",
+        "xdg_relative": "STEMwerk/models",
+        "fallback": "~/.local/share/STEMwerk/models"
+      }
+    }
+  },
+  "runtime_profiles": {
+    "$comment": "Namen matchen de bestaande backend-detectie. 'gated_by' verwijst naar bestaande runtime state / smoke markers; de registry detecteert zelf niets.",
+    "cpu": {
+      "status": "supported"
+    },
+    "cuda": {
+      "status": "supported"
+    },
+    "rocm": {
+      "status": "supported"
+    },
+    "directml": {
+      "status": "supported",
+      "gated_by": "existing_directml_runtime_state_and_smoke_markers"
+    },
+    "mps": {
+      "status": "supported",
+      "gated_by": "existing_mps_smoke_markers (incl. drumsep_mps_direct_demix route)"
+    }
+  },
+  "stem_semantics_types": {
+    "full_mix_decomposition": "stems sommeren (bij benadering) tot de input; standaard multi-stem UI",
+    "complement": "twee stems die elkaars complement zijn (bv. vocals/instrumental); UI: één keuze-paar",
+    "split": "één bron opgesplitst in deelcomponenten (bv. drum-kit parts); UI: sub-selectie van de bron-stem"
+  },
+  "models": [
+    {
+      "id": "htdemucs",
+      "kind": "primary",
+      "engine": "audio_separator",
+      "architecture": "demucs",
+      "family": "demucs_v4",
+      "backend_arg": "htdemucs.yaml",
+      "$comment": "Runtime resolvet friendly id -> yaml via stemwerk_core.models.DEMUCS_AUDIO_SEPARATOR_MODEL_IDS; engine is dus audio_separator, niet een aparte demucs-engine.",
+      "default": true,
+      "hidden": false,
+      "experimental": false,
+      "output_contract": {
+        "stems": [
+          "vocals",
+          "drums",
+          "bass",
+          "other"
+        ],
+        "stem_semantics": "full_mix_decomposition",
+        "expected_outputs": 4
+      },
+      "validation": {
+        "expected_outputs": 4,
+        "expected_stems": [
+          "vocals",
+          "drums",
+          "bass",
+          "other"
+        ],
+        "contract_form": "stem->path JSON map van runtime (_map_reaper_stems_from_result); bestandsnamen zijn runtime-managed, geen vast filename-contract"
+      },
+      "runtime": {
+        "profiles": [
+          "cpu",
+          "cuda",
+          "rocm",
+          "directml",
+          "mps"
+        ],
+        "cpu_warning": false,
+        "experimental_on": []
+      },
+      "download": {
+        "online": true,
+        "offline_pack": "core",
+        "integrity": {
+          "mechanism": "demucs_content_hash_filenames + audio-separator download_checks.json (runtime-validated; zie test_model_failure_classification.py)",
+          "files": [
+            "htdemucs.yaml",
+            "955717e8-8726e21a.th"
+          ]
+        }
+      },
+      "packaging": {
+        "bundled_in_installer": true,
+        "release_gate_required": true
+      },
+      "ui": {
+        "label_key": "model_label_fast",
+        "tooltip_key": "model_fast_desc",
+        "fallback_label": "Fast",
+        "tier": "fast",
+        "order": 10
+      },
+      "provenance": {
+        "author": "Meta AI (Demucs v4)",
+        "license": "MIT",
+        "source": "facebookresearch/demucs via audio-separator"
+      }
+    },
+    {
+      "id": "htdemucs_ft",
+      "kind": "primary",
+      "engine": "audio_separator",
+      "architecture": "demucs",
+      "family": "demucs_v4",
+      "backend_arg": "htdemucs_ft.yaml",
+      "default": false,
+      "hidden": false,
+      "experimental": false,
+      "output_contract": {
+        "stems": [
+          "vocals",
+          "drums",
+          "bass",
+          "other"
+        ],
+        "stem_semantics": "full_mix_decomposition",
+        "expected_outputs": 4
+      },
+      "validation": {
+        "expected_outputs": 4,
+        "expected_stems": [
+          "vocals",
+          "drums",
+          "bass",
+          "other"
+        ],
+        "contract_form": "stem->path JSON map van runtime; bestandsnamen runtime-managed"
+      },
+      "runtime": {
+        "profiles": [
+          "cpu",
+          "cuda",
+          "rocm",
+          "directml",
+          "mps"
+        ],
+        "cpu_warning": false,
+        "experimental_on": []
+      },
+      "download": {
+        "online": true,
+        "offline_pack": "core",
+        "integrity": {
+          "mechanism": "demucs_content_hash_filenames + download_checks.json (runtime-validated)",
+          "files": [
+            "htdemucs_ft.yaml",
+            "f7e0c4bc-ba3fe64a.th",
+            "d12395a8-e57c48e6.th",
+            "92cfc3b6-ef3bcb9c.th",
+            "04573f0d-f3cf25b2.th"
+          ],
+          "$comment": "Bag of 4 checkpoints, conform CORE_MODEL_FILES-groepering in tools/build_macos_apple_silicon_payload.py"
+        }
+      },
+      "packaging": {
+        "bundled_in_installer": true,
+        "release_gate_required": true
+      },
+      "ui": {
+        "label_key": "model_label_quality",
+        "tooltip_key": "model_quality_desc",
+        "fallback_label": "Quality",
+        "tier": "quality",
+        "order": 20
+      },
+      "provenance": {
+        "author": "Meta AI (Demucs v4, fine-tuned)",
+        "license": "MIT",
+        "source": "facebookresearch/demucs via audio-separator"
+      }
+    },
+    {
+      "id": "htdemucs_6s",
+      "kind": "primary",
+      "engine": "audio_separator",
+      "architecture": "demucs",
+      "family": "demucs_v4",
+      "backend_arg": "htdemucs_6s.yaml",
+      "default": false,
+      "hidden": false,
+      "experimental": false,
+      "output_contract": {
+        "stems": [
+          "vocals",
+          "drums",
+          "bass",
+          "guitar",
+          "piano",
+          "other"
+        ],
+        "stem_semantics": "full_mix_decomposition",
+        "expected_outputs": 6
+      },
+      "validation": {
+        "expected_outputs": 6,
+        "expected_stems": [
+          "vocals",
+          "drums",
+          "bass",
+          "guitar",
+          "piano",
+          "other"
+        ],
+        "contract_form": "stem->path JSON map van runtime; bestandsnamen runtime-managed"
+      },
+      "runtime": {
+        "profiles": [
+          "cpu",
+          "cuda",
+          "rocm",
+          "directml",
+          "mps"
+        ],
+        "cpu_warning": false,
+        "experimental_on": []
+      },
+      "download": {
+        "online": true,
+        "offline_pack": "core",
+        "integrity": {
+          "mechanism": "demucs_content_hash_filenames + download_checks.json (runtime-validated)",
+          "files": [
+            "htdemucs_6s.yaml",
+            "5c90dfd2-34c22ccb.th"
+          ]
+        }
+      },
+      "packaging": {
+        "bundled_in_installer": true,
+        "release_gate_required": true
+      },
+      "ui": {
+        "label_key": "model_label_6stem",
+        "tooltip_key": "model_6stem_desc",
+        "fallback_label": "6-Stem",
+        "tier": "fast",
+        "order": 30,
+        "$comment": "Footer-contexten gebruiken model_label_expanded als alias voor htdemucs_6s (STEMwerk.lua); dat blijft een UI-keuze buiten de registry."
+      },
+      "provenance": {
+        "author": "Meta AI (Demucs v4, 6 sources)",
+        "license": "MIT",
+        "source": "facebookresearch/demucs via audio-separator"
+      }
+    },
+    {
+      "id": "stemwerk_dks",
+      "kind": "internal_stage",
+      "engine": "stemwerk_internal",
+      "architecture": "dks",
+      "family": "stemwerk_dks",
+      "backend_arg": null,
+      "default": false,
+      "hidden": true,
+      "experimental": false,
+      "$comment": "GEEN los selecteerbaar model; contract-anker voor presets en gate. De DKS-runtime (aparte runtime-isolatie, drumsep_mps_direct_demix, stage2 concurrency-caps, mirror-fallback voor de dode ckpt-URL) blijft volledig buiten de registry.",
+      "runtime_managed_assets": {
+        "$comment": "Informatief, beheerd door de bestaande DKS-runtime — registry stuurt hier niets mee aan.",
+        "stage2_model_alias": "MDX23C-DrumSep-aufr33-jarredou.ckpt",
+        "stage2_model_filename": "aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.ckpt",
+        "stage2_model_yaml": "aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.yaml",
+        "catalog_entry_name": "MDX23C Model: DrumSep 6stem | (by aufr33 & jarredou)"
+      },
+      "output_contract": {
+        "input_stem": "drums",
+        "stems": [
+          "kick",
+          "snare",
+          "toms",
+          "hihat",
+          "ride",
+          "crash"
+        ],
+        "stem_semantics": "split",
+        "expected_outputs": 6,
+        "$comment": "Volgorde exact DIRECT_DKS_EXPECTED_STEMS (audio_separator_process.py:75)."
+      },
+      "validation": {
+        "expected_outputs": 6,
+        "expected_filenames": [
+          "kick.wav",
+          "snare.wav",
+          "toms.wav",
+          "hi-hat.wav",
+          "ride.wav",
+          "crash.wav"
+        ],
+        "$comment": "REAPER-facing bestandsnamen via key_to_reaper mapping (hihat -> hi-hat.wav); runtime faalt hard met drumsep_output_count_mismatch bij <6 stems, incl. de 'only Kick and Snare' backend-limited classificatie."
+      },
+      "runtime": {
+        "profiles": [
+          "cpu",
+          "cuda",
+          "rocm",
+          "directml",
+          "mps"
+        ],
+        "cpu_warning": false,
+        "experimental_on": []
+      },
+      "download": {
+        "registry_managed_download": false,
+        "runtime_managed_repair": true,
+        "offline_pack": "core/drumsep-models",
+        "$comment": "De registry downloadt niets voor DKS; de bestaande runtime behoudt volledige repair-logica (Setup/Repair, mirror-fallback voor de dode ckpt-URL, download_checks.json).",
+        "integrity": {
+          "mechanism": "managed_by_existing_dks_runtime (download_checks.json + mirror fallback in stemwerk_drumsep_process.py)",
+          "files": [
+            "aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.ckpt",
+            "aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.yaml"
+          ]
+        }
+      },
+      "packaging": {
+        "bundled_in_installer": true,
+        "release_gate_required": true
+      },
+      "ui": {
+        "label_key": null,
+        "tooltip_key": "model_expanded_drumkit_desc",
+        "fallback_label": "DKS (intern)",
+        "tier": "internal",
+        "order": 0
+      },
+      "provenance": {
+        "author": "aufr33 & jarredou (model); flarkAUDIO (DKS runtime/workflow)",
+        "license_status": "existing_payload_unverified",
+        "redistribution_status": "already_in_existing_STEMwerk_payload",
+        "source": "audio-separator model catalog + STEMwerk DKS runtime"
+      }
+    },
+    {
+      "id": "bs_roformer_viperx",
+      "kind": "primary",
+      "engine": "audio_separator",
+      "architecture": "mdxc",
+      "family": "roformer",
+      "backend_arg": "model_bs_roformer_ep_317_sdr_12.9755.ckpt",
+      "default": false,
+      "hidden": true,
+      "experimental": true,
+      "$comment": "Geverifieerde filename (audio-separator --list_models). Niet zichtbaar in UI, geen installer-payload, buiten normale release-gate. Activatie is een 2.4-beslissing na eigen smoke-matrix.",
+      "output_contract": {
+        "stems": [
+          "vocals",
+          "instrumental"
+        ],
+        "stem_semantics": "complement",
+        "expected_outputs": 2
+      },
+      "validation": {
+        "expected_outputs": 2,
+        "expected_stems": [
+          "vocals",
+          "instrumental"
+        ],
+        "contract_form": "TODO_VERIFY_ON_OWN_RUNTIME — toegestaan: hidden+experimental valt buiten de TODO-gate-check"
+      },
+      "runtime": {
+        "profiles": [
+          "cuda",
+          "cpu"
+        ],
+        "cpu_warning": true,
+        "experimental_on": [
+          "directml",
+          "rocm",
+          "mps"
+        ]
+      },
+      "download": {
+        "online": true,
+        "offline_pack": "premium-vocals (nog niet gebouwd)",
+        "integrity": {
+          "mechanism": "audio-separator download_checks.json",
+          "files": [
+            "model_bs_roformer_ep_317_sdr_12.9755.ckpt"
+          ]
+        }
+      },
+      "packaging": {
+        "bundled_in_installer": false,
+        "release_gate_required": false
+      },
+      "ui": {
+        "label_key": null,
+        "tooltip_key": null,
+        "fallback_label": "Vocals HQ (BS-Roformer) [experimental]",
+        "tier": "premium",
+        "order": 100
+      },
+      "provenance": {
+        "author": "viperx (UVR community)",
+        "license": "TODO_VERIFY_BEFORE_ACTIVATION (toegestaan: hidden+experimental)",
+        "source": "nomadkaraoke/python-audio-separator model list"
+      }
+    }
+  ],
+  "presets": [
+    {
+      "id": "all_stems",
+      "label_key": "workflow_all_stems_label",
+      "fallback_label": "All Stems",
+      "workflow": {
+        "primary_model": "user_selected",
+        "select": "all_stems_of_primary_model",
+        "stages": []
+      },
+      "release_gate_required": true
+    },
+    {
+      "id": "direct_kit",
+      "label_key": "workflow_drumkit_label",
+      "fallback_label": "Direct Kit",
+      "shortcut": "Z",
+      "$comment": "Bestaande Direct DKS-route: DKS-model DIRECT op de bronaudio, ZONDER voorafgaande Demucs-stage (workflow_source direct; help_native_direct_kit_desc: 'Direct drum-kit split'). Geen primary demucs-model in deze workflow.",
+      "workflow": {
+        "primary_model": null,
+        "select": null,
+        "stages": [
+          {
+            "stage": "stemwerk_dks",
+            "input": "source_audio",
+            "replaces_input": true
+          }
+        ]
+      },
+      "final_output_contract": {
+        "stems": [
+          "kick",
+          "snare",
+          "toms",
+          "hihat",
+          "ride",
+          "crash"
+        ],
+        "expected_outputs": 6,
+        "expected_filenames": [
+          "kick.wav",
+          "snare.wav",
+          "toms.wav",
+          "hi-hat.wav",
+          "ride.wav",
+          "crash.wav"
+        ]
+      },
+      "release_gate_required": true
+    },
+    {
+      "id": "drum_kit_split",
+      "label_key": "workflow_edks_label",
+      "fallback_label": "Kit Split",
+      "shortcut": "X",
+      "$comment": "Bestaande extract-DKS (edks) route: stage1 = normale separatie met het door de gebruiker geselecteerde model (stage1_model = run_model, output in stage1_normal/), stage2 = DKS op de drums-stem (stage2_drumsep/). help_native_kit_split_desc: 'Two-step drum workflow'.",
+      "workflow": {
+        "primary_model": "user_selected",
+        "select": "per_user_selection",
+        "stages": [
+          {
+            "stage": "stemwerk_dks",
+            "input_stem": "drums",
+            "replaces_input": true
+          }
+        ]
+      },
+      "final_output_contract": {
+        "validated_stage2_stems": [
+          "kick",
+          "snare",
+          "toms",
+          "hihat",
+          "ride",
+          "crash"
+        ],
+        "validated_stage2_expected_outputs": 6,
+        "expected_filenames_stage2": [
+          "kick.wav",
+          "snare.wav",
+          "toms.wav",
+          "hi-hat.wav",
+          "ride.wav",
+          "crash.wav"
+        ],
+        "stage1_stems": "volgen output_contract van het geselecteerde primary model; levering per bestaand workflow-gedrag",
+        "$comment": "De runtime valideert hard op de 6 stage2 kit-parts (drumsep_output_count_mismatch). Welke stage1-stems geïmporteerd worden is bestaand workflow-gedrag en geen registry-beslissing."
+      },
+      "release_gate_required": true
+    }
+  ],
+  "release_gate": {
+    "$comment": "Machine-checkbare regels voor de bestaande gate/smoke tooling.",
+    "backlog": [
+      "license-gate: overweeg voor een latere major release een check 'no license_status == existing_payload_unverified'. Expliciet GEEN blocker voor 2.3.x registry-only."
+    ],
+    "checks": [
+      "schema_version == 2",
+      "exactly one active (hidden==false) model has default == true",
+      "all active models have validation.expected_outputs and a complete output_contract",
+      "hidden experimental PRIMARY models are ignored by the normal release gate",
+      "hidden internal_stage entries referenced by any release_gate_required preset MUST be fully validated (output_contract + validation + packaging), hidden status notwithstanding",
+      "no active model or gate-required internal_stage uses a runtime profile outside runtime_profiles",
+      "no active model or gate-required internal_stage resolves model files outside paths.model_file_dir (env-override excepted)",
+      "DKS presets resolve to stage 'stemwerk_dks' (existing STEMwerk DKS runtime), never to an upstream 4-part drumsep model",
+      "UI labels resolve via i18n label_key/tooltip_key against languages.lua (fallback_label only as last resort); runtime decisions never read ui.* or presets for device/backend selection",
+      "no TODO_ placeholder in any active (hidden==false) model or in any release_gate_required preset/internal_stage contract"
+    ]
+  },
+  "backlog": [
+    "Registry.presets() defensive-copy maken voor/tijdens UI/preset-migratie (preset-tabellen zijn gevoelig voor UI-state-verrijking)",
+    "daarna models()/get()/runtime() read-only of deep-copy bekijken; backend() en ui() bouwen al verse tabellen en zijn veilig",
+    "ui.shortcut (F/Q/S model-sneltoetsen) naar registry verplaatsen zodra schema-uitbreiding gewenst is; tot die tijd lokaal in STEMwerk.lua"
+  ]
+}

--- a/tests/lua/test_model_registry.lua
+++ b/tests/lua/test_model_registry.lua
@@ -1,0 +1,155 @@
+--[[
+  tests/lua/test_model_registry.lua — headless registry-test (commit 2)
+  Draaien met standalone Lua 5.3/5.4 vanuit de repo-root:
+      lua5.4 tests/lua/test_model_registry.lua
+  Zelfde patroon als tests/support/run_support_bundle_headless.lua: geen REAPER nodig.
+]]
+
+local passed, failed = 0, 0
+
+local function check(name, ok, detail)
+    if ok then
+        passed = passed + 1
+        print("PASS  " .. name)
+    else
+        failed = failed + 1
+        print("FAIL  " .. name .. (detail and ("  -- " .. tostring(detail)) or ""))
+    end
+end
+
+local function expect_error(name, fn, pattern)
+    local ok, err = pcall(fn)
+    if ok then
+        check(name, false, "verwachtte hard fail, maar er kwam geen error")
+    else
+        local msg = tostring(err)
+        check(name, pattern == nil or msg:find(pattern, 1, true) ~= nil,
+              "error kwam, maar zonder verwacht patroon '" .. tostring(pattern) .. "': " .. msg)
+    end
+end
+
+-- registry laden vanaf repo-root
+local Registry = dofile("scripts/reaper/_internal/STEMwerk_Model_Registry.lua")
+
+-- ---------------------------------------------------------------------------
+-- Happy path tegen de echte models.json
+-- ---------------------------------------------------------------------------
+
+local models = Registry.models()
+check("models(): drie actieve modellen", #models == 3, "#models=" .. #models)
+check("models(): gesorteerd op ui.order",
+      models[1].id == "htdemucs" and models[2].id == "htdemucs_ft" and models[3].id == "htdemucs_6s")
+check("models(): hidden entries niet zichtbaar", (function()
+    for _, m in ipairs(models) do
+        if m.id == "bs_roformer_viperx" or m.id == "stemwerk_dks" then return false end
+    end
+    return true
+end)())
+
+check("default_id() == htdemucs (matcht SETTINGS.model)", Registry.default_id() == "htdemucs")
+
+local stems6 = Registry.stems("htdemucs_6s")
+check("stems(htdemucs_6s): 6 stems", #stems6 == 6)
+check("has_stem(htdemucs_6s, guitar)", Registry.has_stem("htdemucs_6s", "guitar"))
+check("has_stem(htdemucs, guitar) == false", not Registry.has_stem("htdemucs", "guitar"))
+check("expected_outputs(htdemucs) == 4", Registry.expected_outputs("htdemucs") == 4)
+
+check("stem_semantics(htdemucs) == full_mix_decomposition",
+      Registry.stem_semantics("htdemucs") == "full_mix_decomposition")
+
+local dks = Registry.get("stemwerk_dks")
+check("DKS via get() bereikbaar ondanks hidden", dks ~= nil and dks.kind == "internal_stage")
+check("DKS stems-volgorde == DIRECT_DKS_EXPECTED_STEMS", (function()
+    local expect = { "kick", "snare", "toms", "hihat", "ride", "crash" }
+    local got = Registry.stems("stemwerk_dks")
+    if #got ~= #expect then return false end
+    for i = 1, #expect do
+        if got[i] ~= expect[i] then return false end
+    end
+    return true
+end)())
+
+local backend = Registry.backend("htdemucs_ft")
+check("backend(htdemucs_ft): engine audio_separator + yaml arg",
+      backend.engine == "audio_separator" and backend.backend_arg == "htdemucs_ft.yaml")
+
+local ui = Registry.ui("htdemucs")
+check("ui(htdemucs): label_key aanwezig", ui.label_key == "model_label_fast")
+
+check("preset(direct_kit): primary_model == nil (Direct DKS zonder Demucs-stage)",
+      Registry.preset("direct_kit").workflow.primary_model == nil)
+check("preset(drum_kit_split): primary_model == user_selected",
+      Registry.preset("drum_kit_split").workflow.primary_model == "user_selected")
+check("validate_preset_stages()", Registry.validate_preset_stages() == true)
+
+check("stems() retourneert een kopie — mutatie raakt registry-state niet", (function()
+    local first = Registry.stems("htdemucs_6s")
+    first[1] = "GEMUTEERD"
+    first[#first + 1] = "extra"
+    local second = Registry.stems("htdemucs_6s")
+    return second[1] == "vocals" and #second == 6
+end)())
+
+-- ---------------------------------------------------------------------------
+-- Hard-fail gedrag (registry_policy)
+-- ---------------------------------------------------------------------------
+
+expect_error("get(onbekend id) hard-failt",
+    function() Registry.get("htdemucs_9000") end, "onbekend model-id")
+
+expect_error("stems(onbekend id) hard-failt — geen stille 4-stem fallback",
+    function() Registry.stems("does_not_exist") end, "onbekend model-id")
+
+expect_error("preset(onbekend id) hard-failt",
+    function() Registry.preset("nope") end, "onbekend preset-id")
+
+check("exists() is de enige nil-veilige probe",
+      Registry.exists("htdemucs") == true and Registry.exists("nope") == false)
+
+-- ---------------------------------------------------------------------------
+-- Hard fail op kapotte manifests (verse module-instanties met eigen pad)
+-- ---------------------------------------------------------------------------
+
+local function fresh_registry_with(json_text)
+    local tmp = os.tmpname()
+    local fh = assert(io.open(tmp, "w"))
+    fh:write(json_text)
+    fh:close()
+    local reg = dofile("scripts/reaper/_internal/STEMwerk_Model_Registry.lua")
+    reg.set_manifest_path(tmp)
+    return reg, tmp
+end
+
+do
+    local reg = fresh_registry_with('{ "schema_version": 1, "models": [] }')
+    expect_error("schema_version != 2 hard-failt",
+        function() reg.models() end, "schema_version")
+end
+
+do
+    local reg = fresh_registry_with('{ "schema_version": 2, "models": [ { "id": "x" } ] }')
+    expect_error("registry_policy ontbreekt -> hard fail",
+        function() reg.models() end, "registry_policy")
+end
+
+do
+    local reg = fresh_registry_with([[{
+        "schema_version": 2,
+        "registry_policy": { "unknown_model_id": "hard_fail", "silent_fallback_to_default": false },
+        "stem_semantics_types": { "full_mix_decomposition": "" },
+        "models": [ { "id": "broken", "hidden": false, "default": true } ]
+    }]])
+    expect_error("ontbrekend output_contract hard-failt",
+        function() reg.stems("broken") end, "output_contract")
+end
+
+do
+    local reg = fresh_registry_with('{ not valid json !!! }')
+    expect_error("ongeldige JSON hard-failt met positie-info",
+        function() reg.models() end, "JSON-fout")
+end
+
+-- ---------------------------------------------------------------------------
+
+print(("\n%d passed, %d failed"):format(passed, failed))
+os.exit(failed == 0 and 0 or 1)

--- a/tests/test_model_registry_schema.py
+++ b/tests/test_model_registry_schema.py
@@ -1,0 +1,171 @@
+"""Schema/gate-validatie voor scripts/reaper/models.json (registry schema v2).
+
+Commit-1 scope: dit bestand valideert UITSLUITEND het registry-artifact.
+Het importeert geen runtime-code, wijzigt geen gedrag en draait mee in de
+bestaande pytest-suite. De checks implementeren release_gate.checks uit
+models.json zelf, voor zover mechanisch checkbaar.
+
+Verwachte locatie van de registry: scripts/reaper/models.json
+(naast STEMwerk.lua, zodat de latere Lua-registry hem relatief kan laden).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REGISTRY_PATH = REPO_ROOT / "scripts" / "reaper" / "models.json"
+
+REQUIRED_MODEL_FIELDS = (
+    "id", "kind", "engine", "backend_arg", "default", "hidden",
+    "experimental", "output_contract", "validation", "runtime",
+    "download", "packaging", "ui", "provenance",
+)
+REQUIRED_CONTRACT_FIELDS = ("stems", "stem_semantics", "expected_outputs")
+
+
+@pytest.fixture(scope="module")
+def registry() -> dict:
+    assert REGISTRY_PATH.is_file(), f"registry ontbreekt: {REGISTRY_PATH}"
+    with REGISTRY_PATH.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _active_models(reg: dict) -> list[dict]:
+    return [m for m in reg["models"] if not m.get("hidden", False)]
+
+
+def _gate_required_internal_stages(reg: dict) -> list[dict]:
+    """Hidden internal_stage entries die door gate-required presets gebruikt
+    worden vallen BINNEN de gate, hidden status notwithstanding."""
+    referenced: set[str] = set()
+    for preset in reg.get("presets", []):
+        if not preset.get("release_gate_required", False):
+            continue
+        for stage in (preset.get("workflow") or {}).get("stages", []):
+            referenced.add(stage.get("stage", ""))
+    return [
+        m for m in reg["models"]
+        if m.get("kind") == "internal_stage" and m["id"] in referenced
+    ]
+
+
+def _gate_scope(reg: dict) -> list[dict]:
+    return _active_models(reg) + _gate_required_internal_stages(reg)
+
+
+def test_schema_version(registry):
+    assert registry.get("schema_version") == 2
+
+
+def test_exactly_one_active_default(registry):
+    defaults = [m["id"] for m in _active_models(registry) if m.get("default")]
+    assert defaults == ["htdemucs"], f"verwacht exact één actieve default, kreeg: {defaults}"
+
+
+def test_all_required_fields_present_in_gate_scope(registry):
+    for model in _gate_scope(registry):
+        for field in REQUIRED_MODEL_FIELDS:
+            assert field in model, f"{model.get('id', '?')}: veld '{field}' ontbreekt"
+
+
+def test_output_contracts_complete_and_consistent(registry):
+    for model in _gate_scope(registry):
+        contract = model["output_contract"]
+        for field in REQUIRED_CONTRACT_FIELDS:
+            assert field in contract, f"{model['id']}: output_contract.{field} ontbreekt"
+        assert contract["expected_outputs"] == len(contract["stems"]), (
+            f"{model['id']}: expected_outputs != len(stems)"
+        )
+        assert model["validation"]["expected_outputs"] == contract["expected_outputs"], (
+            f"{model['id']}: validation.expected_outputs wijkt af van output_contract"
+        )
+        assert contract["stem_semantics"] in registry["stem_semantics_types"], (
+            f"{model['id']}: onbekende stem_semantics '{contract['stem_semantics']}'"
+        )
+
+
+def test_runtime_profiles_are_known(registry):
+    known = set(registry["runtime_profiles"].keys()) - {"$comment"}
+    for model in _gate_scope(registry):
+        for profile in model["runtime"]["profiles"]:
+            assert profile in known, f"{model['id']}: onbekend runtime profile '{profile}'"
+        for profile in model["runtime"].get("experimental_on", []):
+            assert profile in known, f"{model['id']}: onbekend experimental profile '{profile}'"
+
+
+def test_model_file_dir_structure(registry):
+    mfd = registry["paths"]["model_file_dir"]
+    assert mfd.get("env_override") == "AUDIO_SEPARATOR_MODEL_DIR"
+    assert "%LOCALAPPDATA%/STEMwerk/models" in mfd["windows"]
+    assert "Application Support/STEMwerk/models" in mfd["macos"]
+    linux = mfd["linux"]
+    assert linux["xdg_env"] == "XDG_DATA_HOME"
+    assert linux["xdg_relative"] == "STEMwerk/models"
+    assert linux["fallback"] == "~/.local/share/STEMwerk/models"
+
+
+def test_dks_presets_resolve_to_stemwerk_dks(registry):
+    model_ids = {m["id"] for m in registry["models"]}
+    for preset in registry.get("presets", []):
+        for stage in (preset.get("workflow") or {}).get("stages", []):
+            stage_id = stage["stage"]
+            assert stage_id in model_ids, f"preset {preset['id']}: onbekende stage '{stage_id}'"
+            stage_model = next(m for m in registry["models"] if m["id"] == stage_id)
+            assert stage_model["kind"] == "internal_stage", (
+                f"preset {preset['id']}: stage '{stage_id}' is geen internal_stage"
+            )
+        if preset["id"] in ("direct_kit", "drum_kit_split"):
+            stages = [s["stage"] for s in preset["workflow"]["stages"]]
+            assert stages == ["stemwerk_dks"], (
+                f"DKS-preset {preset['id']} moet exact naar stemwerk_dks verwijzen, kreeg: {stages}"
+            )
+
+
+def test_dks_contract_matches_runtime_constants(registry):
+    """Pin het DKS-contract op DIRECT_DKS_EXPECTED_STEMS en de key_to_reaper
+    bestandsnamen. Wijzigt de runtime, dan hoort deze test bewust te breken."""
+    dks = next(m for m in registry["models"] if m["id"] == "stemwerk_dks")
+    assert dks["output_contract"]["stems"] == ["kick", "snare", "toms", "hihat", "ride", "crash"]
+    assert dks["validation"]["expected_filenames"] == [
+        "kick.wav", "snare.wav", "toms.wav", "hi-hat.wav", "ride.wav", "crash.wav",
+    ]
+
+
+def test_ui_labels_resolvable(registry):
+    for model in _active_models(registry):
+        ui = model["ui"]
+        assert ui.get("label_key") or ui.get("fallback_label"), (
+            f"{model['id']}: geen label_key en geen fallback_label"
+        )
+
+
+def test_no_todo_in_gate_scope(registry):
+    for model in _gate_scope(registry):
+        blob = json.dumps(model)
+        assert not re.search(r"TODO_", blob), f"{model['id']}: TODO_ placeholder in gate-scope"
+    for preset in registry.get("presets", []):
+        if preset.get("release_gate_required"):
+            assert not re.search(r"TODO_", json.dumps(preset)), (
+                f"preset {preset['id']}: TODO_ placeholder in gate-required preset"
+            )
+
+
+def test_hidden_experimental_primaries_outside_gate(registry):
+    """Sanity: viperx mag TODO's bevatten en wordt door bovenstaande checks
+    genegeerd — deze test documenteert dat dat bewust is."""
+    viperx = next(m for m in registry["models"] if m["id"] == "bs_roformer_viperx")
+    assert viperx["hidden"] is True
+    assert viperx["experimental"] is True
+    assert viperx["packaging"]["release_gate_required"] is False
+    assert viperx not in _gate_scope(registry)
+
+
+def test_registry_policy_hard_fail(registry):
+    policy = registry["registry_policy"]
+    assert policy["unknown_model_id"] == "hard_fail"
+    assert policy["silent_fallback_to_default"] is False

--- a/tools/release_gate.py
+++ b/tools/release_gate.py
@@ -22,6 +22,8 @@ REQUIRED_TOP_LEVEL_SCRIPTS = (
 )
 
 RUNTIME_DEP_REGRESSION_TARGET = "scripts/reaper/_internal/STEMwerk_Timing.lua"
+MODEL_REGISTRY_LUA = "scripts/reaper/_internal/STEMwerk_Model_Registry.lua"
+MODEL_REGISTRY_MANIFEST = "scripts/reaper/models.json"
 BOOTSTRAP_MACOS = "scripts/reaper/STEMwerk_Bootstrap_macOS.sh"
 SAMPLERATE_GUARD_REL = "_internal/stemwerk_samplerate_guard.py"
 SAMPLERATE_GUARD_PAYLOAD_PATH = f"scripts/reaper/{SAMPLERATE_GUARD_REL}"
@@ -267,6 +269,27 @@ def check_runtime_dependencies(root: Path, payload_paths: set[str]) -> Section:
         section.fail(f"regression guard: missing local dependency {timing_path}")
     if timing_path not in payload_paths:
         section.fail(f"regression guard: missing index.xml payload entry for {timing_path}")
+
+    # Paired data dependency: de model registry (Lua) hard-failt bij startup
+    # als scripts/reaper/models.json ontbreekt. Zodra de registry-module in
+    # gebruik is (lokaal aanwezig, als dep gedetecteerd of in de payload),
+    # MOET het manifest lokaal bestaan en in de index.xml payload zitten.
+    registry_in_use = (
+        (root / MODEL_REGISTRY_LUA).exists()
+        or MODEL_REGISTRY_LUA in deps
+        or MODEL_REGISTRY_LUA in payload_paths
+    )
+    if registry_in_use:
+        if not (root / MODEL_REGISTRY_MANIFEST).exists():
+            section.fail(
+                f"model registry guard: {MODEL_REGISTRY_LUA} in use but local manifest missing: {MODEL_REGISTRY_MANIFEST}"
+            )
+        if MODEL_REGISTRY_MANIFEST not in payload_paths:
+            section.fail(
+                f"model registry guard: missing index.xml payload entry for {MODEL_REGISTRY_MANIFEST}"
+            )
+        if section.status != "FAIL":
+            section.note(f"model registry manifest paired with {MODEL_REGISTRY_LUA}: OK")
 
     section.note(f"statically detected internal runtime deps: {len(deps)}")
     return section


### PR DESCRIPTION
Adds a metadata-only model registry foundation on top of v2.3.0.4.

Included:
- models.json schema v2
- hard-failing Lua registry module
- schema and Lua registry tests
- model list / description / allowlist wiring through registry
- ReaPack payload entries for models.json and registry module
- release-gate paired guard to ensure registry module and manifest ship together

Scope:
- no Python runtime dispatch changes
- no new active models
- no Roformer activation
- no DKS runtime changes
- no processing workflow changes
- no installer/runtime behavior changes

Validation:
- release_gate.py --check PASS
- registry schema pytest: 12 passed
- Lua registry tests: 25 passed on Lua 5.4 and Lua 5.5
- STEMwerk.lua luac5.4 compile PASS
- REAPER UI smoke PASS
- allowlist smoke PASS
- MCP preflight snapshot PASS
- manual Fast/default processing smoke PASS:
  - 1 selected item
  - All/Fast normal route
  - 4 outputs: vocals, drums, bass, other
  - no DKS / Kit Split / Roformer traces
  - post-smoke logs clean

Known non-blockers:
- Lua 5.3 unavailable locally; Lua 5.4/5.5 passed
- broad pytest suite already has unrelated baseline/environment noise on this machine
- model/backend/device were not explicitly written in the parsed JSONL logs, but UI reported successful GPU method and expected 4-output result

Backlog:
- defensive-copy/read-only review for models()/get()/runtime()/presets()
- DKS license_status remains existing_payload_unverified
- optional MCP improvement: explicit STEMwerk preflight action token targeting
