### PR TITLE
ci: add fast pytest coverage and clean onnxruntime pins

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -47,3 +47,14 @@ jobs:
             echo "Language file validation failed"
             exit 1
           fi
+
+      - name: Run curated fast pytest coverage
+        run: |
+          python -m pytest -q \
+            tests/test_device_normalization.py \
+            tests/test_macos_mps_fallback.py \
+            tests/test_model_registry_schema.py \
+            tests/test_windows_normal_route_matrix.py \
+            tests/test_vocals_hq_runtime_proof.py \
+            tests/test_dependency_constraints.py::test_ci_fast_quick_script_smoke_installs_pyyaml \
+            tests/test_dependency_constraints.py::test_ci_fast_runs_curated_pytest_coverage

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -58,4 +58,5 @@ jobs:
             tests/test_vocals_hq_runtime_proof.py \
             tests/test_dependency_constraints.py::test_ci_fast_quick_script_smoke_installs_pyyaml \
             tests/test_dependency_constraints.py::test_ci_fast_runs_curated_pytest_coverage \
-            tests/test_dependency_constraints.py::test_no_stale_onnxruntime_ci_pins
+            tests/test_dependency_constraints.py::test_no_stale_onnxruntime_ci_pins \
+            tests/test_dependency_constraints.py::test_onnxruntime_runtime_pin_policy_is_documented

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -57,4 +57,5 @@ jobs:
             tests/test_windows_normal_route_matrix.py \
             tests/test_vocals_hq_runtime_proof.py \
             tests/test_dependency_constraints.py::test_ci_fast_quick_script_smoke_installs_pyyaml \
-            tests/test_dependency_constraints.py::test_ci_fast_runs_curated_pytest_coverage
+            tests/test_dependency_constraints.py::test_ci_fast_runs_curated_pytest_coverage \
+            tests/test_dependency_constraints.py::test_no_stale_onnxruntime_ci_pins

--- a/.github/workflows/macos-apple-silicon-backend-smoke.yml
+++ b/.github/workflows/macos-apple-silicon-backend-smoke.yml
@@ -69,7 +69,7 @@ jobs:
           pip install ./scripts/reaper/vendor/stemwerk-core
           pip install -c scripts/reaper/constraints/macos.txt "audio-separator==0.23.0"
           pip install --force-reinstall --no-deps "torch==2.5.1" "torchvision==0.20.1" "torchaudio==2.5.1"
-          pip install onnxruntime-silicon || pip install "onnxruntime>=1.21,<1.22"
+          pip install onnxruntime-silicon || pip install onnxruntime
           pip install pytest
 
       - name: Show backend smoke dependency diagnostics

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,6 +1,6 @@
 audio-separator[cpu]
-stemwerk-core
-onnxruntime>=1.21,<1.22
+./scripts/reaper/vendor/stemwerk-core
+onnxruntime
 onnx>=1.17,<1.18
 soundfile
 pytest

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -4865,6 +4865,20 @@ def test_ci_fast_runs_curated_pytest_coverage():
     assert "python -m pytest -q \\\n            tests" in workflow
 
 
+def test_no_stale_onnxruntime_ci_pins():
+    requirements = Path("requirements-ci.txt").read_text(encoding="utf-8")
+    smoke = Path(".github/workflows/macos-apple-silicon-backend-smoke.yml").read_text(
+        encoding="utf-8"
+    )
+    workflow = Path(".github/workflows/ci-full.yml").read_text(encoding="utf-8")
+
+    assert "onnxruntime>=1.21,<1.22" not in requirements
+    assert "onnxruntime>=1.21,<1.22" not in smoke
+    assert "\nonnxruntime\n" in requirements
+    assert "pip install onnxruntime-silicon || pip install onnxruntime" in smoke
+    assert "tests/test_dependency_constraints.py::test_no_stale_onnxruntime_ci_pins" in workflow
+
+
 def test_setup_internal_luac_compiles_under_reaper_limits():
     luac = shutil.which("luac")
     if not luac:

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -4879,6 +4879,38 @@ def test_no_stale_onnxruntime_ci_pins():
     assert "tests/test_dependency_constraints.py::test_no_stale_onnxruntime_ci_pins" in workflow
 
 
