### PR TITLE
fix(runtime): normalize torch device requests

### DIFF
--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -3218,6 +3218,53 @@ def _split_list(value: Optional[str]) -> List[str]:
     return [part.strip() for part in text.split(",") if part.strip()]
 
 
+def _torch_device_probe_markers(device_name_index: int = 0) -> Dict[str, object]:
+    markers: Dict[str, object] = {
+        "torch_cuda_available": False,
+        "torch_cuda_device_count": 0,
+        "torch_cuda_device_name": "",
+        "torch_hip_version": "",
+    }
+    try:
+        import torch
+
+        markers["torch_hip_version"] = str(getattr(getattr(torch, "version", None), "hip", "") or "")
+        cuda_available = bool(torch.cuda.is_available())
+        markers["torch_cuda_available"] = cuda_available
+        markers["torch_cuda_device_count"] = int(torch.cuda.device_count()) if cuda_available else 0
+        if cuda_available and int(markers["torch_cuda_device_count"]) > device_name_index:
+            markers["torch_cuda_device_name"] = str(torch.cuda.get_device_name(device_name_index))
+    except Exception:
+        pass
+    return markers
+
+
+def _emit_device_normalization_markers(
+    normalized_result: object,
+    explicit_gpu_request: bool,
+    probe_markers: Dict[str, object],
+) -> None:
+    print(
+        f"STEMWERK_DIAG normalized_device={getattr(normalized_result, 'normalized_device', '')}",
+        file=sys.stderr,
+    )
+    print(
+        f"STEMWERK_DIAG effective_backend={getattr(normalized_result, 'effective_backend', '')}",
+        file=sys.stderr,
+    )
+    print(
+        "STEMWERK_DIAG device_normalized="
+        f"{str(bool(getattr(normalized_result, 'device_normalized', False))).lower()}",
+        file=sys.stderr,
+    )
+    for key in ("torch_cuda_available", "torch_cuda_device_count", "torch_cuda_device_name", "torch_hip_version"):
+        value = probe_markers.get(key, "")
+        if isinstance(value, bool):
+            value = str(value).lower()
+        print(f"STEMWERK_DIAG {key}={value}", file=sys.stderr)
+    print(f"STEMWERK_DIAG explicit_gpu_request={str(explicit_gpu_request).lower()}", file=sys.stderr)
+
+
 def _resolve_normal_runtime_device(device_preference: str) -> Tuple[str, str, str, List[str]]:
     requested = str(device_preference or "auto")
     resolved = requested
