### PR TITLE
fix(runtime): preflight skipped torch devices in strict mode

### DIFF
--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -3218,6 +3218,26 @@ def _split_list(value: Optional[str]) -> List[str]:
     return [part.strip() for part in text.split(",") if part.strip()]
 
 
+def _cuda_device_index(device_id: str) -> Optional[int]:
+    match = re.fullmatch(r"cuda:(\d+)", str(device_id or "").strip().lower())
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except Exception:
+        return None
+
+
+def _find_device_skip(device_id: str) -> Optional[Dict[str, str]]:
+    wanted = str(device_id or "").strip().lower()
+    if not wanted:
+        return None
+    for item in _get_device_skips():
+        if str(item.get("id", "")).strip().lower() == wanted:
+            return item
+    return None
+
+
 def _torch_device_probe_markers(device_name_index: int = 0) -> Dict[str, object]:
     markers: Dict[str, object] = {
         "torch_cuda_available": False,
@@ -3232,7 +3252,7 @@ def _torch_device_probe_markers(device_name_index: int = 0) -> Dict[str, object]
         cuda_available = bool(torch.cuda.is_available())
         markers["torch_cuda_available"] = cuda_available
         markers["torch_cuda_device_count"] = int(torch.cuda.device_count()) if cuda_available else 0
-        if cuda_available and int(markers["torch_cuda_device_count"]) > device_name_index:
+        if cuda_available and device_name_index >= 0 and int(markers["torch_cuda_device_count"]) > device_name_index:
             markers["torch_cuda_device_name"] = str(torch.cuda.get_device_name(device_name_index))
     except Exception:
         pass
@@ -3298,14 +3318,31 @@ def _resolve_normal_runtime_device(device_preference: str) -> Tuple[str, str, st
     else:
         normalizer = getattr(core_devices, "normalize_torch_device", None) if core_devices is not None else None
         if normalizer is not None:
-            probe_markers = _torch_device_probe_markers()
             try:
                 normalized_result = normalizer(requested, strict=True)
                 resolved = str(getattr(normalized_result, "normalized_device", resolved) or resolved)
+                device_name_index = _cuda_device_index(resolved)
+                probe_markers = _torch_device_probe_markers(
+                    device_name_index if device_name_index is not None else 0
+                )
                 _emit_device_normalization_markers(normalized_result, explicit_gpu_request, probe_markers)
+                skip = _find_device_skip(resolved)
+                if skip is not None:
+                    reason = str(skip.get("reason", "") or "device_skipped")
+                    print(f"STEMWERK_DIAG device_skip_reason={reason}", file=sys.stderr)
+                    print(
+                        f"STEMWERK_DIAG device_normalization_error_reason=device_skipped:{resolved}",
+                        file=sys.stderr,
+                    )
+                    return requested, resolved, "cpu|CPU", live_device_ids
             except Exception as exc:
                 error_result = getattr(exc, "result", None)
                 if error_result is not None:
+                    normalized_error_device = str(getattr(error_result, "normalized_device", resolved) or resolved)
+                    device_name_index = _cuda_device_index(normalized_error_device)
+                    probe_markers = _torch_device_probe_markers(
+                        device_name_index if device_name_index is not None else 0
+                    )
                     _emit_device_normalization_markers(error_result, explicit_gpu_request, probe_markers)
                     print(
                         f"STEMWERK_DIAG device_normalization_error_reason={getattr(error_result, 'error_reason', '')}",

--- a/tests/test_device_normalization.py
+++ b/tests/test_device_normalization.py
@@ -206,6 +206,7 @@ def test_runtime_device_resolution_keeps_requested_device_and_returns_normalized
 
     monkeypatch.setattr(module, "get_available_devices", lambda: [{"id": "cuda:0", "name": "RX 9070", "type": "cuda"}])
     monkeypatch.setattr(module, "select_device", lambda requested: (requested, "RX 9070"))
+    monkeypatch.setattr(module, "_get_device_skips", lambda: [])
     monkeypatch.setattr(
         module,
         "core_devices",
@@ -228,6 +229,119 @@ def test_runtime_device_resolution_keeps_requested_device_and_returns_normalized
     assert live_ids == ["cuda:0"]
 
 
+def test_runtime_device_resolution_blocks_skipped_cuda_index_before_preview(monkeypatch, capsys):
+    module = _load_audio_separator_process_module()
+
+    def fail_select_device(_requested):
+        raise AssertionError("select_device should not run for skipped explicit devices")
+
+    seen_probe_indexes = []
+
+    def probe_markers(index=0):
+        seen_probe_indexes.append(index)
+        return {
+            "torch_cuda_available": True,
+            "torch_cuda_device_count": 2,
+            "torch_cuda_device_name": "AMD Radeon 780M Graphics" if index == 1 else "AMD Radeon RX 9070",
+            "torch_hip_version": "7.0.51831",
+        }
+
+    monkeypatch.setattr(
+        module,
+        "get_available_devices",
+        lambda: [{"id": "cuda:0", "name": "AMD Radeon RX 9070", "type": "cuda"}],
+    )
+    monkeypatch.setattr(
+        module,
+        "_get_device_skips",
+        lambda: [
+            {
+                "id": "cuda:1",
+                "name": "AMD Radeon 780M Graphics",
+                "reason": "ROCm rocBLAS Tensile library missing for arch gfx1103.",
+            }
+        ],
+    )
+    monkeypatch.setattr(module, "_torch_device_probe_markers", probe_markers)
+    monkeypatch.setattr(module, "select_device", fail_select_device)
+    monkeypatch.setattr(
+        module,
+        "core_devices",
+        SimpleNamespace(
+            normalize_torch_device=lambda requested, strict=False: SimpleNamespace(
+                requested_device=requested,
+                normalized_device="cuda:1",
+                effective_backend="rocm",
+                device_normalized=False,
+                error_reason="",
+            )
+        ),
+    )
+
+    requested, resolved, preview, live_ids = module._resolve_normal_runtime_device("cuda:1")
+    preview_device, _, _preview_name = preview.partition("|")
+    stderr = capsys.readouterr().err
+
+    assert requested == "cuda:1"
+    assert resolved == "cuda:1"
+    assert preview == "cpu|CPU"
+    assert live_ids == ["cuda:0"]
+    assert seen_probe_indexes == [1]
+    assert "STEMWERK_DIAG torch_cuda_device_name=AMD Radeon 780M Graphics" in stderr
+    assert "STEMWERK_DIAG device_skip_reason=ROCm rocBLAS Tensile library missing for arch gfx1103." in stderr
+    assert "STEMWERK_DIAG device_normalization_error_reason=device_skipped:cuda:1" in stderr
+    assert module._is_unexpected_cpu_downgrade(requested, preview_device) is True
+
+
+def test_runtime_device_resolution_allows_unskipped_cuda_zero(monkeypatch):
+    module = _load_audio_separator_process_module()
+
+    seen_probe_indexes = []
+
+    def probe_markers(index=0):
+        seen_probe_indexes.append(index)
+        return {
+            "torch_cuda_available": True,
+            "torch_cuda_device_count": 2,
+            "torch_cuda_device_name": "AMD Radeon RX 9070",
+            "torch_hip_version": "7.0.51831",
+        }
+
+    monkeypatch.setattr(
+        module,
+        "get_available_devices",
+        lambda: [{"id": "cuda:0", "name": "AMD Radeon RX 9070", "type": "cuda"}],
+    )
+    monkeypatch.setattr(
+        module,
+        "_get_device_skips",
+        lambda: [{"id": "cuda:1", "name": "AMD Radeon 780M Graphics", "reason": "skip"}],
+    )
+    monkeypatch.setattr(module, "_torch_device_probe_markers", probe_markers)
+    monkeypatch.setattr(module, "select_device", lambda requested: (requested, "AMD Radeon RX 9070"))
+    monkeypatch.setattr(
+        module,
+        "core_devices",
+        SimpleNamespace(
+            normalize_torch_device=lambda requested, strict=False: SimpleNamespace(
+                requested_device=requested,
+                normalized_device="cuda:0",
+                effective_backend="rocm",
+                device_normalized=False,
+                error_reason="",
+            )
+        ),
+    )
+
+    requested, resolved, preview, live_ids = module._resolve_normal_runtime_device("cuda:0")
+
+    assert requested == "cuda:0"
+    assert resolved == "cuda:0"
+    assert preview == "cuda:0|AMD Radeon RX 9070"
+    assert live_ids == ["cuda:0"]
+    assert seen_probe_indexes == [0]
+
+
 def test_runtime_device_resolution_strict_error_feeds_existing_cpu_downgrade_guard(monkeypatch):
     module = _load_audio_separator_process_module()
 
@@ -245,6 +359,7 @@ def test_runtime_device_resolution_strict_error_feeds_existing_cpu_downgrade_gua
         raise ErrorWithResult()
 
     monkeypatch.setattr(module, "get_available_devices", lambda: [{"id": "cpu", "name": "CPU", "type": "cpu"}])
+    monkeypatch.setattr(module, "_get_device_skips", lambda: [])
     monkeypatch.setattr(
         module,
         "core_devices",
@@ -313,3 +428,24 @@ def test_select_device_keeps_warning_cpu_fallback_for_unavailable_cuda(monkeypat
 
     assert result == ("cpu", "CPU")
     assert any("Requested device 'cuda' not available; using CPU." in str(item.message) for item in caught)
+
+
+def test_torch_device_probe_markers_use_selected_cuda_index(monkeypatch):
+    module = _load_audio_separator_process_module()
+
+    fake_torch = SimpleNamespace(
+        version=SimpleNamespace(hip="7.0.51831"),
+        cuda=SimpleNamespace(
+            is_available=lambda: True,
+            device_count=lambda: 2,
+            get_device_name=lambda index: ["AMD Radeon RX 9070", "AMD Radeon 780M Graphics"][index],
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    markers = module._torch_device_probe_markers(1)
+
+    assert markers["torch_cuda_available"] is True
+    assert markers["torch_cuda_device_count"] == 2
+    assert markers["torch_cuda_device_name"] == "AMD Radeon 780M Graphics"
+    assert markers["torch_hip_version"] == "7.0.51831"


### PR DESCRIPTION
## Samenvatting

- Strict normal-route runtime preflight raadpleegt nu de auto-gedetecteerde `_DEVICE_SKIPS` na torch-device-normalisatie.
- Een expliciet `cuda:N` dat door vendored stemwerk-core is geskipt faalt nu vóór inference met `device_skip_reason=...`.
- `torch_cuda_device_name` wordt gelogd voor de geselecteerde/genormaliseerde CUDA-index, niet altijd index 0.

## Bewijs voor patch-gate

`cuda:1` zit daadwerkelijk in `_DEVICE_SKIPS` op deze AMD Linux / ROCm machine:

```text
STEMWERK_DEVICE_SKIPPED	cuda:1	AMD Radeon 780M Graphics	ROCm rocBLAS Tensile library missing for arch gfx1103 (see /opt/rocm/lib/rocblas/library).
```

Torch-identiteit:

```text
index 0: AMD Radeon RX 9070, gcnArchName=gfx1201
index 1: AMD Radeon 780M Graphics, gcnArchName=gfx1103
```

Vendored-core introspectie:

```text
after_DEVICE_SKIPS [{'id': 'cuda:1', 'name': 'AMD Radeon 780M Graphics', 'reason': 'ROCm rocBLAS Tensile library missing for arch gfx1103 (see /opt/rocm/lib/rocblas/library).'}]
cuda1_in_skips True
```

## Smoke evidence

Using the same 20s smoke input as PR #73:

- `--device cuda`: PASS, exit 0, `normalized_device=cuda:0`, `effective_backend=rocm`, `torch_cuda_device_name=AMD Radeon RX 9070`, stems written.
- `--device cuda:0`: PASS, exit 0, `device_normalized=false`, `effective_backend=rocm`, `torch_cuda_device_name=AMD Radeon RX 9070`, stems written.
- `--device cuda:1`: expected fail, exit 2, no stems, no primary HIP invalid-device-function crash, `device_skip_reason=ROCm rocBLAS Tensile library missing for arch gfx1103 (see /opt/rocm/lib/rocblas/library).`, `torch_cuda_device_name=AMD Radeon 780M Graphics`.
- `--device cuda:9`: expected fail, exit 2, `device_normalization_error_reason=cuda_index_out_of_range:index=9:count=2`.

## Validation

- `python -m pytest -q tests/test_device_normalization.py` - 21 passed
- `python -m pytest -q tests/test_vocals_hq_runtime_proof.py` - 23 passed
- `python -m pytest -q tests/test_macos_mps_fallback.py` - 12 passed, 1 expected warning
- `python -m pytest -q tests/test_model_registry_schema.py` - 12 passed
- `python -m pytest -q tests/test_windows_normal_route_matrix.py` - 21 passed
- `python tools/release_gate.py --check` - PASS
- `git diff --check` - clean

## Out of scope

- DirectML behavior
- DrumSep helper / DKS stage2 contract
- Lua/UI changes
- `--skip-devices` CLI behavior
- ASEP 0.44.3 pin-matrix
- Installer builds
- Runtime cleanup