+def test_onnxruntime_runtime_pin_policy_is_documented():
+    linux_bootstrap = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text(
+        encoding="utf-8"
+    )
+    linux_wheelhouse = Path("tools/build_linux_wheelhouse.py").read_text(encoding="utf-8")
+    windows_bootstrap = Path("scripts/reaper/STEMwerk_Bootstrap_Windows.ps1").read_text(
+        encoding="utf-8"
+    )
+    directml_constraints = Path("scripts/reaper/constraints/directml.txt").read_text(
+        encoding="utf-8"
+    )
+    macos_payload = Path("tools/build_macos_apple_silicon_payload.py").read_text(
+        encoding="utf-8"
+    )
+    ci_workflow = Path(".github/workflows/ci-full.yml").read_text(encoding="utf-8")
+
+    # Policy: CI Fast runs Python 3.11, production payloads generally use
+    # Python 3.12, Linux main keeps generic onnxruntime unpinned pending the
+    # ASEP 0.44.3 pin matrix, and DrumSep/DirectML pins remain platform-scoped.
+    assert "python-version: 3.11" in ci_workflow
+    assert 'ONNX_PACKAGE="onnxruntime"' in linux_bootstrap
+    assert 'DRUMSEP_ONNXRUNTIME_VERSION="1.26.0"' in linux_bootstrap
+    assert '"onnxruntime"' in linux_wheelhouse
+    assert '"onnxruntime==1.26.0"' in linux_wheelhouse
+    assert '"onnxruntime-gpu==1.24.4"' in linux_wheelhouse
+    assert "onnxruntime-directml==1.24.4" in directml_constraints
+    assert '$onnxRuntimeDirectMlVersion = "1.24.4"' in windows_bootstrap
+    assert '"onnxruntime"' in macos_payload
+    assert '"onnxruntime-silicon"' not in macos_payload
+    assert "tests/test_dependency_constraints.py::test_onnxruntime_runtime_pin_policy_is_documented" in ci_workflow
+
+
 def test_setup_internal_luac_compiles_under_reaper_limits():
     luac = shutil.which("luac")
     if not luac:

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -4852,6 +4852,19 @@ def test_ci_fast_quick_script_smoke_installs_pyyaml():
     assert "python scripts/reaper/audio_separator_process.py --list-models" in workflow
 
 
+def test_ci_fast_runs_curated_pytest_coverage():
+    workflow = Path(".github/workflows/ci-full.yml").read_text(encoding="utf-8")
+
+    assert "Run curated fast pytest coverage" in workflow
+    assert "python -m pytest -q" in workflow
+    assert "tests/test_device_normalization.py" in workflow
+    assert "tests/test_macos_mps_fallback.py" in workflow
+    assert "tests/test_model_registry_schema.py" in workflow
+    assert "tests/test_windows_normal_route_matrix.py" in workflow
+    assert "tests/test_vocals_hq_runtime_proof.py" in workflow
+    assert "python -m pytest -q \\\n            tests" in workflow
+
+
 def test_setup_internal_luac_compiles_under_reaper_limits():
     luac = shutil.which("luac")
     if not luac:


### PR DESCRIPTION
## Summary
- Add a curated `CI Fast` pytest step for device normalization, macOS MPS fallback, model registry, Windows route matrix, Vocals HQ runtime proof, and static CI/pin guards.
- Remove stale `onnxruntime>=1.21,<1.22` CI fossils from `requirements-ci.txt` and the macOS Apple Silicon backend smoke fallback.
- Keep Linux main runtime `onnxruntime` unpinned and document the current platform-scoped pin policy in static tests.

## Root Cause
`CI Fast` previously did not run a general pytest suite. It only ran version/release gates, quick script smoke commands, and i18n validation, so `tests/test_macos_mps_fallback.py` and related runtime/device tests were outside main CI coverage.

## CI Heavy Status
Read-only inspection showed `CI Heavy (manual/scheduled)` does not run pytest. It installs `requirements-ci.txt` and runs `python scripts/reaper/audio_separator_process.py --check`. The last 10 scheduled runs on `main` were failures before the heavy check because `stemwerk-core` was requested from PyPI. This branch changes `requirements-ci.txt` to use the vendored local package, so a `workflow_dispatch` CI Heavy run on this branch is required as merge evidence.

## Python / Runtime Policy
- CI Fast uses Python 3.11.
- Production payload tooling generally targets Python 3.12.
- Local dev Python may differ, including Python 3.14, and must not become implicit CI policy.
- Linux main runtime remains unpinned for `onnxruntime`; pinning belongs to the ASEP 0.44.3 pin matrix.
- Existing DrumSep/DirectML platform pins are intentionally unchanged.

## Out of Scope
- Linux main runtime pinning.
- ASEP 0.44.3 pin-matrix decisions.
- DirectML/DrumSep pin changes.
- Branch cleanup.
- `artifacts/` cleanup.
- Tags, releases, installer builds, or runtime cleanup.

## Local Verification
- `python -m pytest -q tests/test_device_normalization.py` -> 21 passed.
- `python -m pytest -q tests/test_macos_mps_fallback.py` -> 12 passed, 1 known warning.
- `python -m pytest -q tests/test_model_registry_schema.py` -> 12 passed.
- `python -m pytest -q tests/test_windows_normal_route_matrix.py` -> 21 passed.
- `python -m pytest -q tests/test_vocals_hq_runtime_proof.py` -> 23 passed.
- Exact new Fast pytest command -> 93 passed, 1 known warning, 3.617s wall time.
- `python tools/release_gate.py --check` -> PASS.
- `git diff --check` -> PASS.

`python -m pytest -q tests/test_dependency_constraints.py` is not green in the local Python 3.14 environment: it fails on existing env-dependent dependency assertions (`audio_separator` missing, torch 2.12.1 vs expected 2.5.1, missing torchvision/torchaudio, MPS not built). The new static guard nodes pass in the curated Fast command.

## Negative Proof
Not performed. Optional only with explicit approval: temporarily break an MPS assertion, prove CI Fast fails, then drop/revert before merge.