@@ -3225,7 +3272,11 @@ def _resolve_normal_runtime_device(device_preference: str) -> Tuple[str, str, st
     live_device_ids = [str(dev.get("id", "")) for dev in live_devices]
     print(f"STEMWERK_DIAG requested_device={requested}", file=sys.stderr)
 
-    if requested == "auto":
+    requested_norm = requested.strip().lower()
+    explicit_gpu_request = requested_norm not in ("", "auto", "cpu")
+    normalized_result = None
+
+    if requested_norm == "auto":
         preferred = None
         if _is_darwin_arm64():
             preferred = next((dev for dev in live_devices if str(dev.get("id", "")).strip().lower() == "mps"), None)
@@ -3244,6 +3295,25 @@ def _resolve_normal_runtime_device(device_preference: str) -> Tuple[str, str, st
                 resolved = dev_id
             except Exception:
                 resolved = "auto"
+    else:
+        normalizer = getattr(core_devices, "normalize_torch_device", None) if core_devices is not None else None
+        if normalizer is not None:
+            probe_markers = _torch_device_probe_markers()
+            try:
+                normalized_result = normalizer(requested, strict=True)
+                resolved = str(getattr(normalized_result, "normalized_device", resolved) or resolved)
+                _emit_device_normalization_markers(normalized_result, explicit_gpu_request, probe_markers)
+            except Exception as exc:
+                error_result = getattr(exc, "result", None)
+                if error_result is not None:
+                    _emit_device_normalization_markers(error_result, explicit_gpu_request, probe_markers)
+                    print(
+                        f"STEMWERK_DIAG device_normalization_error_reason={getattr(error_result, 'error_reason', '')}",
+                        file=sys.stderr,
+                    )
+                    resolved = str(getattr(error_result, "normalized_device", resolved) or resolved)
+                    return requested, resolved, "cpu|CPU", live_device_ids
+                print(f"normal_workflow_device_normalization_error={type(exc).__name__}:{exc}", file=sys.stderr)
     preview_device_id = resolved
     preview_device_name = ""
     try:
@@ -4807,11 +4877,13 @@ def main():
     print(f"backend={backend}", file=sys.stderr)
     if _is_unexpected_cpu_downgrade(device_preference, preview_device_id):
         print("normal_workflow_backend_fallback_reason=live_runtime_cpu_only", file=sys.stderr)
+        print("STEMWERK_DIAG cpu_fallback_blocked=true", file=sys.stderr)
         print(
             "Runtime device fallback blocked: the explicitly requested accelerator is unavailable in the live normal STEMwerk runtime.",
             file=sys.stderr,
         )
         return 2
+    print("STEMWERK_DIAG cpu_fallback_blocked=false", file=sys.stderr)
 
     runtime_env: Dict[str, object] = {}
     try:

--- a/scripts/reaper/vendor/stemwerk-core/src/stemwerk_core/__init__.py
+++ b/scripts/reaper/vendor/stemwerk-core/src/stemwerk_core/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .devices import get_available_devices, select_device
+from .devices import get_available_devices, normalize_torch_device, select_device
 from .models import AVAILABLE_MODELS, DEMUCS_AUDIO_SEPARATOR_MODEL_IDS
 from .progress import ProgressCallback
 from .separator import SeparationResult, StemSeparator
@@ -9,6 +9,7 @@ __all__ = [
     "StemSeparator",
     "SeparationResult",
     "get_available_devices",
+    "normalize_torch_device",
     "select_device",
     "AVAILABLE_MODELS",
     "DEMUCS_AUDIO_SEPARATOR_MODEL_IDS",

--- a/scripts/reaper/vendor/stemwerk-core/src/stemwerk_core/devices.py
+++ b/scripts/reaper/vendor/stemwerk-core/src/stemwerk_core/devices.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 import platform
+import re
 import subprocess
 import warnings
 from pathlib import Path
@@ -8,6 +10,182 @@ from typing import Dict, List, Optional, Tuple
 
 _DEVICE_SKIPS: List[Dict[str, str]] = []
 _ROCMINFO_ARCHES: Optional[List[str]] = None
+
+
+@dataclass(frozen=True)
+class DeviceNormalizationResult:
+    requested_device: str
+    normalized_device: str
+    effective_backend: str
+    device_normalized: bool
+    error_reason: str = ""
+
+
+class DeviceNormalizationError(ValueError):
+    def __init__(self, result: DeviceNormalizationResult):
+        self.result = result
+        super().__init__(result.error_reason)
+
+
+class TorchDeviceProbe:
+    def torch_cuda_is_available(self) -> bool:
+        try:
+            import torch
+
+            return bool(torch.cuda.is_available())
+        except Exception:
+            return False
+
+    def torch_cuda_device_count(self) -> int:
+        try:
+            import torch
+
+            return int(torch.cuda.device_count())
+        except Exception:
+            return 0
+
+    def torch_cuda_get_device_name(self, index: int) -> str:
+        try:
+            import torch
+
+            return str(torch.cuda.get_device_name(index))
+        except Exception:
+            return ""
+
+    def torch_hip_version(self) -> str:
+        try:
+            import torch
+
+            return str(getattr(getattr(torch, "version", None), "hip", "") or "")
+        except Exception:
+            return ""
+
+    def torch_mps_is_available(self) -> bool:
+        return _is_mps_available()
+
+    def system(self) -> str:
+        try:
+            return str(platform.system())
+        except Exception:
+            return ""
+
+    def machine(self) -> str:
+        try:
+            return str(platform.machine())
+        except Exception:
+            return ""
+
+
+def _device_error(
+    requested: str,
+    normalized: str,
+    backend: str,
+    reason: str,
+) -> DeviceNormalizationError:
+    return DeviceNormalizationError(
+        DeviceNormalizationResult(
+            requested_device=requested,
+            normalized_device=normalized,
+            effective_backend=backend,
+            device_normalized=False,
+            error_reason=reason,
+        )
+    )
+
+
+def _cuda_backend_from_probe(probe: object) -> str:
+    try:
+        hip = str(probe.torch_hip_version() or "")
+    except Exception:
+        hip = ""
+    return "rocm" if hip else "cuda"
+
+
+def normalize_torch_device(
+    requested: str = "auto",
+    probe: Optional[object] = None,
+    strict: bool = False,
+) -> DeviceNormalizationResult:
+    """Normalize explicit torch device requests without owning auto policy."""
+    requested_device = str(requested or "auto").strip().lower()
+    probe = probe or TorchDeviceProbe()
+
+    if requested_device == "cpu":
+        return DeviceNormalizationResult("cpu", "cpu", "cpu", False)
+
+    if requested_device == "auto":
+        return DeviceNormalizationResult("auto", "auto", "auto", False)
+
+    if requested_device == "cuda":
+        backend = _cuda_backend_from_probe(probe)
+        try:
+            cuda_available = bool(probe.torch_cuda_is_available())
+            device_count = int(probe.torch_cuda_device_count())
+        except Exception:
+            cuda_available = False
+            device_count = 0
+        if not cuda_available or device_count < 1:
+            error = _device_error("cuda", "cuda", backend, "torch_cuda_unavailable")
+            if strict:
+                raise error
+            return error.result
+        return DeviceNormalizationResult("cuda", "cuda:0", backend, True)
+
+    cuda_match = re.fullmatch(r"cuda:(\d+)", requested_device)
+    if cuda_match:
+        backend = _cuda_backend_from_probe(probe)
+        try:
+            cuda_available = bool(probe.torch_cuda_is_available())
+            device_count = int(probe.torch_cuda_device_count())
+        except Exception:
+            cuda_available = False
+            device_count = 0
+        if not cuda_available or device_count < 1:
+            error = _device_error(requested_device, requested_device, backend, "torch_cuda_unavailable")
+            if strict:
+                raise error
+            return error.result
+        index = int(cuda_match.group(1))
+        if index >= device_count:
+            error = _device_error(
+                requested_device,
+                requested_device,
+                backend,
+                f"cuda_index_out_of_range:index={index}:count={device_count}",
+            )
+            if strict:
+                raise error
+            return error.result
+        return DeviceNormalizationResult(requested_device, requested_device, backend, False)
+
+    if requested_device == "mps":
+        try:
+            system = str(probe.system() or "")
+            machine = str(probe.machine() or "").lower()
+            mps_available = bool(probe.torch_mps_is_available())
+        except Exception:
+            system = ""
+            machine = ""
+            mps_available = False
+        if system == "Darwin" and machine in {"arm64", "aarch64"} and mps_available:
+            return DeviceNormalizationResult("mps", "mps", "mps", False)
+        error = _device_error("mps", "mps", "mps", "mps_unavailable")
+        if strict:
+            raise error
+        return error.result
+
+    if requested_device == "directml" or re.fullmatch(r"directml:\d+", requested_device):
+        return DeviceNormalizationResult(requested_device, requested_device, "directml", False)
+
+    error = _device_error(
+        requested_device,
+        requested_device,
+        "unknown",
+        "unknown_device_request",
+    )
+    if strict:
+        raise error
+    return error.result
 
 
 def _windows_no_window_kwargs() -> Dict[str, int]:
@@ -252,11 +430,27 @@ def select_device(requested_device: str = "auto") -> Tuple[str, str]:
     if requested_device == "cpu":
         return "cpu", "CPU"
 
-    if requested_device == "mps":
-        if torch is not None and _is_mps_available():
-            return "mps", "Apple MPS"
-        warnings.warn("MPS requested but not available; using CPU.")
-        return "cpu", "CPU"
+    normalized = normalize_torch_device(requested_device)
+
+    if not normalized.error_reason and normalized.normalized_device == "mps":
+        return "mps", "Apple MPS"
+
+    if not normalized.error_reason and normalized.effective_backend == "directml":
+        if normalized.normalized_device in available_ids:
+            for dev in available:
+                if dev["id"] == normalized.normalized_device:
+                    return dev["id"], dev["name"]
+        return normalized.normalized_device, "DirectML"
+
+    if not normalized.error_reason and normalized.normalized_device.startswith("cuda:"):
+        device_name = ""
+        index_match = re.fullmatch(r"cuda:(\d+)", normalized.normalized_device)
+        if index_match and torch is not None:
+            try:
+                device_name = str(torch.cuda.get_device_name(int(index_match.group(1))))
+            except Exception:
+                device_name = ""
+        return normalized.normalized_device, device_name or normalized.normalized_device
 
     if requested_device in available_ids:
         for dev in available:

--- a/tests/test_device_normalization.py
+++ b/tests/test_device_normalization.py
@@ -201,6 +201,66 @@ def test_explicit_cuda_cpu_preview_still_counts_as_unexpected_cpu_downgrade():
     assert module._is_unexpected_cpu_downgrade("cuda", "cpu") is True
 
 
+def test_runtime_device_resolution_keeps_requested_device_and_returns_normalized_value(monkeypatch):
+    module = _load_audio_separator_process_module()
+
+    monkeypatch.setattr(module, "get_available_devices", lambda: [{"id": "cuda:0", "name": "RX 9070", "type": "cuda"}])
+    monkeypatch.setattr(module, "select_device", lambda requested: (requested, "RX 9070"))
+    monkeypatch.setattr(
+        module,
+        "core_devices",
+        SimpleNamespace(
+            normalize_torch_device=lambda requested, strict=False: SimpleNamespace(
+                requested_device=requested,
+                normalized_device="cuda:0",
+                effective_backend="rocm",
+                device_normalized=True,
+                error_reason="",
+            )
+        ),
+    )
+
+    requested, resolved, preview, live_ids = module._resolve_normal_runtime_device("cuda")
+
+    assert requested == "cuda"
+    assert resolved == "cuda:0"
+    assert preview == "cuda:0|RX 9070"
+    assert live_ids == ["cuda:0"]
+
+
+def test_runtime_device_resolution_strict_error_feeds_existing_cpu_downgrade_guard(monkeypatch):
+    module = _load_audio_separator_process_module()
+
+    class ErrorWithResult(Exception):
+        result = SimpleNamespace(
+            requested_device="cuda",
+            normalized_device="cuda",
+            effective_backend="cuda",
+            device_normalized=False,
+            error_reason="torch_cuda_unavailable",
+        )
+
+    def raise_error(_requested, strict=False):
+        assert strict is True
+        raise ErrorWithResult()
+
+    monkeypatch.setattr(module, "get_available_devices", lambda: [{"id": "cpu", "name": "CPU", "type": "cpu"}])
+    monkeypatch.setattr(
+        module,
+        "core_devices",
+        SimpleNamespace(normalize_torch_device=raise_error),
+    )
+
+    requested, resolved, preview, live_ids = module._resolve_normal_runtime_device("cuda")
+    preview_device, _, _preview_name = preview.partition("|")
+
+    assert requested == "cuda"
+    assert resolved == "cuda"
+    assert preview == "cpu|CPU"
+    assert live_ids == ["cpu"]
+    assert module._is_unexpected_cpu_downgrade(requested, preview_device) is True
+
+
 def test_select_device_normalizes_bare_cuda_for_direct_consumers(monkeypatch):
     import stemwerk_core.devices as devices
 

--- a/tests/test_device_normalization.py
+++ b/tests/test_device_normalization.py
@@ -1,0 +1,255 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+import warnings
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CORE_SRC = ROOT / "scripts" / "reaper" / "vendor" / "stemwerk-core" / "src"
+PROCESS_SCRIPT = ROOT / "scripts" / "reaper" / "audio_separator_process.py"
+
+if str(CORE_SRC) not in sys.path:
+    sys.path.insert(0, str(CORE_SRC))
+
+
+def _load_audio_separator_process_module():
+    spec = importlib.util.spec_from_file_location("audio_separator_process_test", PROCESS_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class Probe:
+    def __init__(
+        self,
+        cuda_available=False,
+        cuda_count=0,
+        cuda_names=None,
+        hip=None,
+        mps_available=False,
+        platform_system="Linux",
+        platform_machine="x86_64",
+    ):
+        self.cuda_available = cuda_available
+        self.cuda_count = cuda_count
+        self.cuda_names = list(cuda_names or [])
+        self.hip = hip
+        self.mps_available = mps_available
+        self.platform_system = platform_system
+        self.platform_machine = platform_machine
+        self.calls = []
+
+    def torch_cuda_is_available(self):
+        self.calls.append("torch_cuda_is_available")
+        return self.cuda_available
+
+    def torch_cuda_device_count(self):
+        self.calls.append("torch_cuda_device_count")
+        return self.cuda_count
+
+    def torch_cuda_get_device_name(self, index):
+        self.calls.append(("torch_cuda_get_device_name", index))
+        return self.cuda_names[index] if index < len(self.cuda_names) else f"GPU {index}"
+
+    def torch_hip_version(self):
+        self.calls.append("torch_hip_version")
+        return self.hip
+
+    def torch_mps_is_available(self):
+        self.calls.append("torch_mps_is_available")
+        return self.mps_available
+
+    def system(self):
+        self.calls.append("system")
+        return self.platform_system
+
+    def machine(self):
+        self.calls.append("machine")
+        return self.platform_machine
+
+
+def test_cuda_request_normalizes_to_cuda_zero_when_available():
+    from stemwerk_core.devices import normalize_torch_device
+
+    result = normalize_torch_device("cuda", Probe(cuda_available=True, cuda_count=1, cuda_names=["RX 9070"]))
+
+    assert result.requested_device == "cuda"
+    assert result.normalized_device == "cuda:0"
+    assert result.effective_backend == "cuda"
+    assert result.device_normalized is True
+    assert result.error_reason == ""
+
+
+def test_cuda_request_fails_when_unavailable_without_cpu_fallback():
+    from stemwerk_core.devices import DeviceNormalizationError, normalize_torch_device
+
+    with pytest.raises(DeviceNormalizationError) as excinfo:
+        normalize_torch_device("cuda", Probe(cuda_available=False, cuda_count=0), strict=True)
+
+    assert excinfo.value.result.error_reason == "torch_cuda_unavailable"
+    assert excinfo.value.result.normalized_device == "cuda"
+
+
+def test_cuda_request_on_hip_runtime_uses_cuda_device_string_and_rocm_backend():
+    from stemwerk_core.devices import normalize_torch_device
+
+    result = normalize_torch_device("cuda", Probe(cuda_available=True, cuda_count=1, hip="7.0.51831"))
+
+    assert result.normalized_device == "cuda:0"
+    assert result.effective_backend == "rocm"
+    assert result.device_normalized is True
+
+
+def test_cuda_zero_request_is_unchanged_when_available():
+    from stemwerk_core.devices import normalize_torch_device
+
+    result = normalize_torch_device("cuda:0", Probe(cuda_available=True, cuda_count=1))
+
+    assert result.normalized_device == "cuda:0"
+    assert result.effective_backend == "cuda"
+    assert result.device_normalized is False
+
+
+def test_cuda_index_out_of_range_is_hard_error():
+    from stemwerk_core.devices import DeviceNormalizationError, normalize_torch_device
+
+    with pytest.raises(DeviceNormalizationError) as excinfo:
+        normalize_torch_device("cuda:9", Probe(cuda_available=True, cuda_count=1), strict=True)
+
+    assert excinfo.value.result.error_reason.startswith("cuda_index_out_of_range")
+    assert "count=1" in excinfo.value.result.error_reason
+
+
+def test_cpu_request_does_not_probe_torch():
+    from stemwerk_core.devices import normalize_torch_device
+
+    probe = Probe(cuda_available=True, cuda_count=1, hip="7.0.51831")
+
+    result = normalize_torch_device("cpu", probe)
+
+    assert result.normalized_device == "cpu"
+    assert result.effective_backend == "cpu"
+    assert result.device_normalized is False
+    assert probe.calls == []
+
+
+@pytest.mark.parametrize("device_request", ["directml", "directml:1"])
+def test_directml_requests_are_pass_through(device_request):
+    from stemwerk_core.devices import normalize_torch_device
+
+    result = normalize_torch_device(device_request, Probe())
+
+    assert result.normalized_device == device_request
+    assert result.effective_backend == "directml"
+    assert result.device_normalized is False
+
+
+def test_mps_request_passes_through_on_apple_silicon_with_mps():
+    from stemwerk_core.devices import normalize_torch_device
+
+    result = normalize_torch_device(
+        "mps",
+        Probe(mps_available=True, platform_system="Darwin", platform_machine="arm64"),
+    )
+
+    assert result.normalized_device == "mps"
+    assert result.effective_backend == "mps"
+    assert result.device_normalized is False
+
+
+@pytest.mark.parametrize(
+    "probe",
+    [
+        Probe(mps_available=False, platform_system="Darwin", platform_machine="arm64"),
+        Probe(mps_available=True, platform_system="Linux", platform_machine="x86_64"),
+    ],
+)
+def test_mps_request_without_availability_is_hard_error(probe):
+    from stemwerk_core.devices import DeviceNormalizationError, normalize_torch_device
+
+    with pytest.raises(DeviceNormalizationError) as excinfo:
+        normalize_torch_device("mps", probe, strict=True)
+
+    assert excinfo.value.result.error_reason == "mps_unavailable"
+
+
+def test_unknown_device_request_is_hard_error():
+    from stemwerk_core.devices import DeviceNormalizationError, normalize_torch_device
+
+    with pytest.raises(DeviceNormalizationError) as excinfo:
+        normalize_torch_device("gpu0", Probe(), strict=True)
+
+    assert excinfo.value.result.error_reason == "unknown_device_request"
+
+
+def test_non_strict_cuda_unavailable_reports_error_without_raising():
+    from stemwerk_core.devices import normalize_torch_device
+
+    result = normalize_torch_device("cuda", Probe(cuda_available=False, cuda_count=0))
+
+    assert result.normalized_device == "cuda"
+    assert result.error_reason == "torch_cuda_unavailable"
+
+
+def test_explicit_cuda_cpu_preview_still_counts_as_unexpected_cpu_downgrade():
+    module = _load_audio_separator_process_module()
+
+    assert module._is_unexpected_cpu_downgrade("cuda", "cpu") is True
+
+
+def test_select_device_normalizes_bare_cuda_for_direct_consumers(monkeypatch):
+    import stemwerk_core.devices as devices
+
+    fake_torch = SimpleNamespace(
+        version=SimpleNamespace(hip=None),
+        cuda=SimpleNamespace(
+            is_available=lambda: True,
+            device_count=lambda: 1,
+            get_device_name=lambda _index: "CUDA GPU",
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setattr(
+        devices,
+        "get_available_devices",
+        lambda: [
+            {"id": "auto", "name": "Auto", "type": "auto"},
+            {"id": "cpu", "name": "CPU", "type": "cpu"},
+            {"id": "cuda:0", "name": "CUDA GPU", "type": "cuda"},
+        ],
+    )
+
+    assert devices.select_device("cuda") == ("cuda:0", "CUDA GPU")
+
+
+def test_select_device_keeps_warning_cpu_fallback_for_unavailable_cuda(monkeypatch):
+    import stemwerk_core.devices as devices
+
+    fake_torch = SimpleNamespace(
+        version=SimpleNamespace(hip=None),
+        cuda=SimpleNamespace(
+            is_available=lambda: False,
+            device_count=lambda: 0,
+            get_device_name=lambda _index: "",
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setattr(
+        devices,
+        "get_available_devices",
+        lambda: [
+            {"id": "auto", "name": "Auto", "type": "auto"},
+            {"id": "cpu", "name": "CPU", "type": "cpu"},
+        ],
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = devices.select_device("cuda")
+
+    assert result == ("cpu", "CPU")
+    assert any("Requested device 'cuda' not available; using CPU." in str(item.message) for item in caught)

--- a/tests/test_macos_mps_fallback.py
+++ b/tests/test_macos_mps_fallback.py
@@ -294,7 +294,8 @@ def test_lua_and_i18n_expose_user_facing_apple_mps_labels_without_experimental_c
     assert "MPS/CPU" not in "\n".join(
         line for line in languages.splitlines() if "device_auto_desc" in line
     )
-    assert 'local cachedDevicesApplied = applyCachedRuntimeDevices(cacheOpts)' in main
+    assert "local cachedDevicesApplied = false" in main
+    assert "cachedDevicesApplied = applyCachedRuntimeDevices(cacheOpts)" in main
     assert 'if not cachedDevicesApplied and not RUNTIME_DEVICES then' in main
     assert 'local mpsAvailable = false' in main
     assert 'if mpsAvailable and cpuReady then' in main


### PR DESCRIPTION
## Samenvatting

- `cuda` wordt in het STEMwerk-runtimepad genormaliseerd naar `cuda:0`.
- ROCm blijft torch-device-string `cuda:N`, maar logt `effective_backend=rocm`.
- strict-mode voorkomt stille CPU-fallback bij expliciete GPU-requests.
- `select_device()` blijft permissief voor directe stemwerk-core consumers.

## Bewuste gedragswijzigingen

- Runtimepad met `cuda` zonder CUDA-runtime faalt hard met `torch_cuda_unavailable`.
- Runtimepad met out-of-range `cuda:N` faalt hard met `cuda_index_out_of_range`.
- Runtimepad met expliciete `mps` zonder MPS faalt hard.
- `select_device()` zelf behoudt warning/fallback-gedrag voor directe consumers.

## MPS test drift

MPS fallback assertion was already stale against current main Lua; fixed as pre-existing test drift.

Evidence: a temporary worktree at base `9642f353e41d5b8998693e284edc2e84a39b176a` failed `tests/test_macos_mps_fallback.py` on the old `cachedDevicesApplied` assertion before this branch's runtime changes.

## Smoke evidence

- AMD ROCm `--device cuda`: PASS, `normalized_device=cuda:0`, `device_normalized=true`, `effective_backend=rocm`.
- AMD ROCm `--device cuda:0`: PASS, `device_normalized=false`, `effective_backend=rocm`.
- AMD ROCm `--device cuda:9`: FAIL expected, `cuda_index_out_of_range`, exit 2.
- AMD ROCm `--device cuda:1`: FAIL during HIP inference because iGPU/gfx1103 passes torch device_count but lacks supported kernel path; follow-up needed to make strict-mode consult `_DEVICE_SKIPS` for actionable preflight error.

Marker note: `cpu_fallback_blocked=true` means run blocked instead of degraded, including invalid explicit device requests; not always a literal attempted CPU fallback.

## Out of scope

- DrumSep helper contract
- DirectML behavior
- Lua/UI changes
- ASEP 0.44.3 pin-matrix
- MLX
- unified runtime
- Windows AMD ROCm installer work

## Post-merge or merge-gate note

NVIDIA S1/S2 smokes still pending:

- `--device cuda` should normalize to `cuda:0`
- `--device cuda:0` should remain unchanged

## Validation

- `python -m pytest -q tests/test_device_normalization.py` - 18 passed
- `python -m pytest -q tests/test_vocals_hq_runtime_proof.py` - 23 passed
- `python -m pytest -q tests/test_macos_mps_fallback.py` - 12 passed, 1 expected warning
- `python -m pytest -q tests/test_model_registry_schema.py` - 12 passed
- `python tools/release_gate.py --check` - PASS
- `python -m pytest -q tests/test_windows_normal_route_matrix.py` - 21 passed

Full suite locally remains delegated to CI because this machine's default Python environment previously blocked collection on missing `soundfile`/`numpy`.