### PR TITLE
runtime: add dev-only Vocals HQ model proof

### DIFF
--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -3266,6 +3266,53 @@ def _get_last_output_mapping_info() -> Dict[str, Any]:
     return dict(_LAST_OUTPUT_MAPPING_INFO)
 
 
+def _match_named_stem_label(path: Path, labels: Set[str]) -> Optional[str]:
+    stem_name = path.stem
+    for label in re.findall(r"\(([^()]+)\)", stem_name):
+        normalized = str(label or "").strip().lower()
+        if normalized in labels:
+            return normalized
+    return None
+
+
+def _infer_complement_basename(path: Path) -> str:
+    stem_name = path.stem
+    match = re.match(r"^(?P<prefix>.+?)_\((?:vocals|instrumental|no vocals|no_vocals)\)", stem_name, re.IGNORECASE)
+    if match:
+        return str(match.group("prefix") or "").strip().lower()
+    return ""
+
+
+def _discover_complement_fallback_stems(
+    output_root: Path, known_paths: List[Path]
+) -> Tuple[Dict[str, Path], List[str]]:
+    known_resolved = {str(path.resolve()).lower() for path in known_paths}
+    prefix_hints = {hint for hint in (_infer_complement_basename(path) for path in known_paths) if hint}
+    label_to_target = {"vocals": "vocals", "instrumental": "other", "no vocals": "other", "no_vocals": "other"}
+    candidates: Dict[str, Path] = {}
+    candidate_names: List[str] = []
+    audio_suffixes = {".wav", ".flac", ".mp3", ".ogg", ".m4a", ".aif", ".aiff"}
+
+    for candidate in sorted(output_root.iterdir(), key=lambda p: p.name.lower()):
+        if not candidate.is_file() or candidate.suffix.lower() not in audio_suffixes:
+            continue
+        resolved_key = str(candidate.resolve()).lower()
+        if resolved_key in known_resolved:
+            continue
+        label = _match_named_stem_label(candidate, set(label_to_target))
+        if label is None:
+            continue
+        prefix = _infer_complement_basename(candidate)
+        if prefix_hints and prefix and prefix not in prefix_hints:
+            continue
+        target_name = label_to_target[label]
+        candidate_names.append(str(candidate))
+        if target_name not in candidates:
+            candidates[target_name] = candidate
+
+    return candidates, candidate_names
+
+
 def _complement_contract_info(registry_entry: Optional[Dict[str, Any]]) -> Tuple[bool, int]:
     entry = registry_entry if isinstance(registry_entry, dict) else {}
     contract = entry.get("output_contract") if isinstance(entry.get("output_contract"), dict) else {}
@@ -3312,13 +3359,46 @@ def _map_reaper_stems_from_result(
         "raw_output_files": [],
         "mapped_reaper_stems": {},
         "instrumental_as_other": False,
+        "fallback_output_scan_used": False,
+        "fallback_output_scan_candidates": [],
     }
 
+    source_entries: List[Tuple[str, Path]] = []
     reaper_stems: Dict[str, str] = {}
     for stem_name, stem_path in result.stems.items():
         abs_path = _resolve_stem_path(output_root, stem_path)
         if not abs_path.exists():
             raise FileNotFoundError(f"Expected separated stem not found: {abs_path}")
+        source_entries.append((stem_name, abs_path))
+
+    if complement_contract and len(source_entries) < complement_expected:
+        existing_targets = set()
+        for stem_name, abs_path in source_entries:
+            filename = abs_path.stem.lower()
+            if "instrumental" in filename or "no_vocals" in filename:
+                existing_targets.add("other")
+            elif "vocals" in filename:
+                existing_targets.add("vocals")
+            elif str(stem_name or "").strip().lower() in {"vocals", "other"}:
+                existing_targets.add(str(stem_name or "").strip().lower())
+        fallback_stems, fallback_candidates = _discover_complement_fallback_stems(
+            output_root,
+            [path for _, path in source_entries],
+        )
+        mapping_info["fallback_output_scan_candidates"] = fallback_candidates
+        added = False
+        for target_name in ("vocals", "other"):
+            if target_name in existing_targets:
+                continue
+            fallback_path = fallback_stems.get(target_name)
+            if fallback_path is None:
+                continue
+            source_entries.append((target_name, fallback_path))
+            existing_targets.add(target_name)
+            added = True
+        mapping_info["fallback_output_scan_used"] = added
+
+    for stem_name, abs_path in source_entries:
 
         mapping_info["raw_output_files"].append(str(abs_path))
         filename = abs_path.stem.lower()
