### PR TITLE
docs: record ASEP 0.44.3 platform R&D and prompt safety conventions

### DIFF
--- a/docs/research/MAC_LINUX_ROFORMER_ASEP_0443_RND.md
+++ b/docs/research/MAC_LINUX_ROFORMER_ASEP_0443_RND.md
@@ -1,0 +1,70 @@
+# RoFormer / audio-separator 0.44.3 platform R&D (juli 2026)
+
+## Conclusie
+
+ASEP_0443_PLATFORM_UPGRADE_PROMISING. Alle eerdere "avoid"-labels bleken
+instrument-artefacten, geen eigenschappen van model, hardware of architectuur:
+
+- RoFormer-MPS "avoid" -> torch 2.5.1-artefact (macOS-pin uit 2.2.1.1-era)
+- MelBand 1.6G MPS OOM -> torch 2.5.1 geheugenbeheer; PASS op moderne torch
+- Demucs safeload-crash -> audio-separator 0.23.0-artefact; opgelost in 0.44.3
+- Viperx Linux-fail -> Python 3.14 + beartype 0.18.5 typehint-issue
+  (BeartypeDecorHintNonpepException op BSRoformer.__init__ stft_window_fn)
+
+## Bewezen matrix (versie-gescoped)
+
+macOS (Apple Silicon, audio-separator 0.44.3 + moderne torch):
+  Demucs PASS, RoFormer/Viperx PASS, PR #68-procespath PASS op device=mps.
+  Python-versie: NIET GEVONDEN in beschikbare rapporten — menselijke input nodig.
+
+Linux ROCm (RX 9070, audio-separator 0.44.3, Python 3.12.13,
+torch/torchaudio 2.10.0+rocm7.0, onnxruntime 1.27.0, beartype 0.18.5):
+  htdemucs_ft PASS (30s elapsed / 26s separation), DKS via echt entrypoint
+  PASS (64s, 6 kit-parts, rocm->cuda:0), Viperx PASS (33s elapsed /
+  00:00:26 separation).
+
+Python 3.14.6: known-bad voor Viperx (beartype). Python-versie is
+pin-dimensie #5.
+
+Instructie macOS-Python-veld:
+
+- Zoek alleen in bestaande lokale docs/logs/rapporten.
+- Niet infereren. Niet gokken. Niet uit Linux afleiden. Niet uit
+  systeem-Python afleiden.
+- Als geen exacte macOS runtime-Python gevonden wordt, schrijf letterlijk:
+  "NIET GEVONDEN in beschikbare rapporten — menselijke input nodig."
+
+## Timing
+
+Viperx ROCm 0.44.3 cold: 33s elapsed / 26s separation. Oude
+0.23.0-baseline: ~19s/14s. Warm timing niet gemeten: throwaway-runtime
+verloren bij cleanup-incident. Herbeoordelen tijdens pins-branch-smokes
+(die bouwen toch een verse runtime). Eerdere Errno 28 definitief
+verklaard: /tmp is 32G tmpfs.
+
+## DKS catalogus-rename (actiepunt pins-branch)
+
+0.44.3-catalogus: MDX23C-DrumSep-aufr33-jarredou.ckpt +
+config_drumsep_mdx23c.yaml. Oude STEMwerk-naming:
+aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.ckpt/.yaml.
+Sync vereist in: stemwerk_drumsep_process.py aliases, models.json
+runtime_managed_assets, fresh-install gedrag. Drie testcases: oude cache /
+verse install / gemengde upgrade-state (de "echte gebruiker"-case).
+
+## Cleanup-incident
+
+Warm timing niet gemeten omdat de throwaway-runtime is verwijderd tijdens
+cleanup (find zonder -mindepth 1 matchte de parent-directory; exact-match
+KEEP-check ving de ancestor niet). Alleen wegwerp-artefacten verloren;
+shared runtime, model-cache, repo en vastgelegde resultaten onaangetast.
+Leidde tot strengere conventie, zie PROMPT_SAFETY_CONVENTIONS.md.
+
+## Pin-matrix voor de pins-branch (5 dimensies per platform)
+
+| Platform | Python | audio-separator | torch/torchaudio | onnxruntime | compat-notes |
+| --- | --- | --- | --- | --- | --- |
+| Linux ROCm | 3.12.13 | 0.44.3 | 2.10.0+rocm7.0 | 1.27.0 | beartype 0.18.5; 3.14 known-bad |
+| macOS | NIET GEVONDEN in beschikbare rapporten — menselijke input nodig. | 0.44.3 | [uit Fase A-rapport] | [idem] | idem beartype-note |
+| Windows | open | open | open | open | open kolom |
+
+(torchvision alleen pinnen als daadwerkelijk vereist — verifieer.)

--- a/docs/research/PROMPT_SAFETY_CONVENTIONS.md
+++ b/docs/research/PROMPT_SAFETY_CONVENTIONS.md
@@ -1,0 +1,18 @@
+# Prompt-safety conventies voor gegenereerde shell-opdrachten
+
+Destructieve operaties (rm -rf, resets) in gegenereerde prompts vereisen
+drie lagen:
+
+1. Preventie: find-gebaseerde cleanup altijd met -mindepth 1, zodat het
+   startpunt zelf nooit in de deletelijst komt.
+2. Guard: ancestor-safe KEEP-check, geen exact-match:
+   case "$KEEP" in "$d"|"$d"/*) echo "REFUSE_TO_REMOVE_KEEP_OR_PARENT: $d"; exit 2;; esac
+3. Menselijke poort: dry-run tonen, STOPPEN, expliciet akkoord vragen
+   vóór executie. Nooit auto-delete direct na een dry-run.
+
+Aanvullend: destructieve of overschrijvende acties krijgen een positieve
+verificatie vooraf (existence/KEEP-checks) en een mechanische controle
+achteraf (bv. git diff --name-only HEAD~1..HEAD na een commit).
+
+Achtergrond: cleanup-incident juli 2026, zie
+MAC_LINUX_ROFORMER_ASEP_0443_RND.md.


### PR DESCRIPTION
## Summary

Docs-only follow-up for the ASEP 0.44.3 / RoFormer platform R&D closure.

Adds:

- `docs/research/MAC_LINUX_ROFORMER_ASEP_0443_RND.md`
  - records the Mac/Linux ASEP 0.44.3 R&D conclusion
  - preserves the `ASEP_0443_PLATFORM_UPGRADE_PROMISING` label
  - documents version-scoped findings around torch, audio-separator, Python, beartype, DKS catalog rename, timing notes, and open pin-matrix fields

- `docs/research/PROMPT_SAFETY_CONVENTIONS.md`
  - records reusable prompt-safety conventions for generated shell commands
  - especially destructive cleanup conventions: positive verification, dry-run, human gate, `find -mindepth 1`, and ancestor-safe KEEP checks

## Scope

Docs only.

No changes to:

- Lua/UI
- Python runtime
- model registry / `models.json`
- installers
- payloads
- workflows
- tests
- release/tagging

## Notes

The Windows runtime hardening work that was previously dirty has been preserved separately on:

- `chore/windows-runtime-hardening-wip`
- commit `ca90b839d9da82a208b59482c1dd63ade42e18ea`

It is intentionally not part of this PR.

## Validation

Local guards confirmed:

- HEAD commit contains exactly the two docs files
- PR diff against `origin/main` contains exactly the two docs files
- worktree clean before push/PR
- release gate checked locally if available