@@ -3340,6 +3420,8 @@ def _map_reaper_stems_from_result(
         mapping_info["mapped_reaper_stems"][target_name] = str(new_path)
         print(f"  {target_name}:  {new_path}", file=sys.stderr)
 
+    _LAST_OUTPUT_MAPPING_INFO = mapping_info
+
     if complement_contract:
         if len(mapping_info["raw_output_files"]) != complement_expected:
             raise RuntimeError(
@@ -3350,7 +3432,6 @@ def _map_reaper_stems_from_result(
                 f"Complement output contract expected REAPER stems vocals+other, got {sorted(reaper_stems)}"
             )
 
-    _LAST_OUTPUT_MAPPING_INFO = mapping_info
     return reaper_stems
 
 
@@ -4771,6 +4852,15 @@ def main():
         print(
             "mapped_reaper_stems="
             + json.dumps(mapping_info.get("mapped_reaper_stems") or {}, sort_keys=True, ensure_ascii=False),
+            file=sys.stderr,
+        )
+        print(
+            "fallback_output_scan_candidates="
+            + json.dumps(mapping_info.get("fallback_output_scan_candidates") or [], ensure_ascii=False),
+            file=sys.stderr,
+        )
+        print(
+            f"fallback_output_scan_used={'true' if mapping_info.get('fallback_output_scan_used') else 'false'}",
             file=sys.stderr,
         )
         if mapping_info.get("instrumental_as_other"):

--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -77,6 +77,23 @@ LOW_VRAM_THRESHOLD_BYTES = 6 * 1024 * 1024 * 1024
 CUDA_DKS_RUNTIME_GUIDANCE = "CUDA Drum Kit Split failed on this GPU. Try CPU/low-VRAM mode or rebuild/repair runtime."
 DRUMSEP_HELPER_POLL_INTERVAL_SECONDS = 2.0
 DRUMSEP_HELPER_NO_OUTPUT_STALL_SECONDS = 60 * 60
+EXPERIMENTAL_MODELS_ENABLE_ENV = "STEMWERK_ENABLE_EXPERIMENTAL_MODELS"
+EXPERIMENTAL_MODEL_ID_ENV = "STEMWERK_EXPERIMENTAL_MODEL_ID"
+# Dev-only proof guard: hidden experimental primaries are not allowed through the
+# normal CLI model route without the explicit env gate below.
+EXPERIMENTAL_ENV_ONLY_MODEL_IDS = {"bs_roformer_viperx"}
+_RUNTIME_REGISTRY_ALLOWED_FIELDS = {
+    "id",
+    "kind",
+    "hidden",
+    "experimental",
+    "engine",
+    "backend_arg",
+    "architecture",
+    "family",
+    "output_contract",
+    "validation",
+}
 
 
 def _prefer_vendored_stemwerk_core() -> None:
@@ -1054,6 +1071,77 @@ def _resolve_run_model(args: argparse.Namespace) -> str:
         if requested:
             return requested
     return str(getattr(args, "model", "htdemucs") or "htdemucs")
+
+
+def _runtime_registry_path() -> Path:
+    return Path(__file__).resolve().with_name("models.json")
+
+
+def _load_runtime_registry_entry(model_id: str) -> Dict[str, Any]:
+    registry_path = _runtime_registry_path()
+    payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    models = payload.get("models")
+    if not isinstance(models, list):
+        raise RuntimeError(f"Invalid runtime registry at {registry_path}: models list missing")
+    for entry in models:
+        if not isinstance(entry, dict):
+            continue
+        if str(entry.get("id") or "").strip() != model_id:
+            continue
+        return {key: entry.get(key) for key in _RUNTIME_REGISTRY_ALLOWED_FIELDS}
+    raise RuntimeError(f"Unknown experimental model id: {model_id}")
+
+
+def _resolve_normal_route_model_selection(args: argparse.Namespace) -> Dict[str, Any]:
+    requested_model_id = str(getattr(args, "model", "htdemucs") or "htdemucs").strip() or "htdemucs"
+    enable_value = str(os.environ.get(EXPERIMENTAL_MODELS_ENABLE_ENV, "") or "").strip()
+    experimental_model_id = str(os.environ.get(EXPERIMENTAL_MODEL_ID_ENV, "") or "").strip()
+    enable_present = enable_value != ""
+    model_present = experimental_model_id != ""
+
+    if not enable_present and not model_present:
+        if requested_model_id in EXPERIMENTAL_ENV_ONLY_MODEL_IDS:
+            raise RuntimeError(
+                "Hidden experimental model ids require the explicit env gate. "
+                f"Set both {EXPERIMENTAL_MODELS_ENABLE_ENV}=1 and {EXPERIMENTAL_MODEL_ID_ENV}=<model-id>."
+            )
+        return {
+            "requested_model_id": requested_model_id,
+            "effective_model_id": requested_model_id,
+            "model_for_separator": requested_model_id,
+            "registry_entry": None,
+            "experimental_override_active": False,
+        }
+
+    if not enable_present or not model_present:
+        print("experimental_env_gate=half_configured", file=sys.stderr)
+        raise RuntimeError(
+            "Half-configured experimental env gate: set both "
+            f"{EXPERIMENTAL_MODELS_ENABLE_ENV} and {EXPERIMENTAL_MODEL_ID_ENV} together."
+        )
+
+    if enable_value != "1":
+        raise RuntimeError(
+            f"{EXPERIMENTAL_MODELS_ENABLE_ENV} must be exactly '1' when {EXPERIMENTAL_MODEL_ID_ENV} is used."
+        )
+
+    registry_entry = _load_runtime_registry_entry(experimental_model_id)
+    if not bool(registry_entry.get("hidden")) or not bool(registry_entry.get("experimental")):
+        raise RuntimeError(
+            f"Experimental env override only allows hidden+experimental models; rejected: {experimental_model_id}"
+        )
+
+    backend_arg = str(registry_entry.get("backend_arg") or "").strip()
+    if not backend_arg:
+        raise RuntimeError(f"Experimental registry model has no backend_arg: {experimental_model_id}")
+
+    return {
+        "requested_model_id": requested_model_id,
+        "effective_model_id": experimental_model_id,
+        "model_for_separator": backend_arg,
+        "registry_entry": registry_entry,
+        "experimental_override_active": True,
+    }
 
 
 def _resolve_requested_stage2_model(args: argparse.Namespace) -> str:
@@ -4536,6 +4624,8 @@ def main():
             write_done("DONE")
         return _finish_benchmark_run(benchmark_sampler, 0)
 
+    normal_model_selection = _resolve_normal_route_model_selection(args)
+    run_model = str(normal_model_selection.get("model_for_separator") or run_model)
     requested_device, resolved_device, preview_text, live_device_ids = _resolve_normal_runtime_device(device_preference)
     preview_device_id, _sep, preview_device_name = preview_text.partition("|")
     print(f"normal_workflow_backend_seen_device_request={requested_device}", file=sys.stderr)
@@ -4552,6 +4642,11 @@ def main():
     print(f"workflow_mode={workflow_mode}", file=sys.stderr)
     print(f"route={route}", file=sys.stderr)
     print(f"stage={stage}", file=sys.stderr)
+    print(f"requested_model_id={normal_model_selection.get('requested_model_id', '')}", file=sys.stderr)
+    print(f"effective_model_id={normal_model_selection.get('effective_model_id', '')}", file=sys.stderr)
+    print(f"resolved_model_filename={run_model}", file=sys.stderr)
+    if normal_model_selection.get("experimental_override_active"):
+        print("experimental_override_active=1", file=sys.stderr)
     print(f"model_name={run_model}", file=sys.stderr)
     print(f"device={resolved_device}", file=sys.stderr)
     print(f"backend={backend}", file=sys.stderr)

--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -1095,6 +1095,8 @@ def _load_runtime_registry_entry(model_id: str) -> Dict[str, Any]:
 
 def _resolve_normal_route_model_selection(args: argparse.Namespace) -> Dict[str, Any]:
     requested_model_id = str(getattr(args, "model", "htdemucs") or "htdemucs").strip() or "htdemucs"
+    workflow_mode = str(getattr(args, "workflow_mode", "") or "").strip()
+    workflow_source = str(getattr(args, "workflow_source", "") or "").strip()
     enable_value = str(os.environ.get(EXPERIMENTAL_MODELS_ENABLE_ENV, "") or "").strip()
     experimental_model_id = str(os.environ.get(EXPERIMENTAL_MODEL_ID_ENV, "") or "").strip()
     enable_present = enable_value != ""
@@ -1124,6 +1126,18 @@ def _resolve_normal_route_model_selection(args: argparse.Namespace) -> Dict[str,
     if enable_value != "1":
         raise RuntimeError(
             f"{EXPERIMENTAL_MODELS_ENABLE_ENV} must be exactly '1' when {EXPERIMENTAL_MODEL_ID_ENV} is used."
+        )
+
+    if (
+        _is_direct_dks_source(workflow_mode, workflow_source)
+        or _is_extract_dks_source(workflow_mode, workflow_source)
+        or _is_direct_dks_mode(workflow_mode)
+    ):
+        print("experimental_env_gate=invalid_for_drum_kit_workflow", file=sys.stderr)
+        raise RuntimeError(
+            "experimental model override is not valid for drum-kit workflows. "
+            f"Set neither {EXPERIMENTAL_MODELS_ENABLE_ENV} nor {EXPERIMENTAL_MODEL_ID_ENV} for this run. "
+            f"workflow_mode={workflow_mode or '<empty>'} workflow_source={workflow_source or '<empty>'}"
         )
 
     registry_entry = _load_runtime_registry_entry(experimental_model_id)
@@ -3265,6 +3279,22 @@ def _complement_contract_info(registry_entry: Optional[Dict[str, Any]]) -> Tuple
     return semantics == "complement" and normalized_stems == ["vocals", "instrumental"], expected_outputs
 
 
+def _emit_registry_model_markers(registry_entry: Optional[Dict[str, Any]], run_model: str) -> None:
+    if not isinstance(registry_entry, dict):
+        return
+    print(f"registry_model_id={registry_entry.get('id', '')}", file=sys.stderr)
+    print(f"registry_family={registry_entry.get('family', '')}", file=sys.stderr)
+    print(f"registry_architecture={registry_entry.get('architecture', '')}", file=sys.stderr)
+    contract = registry_entry.get("output_contract") if isinstance(registry_entry.get("output_contract"), dict) else {}
+    print(f"registry_stem_semantics={contract.get('stem_semantics', '')}", file=sys.stderr)
+    print(f"output_contract_expected={contract.get('expected_outputs', '')}", file=sys.stderr)
+    if (
+        str(registry_entry.get("architecture") or "").strip().lower() == "mdxc"
+        and str(run_model or "").strip().lower().endswith(".ckpt")
+    ):
+        print("onnx_provider_warning_expected_for_ckpt_mdxc=true", file=sys.stderr)
+
+
 def _map_reaper_stems_from_result(
     result: Any, output_root: Path, registry_entry: Optional[Dict[str, Any]] = None
 ) -> Dict[str, str]:
@@ -4690,18 +4720,7 @@ def main():
     if normal_model_selection.get("experimental_override_active"):
         print("experimental_override_active=1", file=sys.stderr)
     registry_entry = normal_model_selection.get("registry_entry")
-    if isinstance(registry_entry, dict):
-        print(f"registry_model_id={registry_entry.get('id', '')}", file=sys.stderr)
-        print(f"registry_family={registry_entry.get('family', '')}", file=sys.stderr)
-        print(f"registry_architecture={registry_entry.get('architecture', '')}", file=sys.stderr)
-        contract = registry_entry.get("output_contract") if isinstance(registry_entry.get("output_contract"), dict) else {}
-        print(f"registry_stem_semantics={contract.get('stem_semantics', '')}", file=sys.stderr)
-        print(f"output_contract_expected={contract.get('expected_outputs', '')}", file=sys.stderr)
-        if (
-            str(registry_entry.get("architecture") or "").strip().lower() == "mdxc"
-            and str(run_model or "").strip().lower().endswith(".ckpt")
-        ):
-            print("onnx_provider_warning_expected_for_ckpt_mdxc=true", file=sys.stderr)
+    _emit_registry_model_markers(registry_entry, run_model)
     print(f"model_name={run_model}", file=sys.stderr)
     print(f"device={resolved_device}", file=sys.stderr)
     print(f"backend={backend}", file=sys.stderr)

--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -94,6 +94,7 @@ _RUNTIME_REGISTRY_ALLOWED_FIELDS = {
     "output_contract",
     "validation",
 }
+_LAST_OUTPUT_MAPPING_INFO: Dict[str, Any] = {}
 
 
 def _prefer_vendored_stemwerk_core() -> None:
@@ -3247,7 +3248,27 @@ def _is_unexpected_cpu_downgrade(requested_device: str, preview_device: str) -> 
     return requested not in ("", "auto", "cpu")
 
 
-def _map_reaper_stems_from_result(result: Any, output_root: Path) -> Dict[str, str]:
+def _get_last_output_mapping_info() -> Dict[str, Any]:
+    return dict(_LAST_OUTPUT_MAPPING_INFO)
+
+
+def _complement_contract_info(registry_entry: Optional[Dict[str, Any]]) -> Tuple[bool, int]:
+    entry = registry_entry if isinstance(registry_entry, dict) else {}
+    contract = entry.get("output_contract") if isinstance(entry.get("output_contract"), dict) else {}
+    semantics = str(contract.get("stem_semantics") or "").strip()
+    stems = contract.get("stems") if isinstance(contract.get("stems"), list) else []
+    normalized_stems = [str(item or "").strip().lower() for item in stems]
+    try:
+        expected_outputs = int(contract.get("expected_outputs") or 0)
+    except Exception:
+        expected_outputs = 0
+    return semantics == "complement" and normalized_stems == ["vocals", "instrumental"], expected_outputs
+
+
+def _map_reaper_stems_from_result(
+    result: Any, output_root: Path, registry_entry: Optional[Dict[str, Any]] = None
+) -> Dict[str, str]:
+    global _LAST_OUTPUT_MAPPING_INFO
     stem_mapping = {
         "vocals": ["vocals", "vocal", "Vocals"],
         "drums": ["drums", "drum", "Drums"],
@@ -3256,6 +3277,12 @@ def _map_reaper_stems_from_result(result: Any, output_root: Path) -> Dict[str, s
         "guitar": ["guitar", "Guitar"],
         "piano": ["piano", "Piano", "keys", "Keys"],
     }
+    complement_contract, complement_expected = _complement_contract_info(registry_entry)
+    mapping_info: Dict[str, Any] = {
+        "raw_output_files": [],
+        "mapped_reaper_stems": {},
+        "instrumental_as_other": False,
+    }
 
     reaper_stems: Dict[str, str] = {}
     for stem_name, stem_path in result.stems.items():
@@ -3263,11 +3290,14 @@ def _map_reaper_stems_from_result(result: Any, output_root: Path) -> Dict[str, s
         if not abs_path.exists():
             raise FileNotFoundError(f"Expected separated stem not found: {abs_path}")
 
+        mapping_info["raw_output_files"].append(str(abs_path))
         filename = abs_path.stem.lower()
         target_name = stem_name
         for map_name, patterns in stem_mapping.items():
             if any(p.lower() in filename for p in patterns):
                 target_name = map_name
+                if map_name == "other" and ("instrumental" in filename or "no_vocals" in filename):
+                    mapping_info["instrumental_as_other"] = True
                 break
 
         new_path = abs_path.parent / f"{target_name}.wav"
@@ -3277,8 +3307,20 @@ def _map_reaper_stems_from_result(result: Any, output_root: Path) -> Dict[str, s
             shutil.move(str(abs_path), str(new_path))
 
         reaper_stems[target_name] = str(new_path)
+        mapping_info["mapped_reaper_stems"][target_name] = str(new_path)
         print(f"  {target_name}:  {new_path}", file=sys.stderr)
 
+    if complement_contract:
+        if len(mapping_info["raw_output_files"]) != complement_expected:
+            raise RuntimeError(
+                f"Complement output contract expected {complement_expected} outputs, got {len(mapping_info['raw_output_files'])}"
+            )
+        if set(reaper_stems) != {"vocals", "other"}:
+            raise RuntimeError(
+                f"Complement output contract expected REAPER stems vocals+other, got {sorted(reaper_stems)}"
+            )
+
+    _LAST_OUTPUT_MAPPING_INFO = mapping_info
     return reaper_stems
 
 
@@ -4647,6 +4689,19 @@ def main():
     print(f"resolved_model_filename={run_model}", file=sys.stderr)
     if normal_model_selection.get("experimental_override_active"):
         print("experimental_override_active=1", file=sys.stderr)
+    registry_entry = normal_model_selection.get("registry_entry")
+    if isinstance(registry_entry, dict):
+        print(f"registry_model_id={registry_entry.get('id', '')}", file=sys.stderr)
+        print(f"registry_family={registry_entry.get('family', '')}", file=sys.stderr)
+        print(f"registry_architecture={registry_entry.get('architecture', '')}", file=sys.stderr)
+        contract = registry_entry.get("output_contract") if isinstance(registry_entry.get("output_contract"), dict) else {}
+        print(f"registry_stem_semantics={contract.get('stem_semantics', '')}", file=sys.stderr)
+        print(f"output_contract_expected={contract.get('expected_outputs', '')}", file=sys.stderr)
+        if (
+            str(registry_entry.get("architecture") or "").strip().lower() == "mdxc"
+            and str(run_model or "").strip().lower().endswith(".ckpt")
+        ):
+            print("onnx_provider_warning_expected_for_ckpt_mdxc=true", file=sys.stderr)
     print(f"model_name={run_model}", file=sys.stderr)
     print(f"device={resolved_device}", file=sys.stderr)
     print(f"backend={backend}", file=sys.stderr)
@@ -4688,7 +4743,19 @@ def main():
         # audio-separator writes model outputs inside sep.separate(); this phase
         # brackets the REAPER-facing output mapping and final stem renames.
         emit_phase("stem_write_start")
-        reaper_stems = _map_reaper_stems_from_result(result, output_root)
+        reaper_stems = _map_reaper_stems_from_result(result, output_root, registry_entry=registry_entry)
+        mapping_info = _get_last_output_mapping_info()
+        print(
+            "raw_output_files=" + json.dumps(mapping_info.get("raw_output_files") or [], ensure_ascii=False),
+            file=sys.stderr,
+        )
+        print(
+            "mapped_reaper_stems="
+            + json.dumps(mapping_info.get("mapped_reaper_stems") or {}, sort_keys=True, ensure_ascii=False),
+            file=sys.stderr,
+        )
+        if mapping_info.get("instrumental_as_other"):
+            print("instrumental_as_other=true", file=sys.stderr)
 
         emit_phase("stem_write_end")
 

--- a/tests/test_vocals_hq_runtime_proof.py
+++ b/tests/test_vocals_hq_runtime_proof.py
@@ -19,7 +19,7 @@ def _load_module():
 
 
 def _normal_args(model="htdemucs"):
-    return type("Args", (), {"model": model})()
+    return type("Args", (), {"model": model, "workflow_mode": "", "workflow_source": ""})()
 
 
 def test_visible_model_passes_through_without_registry_io(monkeypatch):
@@ -48,6 +48,14 @@ def test_normal_flow_ignores_corrupt_registry_without_env_gate(monkeypatch, tmp_
     bad_registry = tmp_path / "models.json"
     bad_registry.write_text("{ definitely-not-json", encoding="utf-8")
     monkeypatch.setattr(module, "_runtime_registry_path", lambda: bad_registry)
+    original_read_text = Path.read_text
+
+    def guarded_read_text(self, *args, **kwargs):
+        if self == bad_registry:
+            raise AssertionError("registry read should not happen without env gate")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", guarded_read_text)
 
     selection = module._resolve_normal_route_model_selection(_normal_args("htdemucs"))
 
@@ -113,6 +121,49 @@ def test_unknown_experimental_model_id_fails(monkeypatch):
         module._resolve_normal_route_model_selection(_normal_args("htdemucs"))
 
 
+@pytest.mark.parametrize("enable_value", ["0", "true"])
+def test_non_one_enable_value_hard_fails(monkeypatch, enable_value):
+    module = _load_module()
+    monkeypatch.setenv(module.EXPERIMENTAL_MODELS_ENABLE_ENV, enable_value)
+    monkeypatch.setenv(module.EXPERIMENTAL_MODEL_ID_ENV, "bs_roformer_viperx")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        module._resolve_normal_route_model_selection(_normal_args("htdemucs"))
+
+    assert module.EXPERIMENTAL_MODELS_ENABLE_ENV in str(excinfo.value)
+    assert module.EXPERIMENTAL_MODEL_ID_ENV in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "workflow_mode,workflow_source",
+    [
+        ("drumkit", "dks_extract"),
+        ("dks_direct", ""),
+        ("", "dks_direct"),
+    ],
+)
+def test_experimental_override_fails_for_drum_workflows(monkeypatch, capsys, workflow_mode, workflow_source):
+    module = _load_module()
+    monkeypatch.setenv(module.EXPERIMENTAL_MODELS_ENABLE_ENV, "1")
+    monkeypatch.setenv(module.EXPERIMENTAL_MODEL_ID_ENV, "bs_roformer_viperx")
+    args = type(
+        "Args",
+        (),
+        {"model": "htdemucs", "workflow_mode": workflow_mode, "workflow_source": workflow_source},
+    )()
+
+    with pytest.raises(RuntimeError) as excinfo:
+        module._resolve_normal_route_model_selection(args)
+
+    text = str(excinfo.value)
+    assert module.EXPERIMENTAL_MODELS_ENABLE_ENV in text
+    assert module.EXPERIMENTAL_MODEL_ID_ENV in text
+    assert "experimental model override is not valid for drum-kit workflows" in text
+    assert f"workflow_mode={workflow_mode or '<empty>'}" in text
+    assert f"workflow_source={workflow_source or '<empty>'}" in text
+    assert "experimental_env_gate=invalid_for_drum_kit_workflow" in capsys.readouterr().err
+
+
 def test_runtime_registry_reader_ignores_ui_and_presets(monkeypatch, tmp_path):
     module = _load_module()
     monkeypatch.setenv(module.EXPERIMENTAL_MODELS_ENABLE_ENV, "1")
@@ -149,6 +200,26 @@ def test_hidden_roformer_is_absent_from_normal_visible_registry_list():
     registry = json.loads((ROOT / "scripts" / "reaper" / "models.json").read_text(encoding="utf-8"))
     visible_ids = [entry["id"] for entry in registry["models"] if not entry.get("hidden")]
     assert "bs_roformer_viperx" not in visible_ids
+
+
+def test_mdxc_ckpt_registry_marker_is_emitted(capsys):
+    module = _load_module()
+    registry_entry = {
+        "id": "bs_roformer_viperx",
+        "family": "roformer",
+        "architecture": "mdxc",
+        "output_contract": {
+            "stems": ["vocals", "instrumental"],
+            "stem_semantics": "complement",
+            "expected_outputs": 2,
+        },
+    }
+
+    module._emit_registry_model_markers(registry_entry, "model_bs_roformer_ep_317_sdr_12.9755.ckpt")
+
+    stderr = capsys.readouterr().err
+    assert "registry_model_id=bs_roformer_viperx" in stderr
+    assert "onnx_provider_warning_expected_for_ckpt_mdxc=true" in stderr
 
 
 @pytest.mark.parametrize("suffix", [".flac", ".wav"])

--- a/tests/test_vocals_hq_runtime_proof.py
+++ b/tests/test_vocals_hq_runtime_proof.py
@@ -121,6 +121,20 @@ def test_unknown_experimental_model_id_fails(monkeypatch):
         module._resolve_normal_route_model_selection(_normal_args("htdemucs"))
 
 
+@pytest.mark.parametrize("override_target", ["htdemucs", "stemwerk_dks"])
+def test_override_rejects_non_hidden_or_non_experimental_targets(monkeypatch, override_target):
+    module = _load_module()
+    monkeypatch.setenv(module.EXPERIMENTAL_MODELS_ENABLE_ENV, "1")
+    monkeypatch.setenv(module.EXPERIMENTAL_MODEL_ID_ENV, override_target)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        module._resolve_normal_route_model_selection(_normal_args("htdemucs"))
+
+    text = str(excinfo.value)
+    assert "hidden+experimental" in text
+    assert override_target in text
+
+
 @pytest.mark.parametrize("enable_value", ["0", "true"])
 def test_non_one_enable_value_hard_fails(monkeypatch, enable_value):
     module = _load_module()

--- a/tests/test_vocals_hq_runtime_proof.py
+++ b/tests/test_vocals_hq_runtime_proof.py
@@ -1,0 +1,151 @@
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "reaper" / "audio_separator_process.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("audio_separator_process_vocals_hq_proof_test", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _normal_args(model="htdemucs"):
+    return type("Args", (), {"model": model})()
+
+
+def test_visible_model_passes_through_without_registry_io(monkeypatch):
+    module = _load_module()
+    monkeypatch.delenv(module.EXPERIMENTAL_MODELS_ENABLE_ENV, raising=False)
+    monkeypatch.delenv(module.EXPERIMENTAL_MODEL_ID_ENV, raising=False)
+    monkeypatch.setattr(
+        module,
+        "_load_runtime_registry_entry",
+        lambda _model_id: (_ for _ in ()).throw(AssertionError("registry I/O should stay lazy")),
+    )
+
+    selection = module._resolve_normal_route_model_selection(_normal_args("htdemucs"))
+
+    assert selection["requested_model_id"] == "htdemucs"
+    assert selection["effective_model_id"] == "htdemucs"
+    assert selection["model_for_separator"] == "htdemucs"
+    assert selection["registry_entry"] is None
+    assert selection["experimental_override_active"] is False
+
+
+def test_normal_flow_ignores_corrupt_registry_without_env_gate(monkeypatch, tmp_path):
+    module = _load_module()
+    monkeypatch.delenv(module.EXPERIMENTAL_MODELS_ENABLE_ENV, raising=False)
+    monkeypatch.delenv(module.EXPERIMENTAL_MODEL_ID_ENV, raising=False)
+    bad_registry = tmp_path / "models.json"
+    bad_registry.write_text("{ definitely-not-json", encoding="utf-8")
+    monkeypatch.setattr(module, "_runtime_registry_path", lambda: bad_registry)
+
+    selection = module._resolve_normal_route_model_selection(_normal_args("htdemucs"))
+
+    assert selection["model_for_separator"] == "htdemucs"
+    assert selection["registry_entry"] is None
+
+
+def test_hidden_experimental_model_without_env_gate_fails(monkeypatch):
+    module = _load_module()
+    monkeypatch.delenv(module.EXPERIMENTAL_MODELS_ENABLE_ENV, raising=False)
+    monkeypatch.delenv(module.EXPERIMENTAL_MODEL_ID_ENV, raising=False)
+
+    with pytest.raises(RuntimeError, match="Hidden experimental model ids require the explicit env gate"):
+        module._resolve_normal_route_model_selection(_normal_args("bs_roformer_viperx"))
+
+
+def test_enable_without_model_id_fails_and_marks_half_configured(monkeypatch, capsys):
+    module = _load_module()
+    monkeypatch.setenv(module.EXPERIMENTAL_MODELS_ENABLE_ENV, "1")
+    monkeypatch.delenv(module.EXPERIMENTAL_MODEL_ID_ENV, raising=False)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        module._resolve_normal_route_model_selection(_normal_args("htdemucs"))
+
+    assert module.EXPERIMENTAL_MODELS_ENABLE_ENV in str(excinfo.value)
+    assert module.EXPERIMENTAL_MODEL_ID_ENV in str(excinfo.value)
+    assert "experimental_env_gate=half_configured" in capsys.readouterr().err
+
+
+def test_model_id_without_enable_fails_and_marks_half_configured(monkeypatch, capsys):
+    module = _load_module()
+    monkeypatch.delenv(module.EXPERIMENTAL_MODELS_ENABLE_ENV, raising=False)
+    monkeypatch.setenv(module.EXPERIMENTAL_MODEL_ID_ENV, "bs_roformer_viperx")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        module._resolve_normal_route_model_selection(_normal_args("htdemucs"))
+
+    assert module.EXPERIMENTAL_MODELS_ENABLE_ENV in str(excinfo.value)
+    assert module.EXPERIMENTAL_MODEL_ID_ENV in str(excinfo.value)
+    assert "experimental_env_gate=half_configured" in capsys.readouterr().err
+
+
+def test_hidden_experimental_model_resolves_to_registry_backend_arg(monkeypatch):
+    module = _load_module()
+    monkeypatch.setenv(module.EXPERIMENTAL_MODELS_ENABLE_ENV, "1")
+    monkeypatch.setenv(module.EXPERIMENTAL_MODEL_ID_ENV, "bs_roformer_viperx")
+
+    selection = module._resolve_normal_route_model_selection(_normal_args("htdemucs"))
+
+    assert selection["requested_model_id"] == "htdemucs"
+    assert selection["effective_model_id"] == "bs_roformer_viperx"
+    assert selection["model_for_separator"] == "model_bs_roformer_ep_317_sdr_12.9755.ckpt"
+    assert selection["experimental_override_active"] is True
+    assert selection["registry_entry"]["family"] == "roformer"
+
+
+def test_unknown_experimental_model_id_fails(monkeypatch):
+    module = _load_module()
+    monkeypatch.setenv(module.EXPERIMENTAL_MODELS_ENABLE_ENV, "1")
+    monkeypatch.setenv(module.EXPERIMENTAL_MODEL_ID_ENV, "does_not_exist")
+
+    with pytest.raises(RuntimeError, match="Unknown experimental model id"):
+        module._resolve_normal_route_model_selection(_normal_args("htdemucs"))
+
+
+def test_runtime_registry_reader_ignores_ui_and_presets(monkeypatch, tmp_path):
+    module = _load_module()
+    monkeypatch.setenv(module.EXPERIMENTAL_MODELS_ENABLE_ENV, "1")
+    monkeypatch.setenv(module.EXPERIMENTAL_MODEL_ID_ENV, "bs_roformer_viperx")
+    fake_registry = {
+        "presets": "should_not_be_read",
+        "models": [
+            {
+                "id": "bs_roformer_viperx",
+                "kind": "primary",
+                "hidden": True,
+                "experimental": True,
+                "engine": "audio_separator",
+                "backend_arg": "model_bs_roformer_ep_317_sdr_12.9755.ckpt",
+                "architecture": "mdxc",
+                "family": "roformer",
+                "output_contract": {"stems": ["vocals", "instrumental"], "stem_semantics": "complement", "expected_outputs": 2},
+                "validation": {"expected_outputs": 2},
+                "ui": {"fallback_label": "should be ignored"},
+            }
+        ],
+    }
+    registry_path = tmp_path / "models.json"
+    registry_path.write_text(json.dumps(fake_registry), encoding="utf-8")
+    monkeypatch.setattr(module, "_runtime_registry_path", lambda: registry_path)
+
+    selection = module._resolve_normal_route_model_selection(_normal_args("htdemucs"))
+
+    assert "ui" not in selection["registry_entry"]
+    assert selection["registry_entry"]["backend_arg"] == "model_bs_roformer_ep_317_sdr_12.9755.ckpt"
+
+
+def test_hidden_roformer_is_absent_from_normal_visible_registry_list():
+    registry = json.loads((ROOT / "scripts" / "reaper" / "models.json").read_text(encoding="utf-8"))
+    visible_ids = [entry["id"] for entry in registry["models"] if not entry.get("hidden")]
+    assert "bs_roformer_viperx" not in visible_ids

--- a/tests/test_vocals_hq_runtime_proof.py
+++ b/tests/test_vocals_hq_runtime_proof.py
@@ -1,7 +1,7 @@
 import importlib.util
 import json
-import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -149,3 +149,51 @@ def test_hidden_roformer_is_absent_from_normal_visible_registry_list():
     registry = json.loads((ROOT / "scripts" / "reaper" / "models.json").read_text(encoding="utf-8"))
     visible_ids = [entry["id"] for entry in registry["models"] if not entry.get("hidden")]
     assert "bs_roformer_viperx" not in visible_ids
+
+
+@pytest.mark.parametrize("suffix", [".flac", ".wav"])
+def test_complement_output_mapping_accepts_vocals_and_instrumental(tmp_path, suffix):
+    module = _load_module()
+    vocals = tmp_path / f"input_20s_(Vocals)_model_bs_roformer_ep_317_sdr_12{suffix}"
+    instrumental = tmp_path / f"input_20s_(Instrumental)_model_bs_roformer_ep_317_sdr_12{suffix}"
+    vocals.write_bytes(b"vocals")
+    instrumental.write_bytes(b"instrumental")
+    registry_entry = {
+        "output_contract": {
+            "stems": ["vocals", "instrumental"],
+            "stem_semantics": "complement",
+            "expected_outputs": 2,
+        }
+    }
+
+    result = SimpleNamespace(stems={"vocals": str(vocals), "other": str(instrumental)})
+    reaper_stems = module._map_reaper_stems_from_result(result, tmp_path, registry_entry=registry_entry)
+    mapping_info = module._get_last_output_mapping_info()
+
+    assert set(reaper_stems) == {"vocals", "other"}
+    assert Path(reaper_stems["vocals"]).name == "vocals.wav"
+    assert Path(reaper_stems["other"]).name == "other.wav"
+    assert sorted(Path(p).name for p in mapping_info["raw_output_files"]) == sorted([vocals.name, instrumental.name])
+    assert mapping_info["instrumental_as_other"] is True
+
+
+def test_complement_output_mapping_requires_exactly_two_outputs(tmp_path):
+    module = _load_module()
+    vocals = tmp_path / "input_(Vocals).flac"
+    instrumental = tmp_path / "input_(Instrumental).flac"
+    extra = tmp_path / "input_(Drums).flac"
+    for path in (vocals, instrumental, extra):
+        path.write_bytes(b"x")
+    registry_entry = {
+        "output_contract": {
+            "stems": ["vocals", "instrumental"],
+            "stem_semantics": "complement",
+            "expected_outputs": 2,
+        }
+    }
+    result = SimpleNamespace(
+        stems={"vocals": str(vocals), "other": str(instrumental), "drums": str(extra)}
+    )
+
+    with pytest.raises(RuntimeError, match="Complement output contract expected 2 outputs"):
+        module._map_reaper_stems_from_result(result, tmp_path, registry_entry=registry_entry)

--- a/tests/test_vocals_hq_runtime_proof.py
+++ b/tests/test_vocals_hq_runtime_proof.py
@@ -260,6 +260,82 @@ def test_complement_output_mapping_accepts_vocals_and_instrumental(tmp_path, suf
     assert Path(reaper_stems["other"]).name == "other.wav"
     assert sorted(Path(p).name for p in mapping_info["raw_output_files"]) == sorted([vocals.name, instrumental.name])
     assert mapping_info["instrumental_as_other"] is True
+    assert mapping_info["fallback_output_scan_used"] is False
+
+
+def test_complement_output_mapping_falls_back_to_output_scan_for_windows_shape(tmp_path):
+    module = _load_module()
+    vocals = tmp_path / "input_20s_(Vocals)_model_bs_roformer_ep_317_sdr_12.wav"
+    instrumental = tmp_path / "input_20s_(Instrumental)_model_bs_roformer_ep_317_sdr_12.wav"
+    vocals.write_bytes(b"vocals")
+    instrumental.write_bytes(b"instrumental")
+    registry_entry = {
+        "output_contract": {
+            "stems": ["vocals", "instrumental"],
+            "stem_semantics": "complement",
+            "expected_outputs": 2,
+        }
+    }
+
+    result = SimpleNamespace(stems={"vocals": str(vocals)})
+    reaper_stems = module._map_reaper_stems_from_result(result, tmp_path, registry_entry=registry_entry)
+    mapping_info = module._get_last_output_mapping_info()
+
+    assert set(reaper_stems) == {"vocals", "other"}
+    assert Path(reaper_stems["vocals"]).name == "vocals.wav"
+    assert Path(reaper_stems["other"]).name == "other.wav"
+    assert sorted(Path(p).name for p in mapping_info["raw_output_files"]) == sorted([vocals.name, instrumental.name])
+    assert mapping_info["instrumental_as_other"] is True
+    assert mapping_info["fallback_output_scan_used"] is True
+    assert Path(mapping_info["fallback_output_scan_candidates"][0]).name == instrumental.name
+
+
+def test_complement_output_mapping_ignores_stale_other_input_during_fallback(tmp_path):
+    module = _load_module()
+    vocals = tmp_path / "input_20s_(Vocals)_model_bs_roformer_ep_317_sdr_12.wav"
+    stale_instrumental = tmp_path / "old_take_(Instrumental)_model_bs_roformer_ep_317_sdr_12.wav"
+    vocals.write_bytes(b"vocals")
+    stale_instrumental.write_bytes(b"instrumental")
+    registry_entry = {
+        "output_contract": {
+            "stems": ["vocals", "instrumental"],
+            "stem_semantics": "complement",
+            "expected_outputs": 2,
+        }
+    }
+
+    result = SimpleNamespace(stems={"vocals": str(vocals)})
+
+    with pytest.raises(RuntimeError, match="Complement output contract expected 2 outputs"):
+        module._map_reaper_stems_from_result(result, tmp_path, registry_entry=registry_entry)
+
+    mapping_info = module._get_last_output_mapping_info()
+    assert mapping_info["fallback_output_scan_used"] is False
+    assert mapping_info["fallback_output_scan_candidates"] == []
+
+
+def test_non_complement_contract_does_not_scan_for_instrumental_fallback(tmp_path):
+    module = _load_module()
+    vocals = tmp_path / "input_20s_(Vocals)_model_bs_roformer_ep_317_sdr_12.wav"
+    instrumental = tmp_path / "input_20s_(Instrumental)_model_bs_roformer_ep_317_sdr_12.wav"
+    vocals.write_bytes(b"vocals")
+    instrumental.write_bytes(b"instrumental")
+    registry_entry = {
+        "output_contract": {
+            "stems": ["vocals", "other"],
+            "stem_semantics": "independent",
+            "expected_outputs": 2,
+        }
+    }
+
+    result = SimpleNamespace(stems={"vocals": str(vocals)})
+    reaper_stems = module._map_reaper_stems_from_result(result, tmp_path, registry_entry=registry_entry)
+    mapping_info = module._get_last_output_mapping_info()
+
+    assert set(reaper_stems) == {"vocals"}
+    assert mapping_info["fallback_output_scan_used"] is False
+    assert mapping_info["fallback_output_scan_candidates"] == []
+    assert mapping_info["instrumental_as_other"] is False
 
 
 def test_complement_output_mapping_requires_exactly_two_outputs(tmp_path):


### PR DESCRIPTION
## Summary

Dev-only runtime proof for hidden experimental Vocals HQ / Viperx.

This PR builds on the merged registry v2 layer and proves that Python-side runtime code can:

- resolve a hidden experimental registry model through an explicit env-gated override
- map `bs_roformer_viperx` to `model_bs_roformer_ep_317_sdr_12.9755.ckpt`
- accept 2-stem complement output:
  - `(Vocals)` -> `vocals`
  - `(Instrumental)` -> `other`
- log requested/effective/resolved model information and output contract mapping
- guard against accidental override during DKS/DrumSep/Kit Split workflows

## Scope

Changed files:

- `scripts/reaper/audio_separator_process.py`
- `tests/test_vocals_hq_runtime_proof.py`

No changes to:

- Lua/UI
- `models.json`
- `index.xml`
- installer/offline packaging
- DKS runtime files
- MDX23C
- model packs
- release/tagging

## Safety model

No behavior changes without explicit per-command env vars.

Normal runs without env vars:

- do not read `models.json`
- do not initialize the runtime registry resolver
- keep the incoming `--model` pass-through behavior
- are unaffected by corrupt/missing registry metadata

Experimental override requires both:

```bash
STEMWERK_ENABLE_EXPERIMENTAL_MODELS=1
STEMWERK_EXPERIMENTAL_MODEL_ID=bs_roformer_viperx

Half-configured env vars fail hard.

Override is rejected for Drum Kit / DKS / DrumSep / Kit Split workflows.

Override is also rejected for non-hidden or non-experimental targets such as htdemucs and stemwerk_dks.

Local checks

Passed locally:

python tools/release_gate.py --check
pytest -q tests/test_model_registry_schema.py tests/test_vocals_hq_runtime_proof.py
lua5.4 tests/lua/test_model_registry.lua
luac5.4 -p scripts/reaper/STEMwerk.lua

Proof tests: 32 passed.

Linux process smoke

Linux AMD/ROCm process smoke passed with notes:

incoming requested model: htdemucs
env override effective model: bs_roformer_viperx
resolved filename: model_bs_roformer_ep_317_sdr_12.9755.ckpt
output contract: complement, 2 stems
raw outputs: (Vocals) + (Instrumental)
mapped outputs: vocals.wav + other.wav
final WAV outputs were real RIFF/WAVE PCM
no DKS/DrumSep/Kit Split path touched

Verdict:

PROCESS_SMOKE_PASS_WITH_NOTES
Apple Silicon notes

Separate Mac CLI diagnostics, not part of this PR:

MDX23C works on Apple Silicon MPS and is the better Mac Balanced candidate.
Viperx works on Apple Silicon CPU and is much faster than MPS there.
Viperx on Apple Silicon MPS is currently avoid/defer because it is extremely slow in the tested stack.
MLX remains a later Apple Silicon backend R&D track.
Not proven by this PR

This PR does not add visible UI.

This PR does not prove the final Vocals HQ workflow UI.

This PR does not add model-pack/install-state management.

This PR does not make Vocals HQ user-facing.