### PR TITLE
linux: bump ROCm main runtime to audio-separator 0.44.3

### DIFF
--- a/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
+++ b/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
@@ -7,6 +7,10 @@ BUNDLED_PAYLOAD_DIR="${SCRIPT_DIR}/_bundled"
 PINNED_TORCH_VERSION="2.5.1"
 PINNED_TORCHAUDIO_VERSION="2.5.1"
 PINNED_TORCHVISION_VERSION="0.20.1"
+PINNED_AUDIO_SEPARATOR_VERSION="0.44.3"
+MAIN_AUDIO_SEPARATOR_PACKAGE="audio-separator==${PINNED_AUDIO_SEPARATOR_VERSION}"
+MAIN_GPU_AUDIO_SEPARATOR_PACKAGE="audio-separator[gpu]==${PINNED_AUDIO_SEPARATOR_VERSION}"
+PINNED_BEARTYPE_VERSION="0.18.5"
 ROCM7_GFX1201_TORCH_VERSION="2.10.0"
 ROCM7_GFX1201_TORCHAUDIO_VERSION="2.10.0"
 ROCM7_GFX1201_TORCHVISION_VERSION="0.25.0"
@@ -1487,7 +1491,7 @@ PY
 )"
   case "${_probe}" in
     rebuild\|*)
-      log_step "Existing venv has incompatible torch ${_probe#rebuild|}; rebuilding .venv for audio-separator 0.23.0 compatibility"
+      log_step "Existing venv has incompatible torch ${_probe#rebuild|}; rebuilding .venv for audio-separator ${PINNED_AUDIO_SEPARATOR_VERSION} compatibility"
       return 0
       ;;
     ok\|*)
@@ -1679,6 +1683,53 @@ enforce_runtime_python_pins() {
     "numba==${PINNED_NUMBA_VERSION}" >> "${LOG_FILE}" 2>&1
 }
 
+install_main_audio_separator_runtime_deps() {
+  _py="$1"
+  if [ -n "${CONSTRAINTS_FILE}" ]; then
+    pip_install_with_scope main "${_py}" -c "${CONSTRAINTS_FILE}" --upgrade --no-cache-dir \
+      "beartype==${PINNED_BEARTYPE_VERSION}" \
+      "diffq>=0.2" \
+      "einops>=0.7" \
+      "julius>=0.2" \
+      "librosa>=0.10" \
+      "ml_collections" \
+      "onnx-weekly" \
+      "onnx2torch-py313>=1.6" \
+      "${ONNX_PACKAGE}" \
+      "pydub>=0.25" \
+      "PyYAML" \
+      "requests>=2" \
+      "resampy>=0.4" \
+      "rotary-embedding-torch>=0.6.1,<0.7.0" \
+      "samplerate==0.1.0" \
+      "scipy==1.17.1" \
+      "six>=1.16" \
+      "soundfile>=0.12" \
+      "tqdm" >> "${LOG_FILE}" 2>&1
+    return $?
+  fi
+  pip_install_with_scope main "${_py}" --upgrade --no-cache-dir \
+    "beartype==${PINNED_BEARTYPE_VERSION}" \
+    "diffq>=0.2" \
+    "einops>=0.7" \
+    "julius>=0.2" \
+    "librosa>=0.10" \
+    "ml_collections" \
+    "onnx-weekly" \
+    "onnx2torch-py313>=1.6" \
+    "${ONNX_PACKAGE}" \
+    "pydub>=0.25" \
+    "PyYAML" \
+    "requests>=2" \
+    "resampy>=0.4" \
+    "rotary-embedding-torch>=0.6.1,<0.7.0" \
+    "samplerate==0.1.0" \
+    "scipy==1.17.1" \
+    "six>=1.16" \
+    "soundfile>=0.12" \
+    "tqdm" >> "${LOG_FILE}" 2>&1
+}
+
 if [ -z "${RUNTIME_BASE}" ]; then
   echo "Missing runtime base" >&2
   exit 1
@@ -1722,7 +1773,7 @@ SUPPORTED_PYTHON_FOUND="no"
 DETECTED_PYTHON_VERSION=""
 DETECTED_PYTHON_PATH=""
 # Conservative default on Linux to avoid extra GPU deps unless explicitly needed.
-PACKAGE="audio-separator==0.23.0"
+PACKAGE="${MAIN_AUDIO_SEPARATOR_PACKAGE}"
 ONNX_PACKAGE="onnxruntime"
 CORE_EXTRA=""
 PROFILE="linux-cpu"
@@ -1804,7 +1855,7 @@ if [ "${ROCM_MODE}" -eq 1 ] && [ "${GPU_MODE}" -eq 0 ]; then
   BACKEND="rocm"
 elif [ "${GPU_MODE}" -eq 1 ]; then
   log_step "CUDA-capable NVIDIA detected; enabling GPU packages"
-  PACKAGE="audio-separator[gpu]==0.23.0"
+  PACKAGE="${MAIN_GPU_AUDIO_SEPARATOR_PACKAGE}"
   CORE_EXTRA="[gpu]"
   PROFILE="linux-cuda"
   BACKEND="cuda"
@@ -2180,7 +2231,7 @@ else
       log_stage "Installing CPU torch"
       install_linux_torch_stack "cpu" || set_status "deps_failed" "torch_cpu_install_failed"
       log_nvidia_packages "CPU torch install"
-      PACKAGE="audio-separator==0.23.0"
+      PACKAGE="${MAIN_AUDIO_SEPARATOR_PACKAGE}"
       CORE_EXTRA=""
     elif [ "${BACKEND}" = "cuda" ]; then
       log_stage "Installing CUDA torch"
@@ -2381,7 +2432,7 @@ EOF
         PROFILE="linux-cpu"
         BACKEND="cpu"
         BACKEND_REASON="${rocm_fail_reason}"
-        PACKAGE="audio-separator==0.23.0"
+        PACKAGE="${MAIN_AUDIO_SEPARATOR_PACKAGE}"
         CORE_EXTRA=""
       fi
     fi
@@ -2478,7 +2529,7 @@ PY
     "${VENV_PY}" -c "import audio_separator" >/dev/null 2>&1 || audio_import_rc=$?
     if [ "${audio_import_rc}" -ne 0 ] && [ "${audio_install_rc}" -eq 0 ]; then
       if [ -n "${CONSTRAINTS_FILE}" ]; then
-        log_step "Installing audio-separator 0.23.0 with constraints (torch pinned)"
+        log_step "Installing audio-separator ${PINNED_AUDIO_SEPARATOR_VERSION} with constraints (torch pinned)"
         if [ "${managed_diffq_required}" -eq 1 ] && [ "${managed_diffq_ready}" -eq 1 ]; then
           pip_install_with_scope main "${VENV_PY}" -c "${CONSTRAINTS_FILE}" --only-binary=diffq "${PACKAGE}" >> "${audio_install_log}" 2>&1 || audio_install_rc=$?
         else
@@ -2493,12 +2544,12 @@ PY
       fi
       cat "${audio_install_log}" >> "${LOG_FILE}" 2>/dev/null || true
     fi
-    if [ "${audio_install_rc}" -ne 0 ] && [ "${PACKAGE}" != "audio-separator==0.23.0" ]; then
+    if [ "${audio_install_rc}" -ne 0 ] && [ "${PACKAGE}" != "${MAIN_AUDIO_SEPARATOR_PACKAGE}" ]; then
       if detect_build_tools_missing_log "${audio_install_log}"; then
         mark_build_tools_missing
       fi
       log_step "GPU audio-separator install failed; falling back to CPU package"
-      PACKAGE="audio-separator==0.23.0"
+      PACKAGE="${MAIN_AUDIO_SEPARATOR_PACKAGE}"
       PROFILE="linux-cpu"
       BACKEND="cpu"
       BACKEND_REASON="${BACKEND_REASON:-backend_install_failed}"
@@ -2510,6 +2561,14 @@ PY
         pip_install_with_scope main "${VENV_PY}" "${PACKAGE}" >> "${audio_install_log}" 2>&1 || audio_install_rc=$?
       fi
       cat "${audio_install_log}" >> "${LOG_FILE}" 2>/dev/null || true
+    fi
+    if [ "${audio_install_rc}" -ne 0 ]; then
+      log_step "audio-separator resolver install failed; installing pinned runtime dependencies and retrying package install without dependency resolution"
+      audio_install_rc=0
+      install_main_audio_separator_runtime_deps "${VENV_PY}" || audio_install_rc=$?
+      if [ "${audio_install_rc}" -eq 0 ]; then
+        pip_install_with_scope main "${VENV_PY}" --no-deps "${PACKAGE}" >> "${LOG_FILE}" 2>&1 || audio_install_rc=$?
+      fi
     fi
     if [ "${audio_install_rc}" -ne 0 ] && [ "${managed_diffq_required}" -eq 0 ]; then
       if detect_build_tools_missing_log "${audio_install_log}"; then
@@ -2527,7 +2586,7 @@ PY
     if [ "${audio_install_rc}" -ne 0 ]; then
       log_step "audio-separator runtime dependencies incomplete; attempting full dependency repair install"
       audio_repair_attempted=1
-      PACKAGE="audio-separator==0.23.0"
+      PACKAGE="${MAIN_AUDIO_SEPARATOR_PACKAGE}"
       audio_repair_rc=0
       : > "${audio_install_log}" || true
       if [ "${managed_diffq_required}" -eq 1 ]; then

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -19,7 +19,7 @@ import pytest
 EXPECTED_TORCH = "2.5.1"
 EXPECTED_TORCHVISION = "0.20.1"
 EXPECTED_TORCHAUDIO = "2.5.1"
-EXPECTED_AUDIO_SEPARATOR = "0.23.0"
+EXPECTED_AUDIO_SEPARATOR = "0.44.3"
 
 
 def _load_audio_separator_process_module():
@@ -2021,6 +2021,10 @@ def test_command_path_noise_is_ignored_for_python_resolution():
 def test_linux_managed_flow_installs_audio_separator_runtime_deps_after_torch():
     script = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
 
+    assert 'PINNED_AUDIO_SEPARATOR_VERSION="0.44.3"' in script
+    assert 'MAIN_AUDIO_SEPARATOR_PACKAGE="audio-separator==${PINNED_AUDIO_SEPARATOR_VERSION}"' in script
+    assert 'MAIN_GPU_AUDIO_SEPARATOR_PACKAGE="audio-separator[gpu]==${PINNED_AUDIO_SEPARATOR_VERSION}"' in script
+    assert 'PINNED_BEARTYPE_VERSION="0.18.5"' in script
     assert 'PINNED_NUMPY_VERSION="1.26.4"' in script
     assert 'PINNED_NUMBA_VERSION="0.59.1"' in script
     assert 'PINNED_LLVM_VERSION="0.42.0"' in script
@@ -2029,7 +2033,11 @@ def test_linux_managed_flow_installs_audio_separator_runtime_deps_after_torch():
     assert '"llvmlite==${PINNED_LLVM_VERSION}"' in script
     assert '"numba==${PINNED_NUMBA_VERSION}"' in script
     assert 'log_stage "Checking/installing audio_separator"' in script
-    assert 'Installing audio-separator 0.23.0 with constraints (torch pinned)' in script
+    assert 'Installing audio-separator ${PINNED_AUDIO_SEPARATOR_VERSION} with constraints (torch pinned)' in script
+    assert "install_main_audio_separator_runtime_deps" in script
+    assert '"beartype==${PINNED_BEARTYPE_VERSION}"' in script
+    assert '"onnx2torch-py313>=1.6"' in script
+    assert '"samplerate==0.1.0"' in script
     assert 'pip_install_with_scope main "${VENV_PY}" --no-deps "${PACKAGE}"' in script
     assert script.index('install_linux_torch_stack "cpu"') < script.index('log_stage "Checking/installing audio_separator"')
     assert script.index('log_stage "Checking/installing audio_separator"') < script.index("Final verification")
@@ -2141,7 +2149,7 @@ def test_linux_no_deps_audio_separator_fallback_requires_runtime_deps():
     assert "verify_audio_separator_runtime_deps || audio_install_rc=1" in script
     assert 'log_step "audio-separator runtime dependencies incomplete; attempting full dependency repair install"' in script
     assert 'audio_repair_attempted=1' in script
-    assert 'PACKAGE="audio-separator==0.23.0"' in script
+    assert 'PACKAGE="${MAIN_AUDIO_SEPARATOR_PACKAGE}"' in script
     assert 'if [ "${audio_repair_rc}" -eq 0 ]; then' in script
     assert "verify_audio_separator_runtime_deps || audio_repair_rc=1" in script
     assert "AUDIO_SEPARATOR_DEPS_COMPLETE=\"no\"" in script
@@ -5183,7 +5191,7 @@ def test_linux_wheelhouse_builder_targets_cp312_manylinux_and_uses_name_preload(
     assert '"pip"' not in main_cpu_block
     assert '"setuptools"' not in main_cpu_block
     assert '"wheel"' not in main_cpu_block
-    assert '"audio-separator==0.23.0"' in main_cpu_block
+    assert '"audio-separator==0.44.3"' in main_cpu_block
 
     torch_requirements_block = script.split("TORCH_REQUIREMENTS = (", 1)[1].split(")", 1)[0]
     assert '"torch"' in torch_requirements_block
@@ -5204,6 +5212,38 @@ def test_linux_wheelhouse_builder_targets_cp312_manylinux_and_uses_name_preload(
     assert "cuda-toolkit" not in drumsep_cpu_block
 
     assert '"linux-x86_64-cp312"' in payload_builder
+
+
+def test_linux_main_runtime_asep_0443_pins_preserve_drumsep_policy():
+    linux_bootstrap = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
+    linux_wheelhouse = Path("tools/build_linux_wheelhouse.py").read_text()
+
+    main_cpu_block = linux_wheelhouse.split('("main", "cpu"): WheelhouseSpec(', 1)[1].split('("main", "cuda")', 1)[0]
+    main_cuda_block = linux_wheelhouse.split('("main", "cuda"): WheelhouseSpec(', 1)[1].split('("main", "rocm")', 1)[0]
+    main_rocm_block = linux_wheelhouse.split('("main", "rocm"): WheelhouseSpec(', 1)[1].split('("drumsep", "cpu")', 1)[0]
+
+    assert 'PINNED_AUDIO_SEPARATOR_VERSION="0.44.3"' in linux_bootstrap
+    assert 'PACKAGE="${MAIN_AUDIO_SEPARATOR_PACKAGE}"' in linux_bootstrap
+    assert 'PACKAGE="${MAIN_GPU_AUDIO_SEPARATOR_PACKAGE}"' in linux_bootstrap
+    assert 'PINNED_NUMPY_VERSION="1.26.4"' in linux_bootstrap
+    assert 'PINNED_NUMBA_VERSION="0.59.1"' in linux_bootstrap
+    assert 'PINNED_LLVM_VERSION="0.42.0"' in linux_bootstrap
+    assert 'PINNED_BEARTYPE_VERSION="0.18.5"' in linux_bootstrap
+    assert "install_main_audio_separator_runtime_deps" in linux_bootstrap
+    assert 'DRUMSEP_AUDIO_SEPARATOR_VERSION="0.34.1"' in linux_bootstrap
+    assert 'ROCM7_GFX1201_TORCH_VERSION="2.10.0"' in linux_bootstrap
+    assert 'ROCM7_GFX1201_TORCHAUDIO_VERSION="2.10.0"' in linux_bootstrap
+    assert 'ROCM7_GFX1201_TORCHVISION_VERSION="0.25.0"' in linux_bootstrap
+    assert 'IDX_LIST="https://download.pytorch.org/whl/rocm7.0 https://download.pytorch.org/whl/rocm7.1 https://download.pytorch.org/whl/rocm7.2"' in linux_bootstrap
+
+    assert '"audio-separator==0.44.3"' in main_cpu_block
+    assert '"audio-separator[gpu]==0.44.3"' in main_cuda_block
+    assert '"audio-separator==0.44.3"' in main_rocm_block
+    assert '"numpy==1.26.4"' in main_rocm_block
+    assert '"numba==0.59.1"' in main_rocm_block
+    assert '"llvmlite==0.42.0"' in main_rocm_block
+    assert '"onnxruntime"' in main_rocm_block
+    assert '"audio-separator==0.34.1"' in linux_wheelhouse
 
 
 def test_macos_build_script_supports_package_variants_without_wiping_dist():

--- a/tools/build_linux_wheelhouse.py
+++ b/tools/build_linux_wheelhouse.py
@@ -74,7 +74,7 @@ class WheelhouseSpec:
 SPECS: Dict[tuple[str, str], WheelhouseSpec] = {
     ("main", "cpu"): WheelhouseSpec(
         requirements=(
-            "audio-separator==0.23.0",
+            "audio-separator==0.44.3",
             "numpy==1.26.4",
             "numba==0.59.1",
             "llvmlite==0.42.0",
@@ -88,7 +88,7 @@ SPECS: Dict[tuple[str, str], WheelhouseSpec] = {
     ),
     ("main", "cuda"): WheelhouseSpec(
         requirements=(
-            "audio-separator[gpu]==0.23.0",
+            "audio-separator[gpu]==0.44.3",
             "numpy==1.26.4",
             "numba==0.59.1",
             "llvmlite==0.42.0",
@@ -101,7 +101,7 @@ SPECS: Dict[tuple[str, str], WheelhouseSpec] = {
     ),
     ("main", "rocm"): WheelhouseSpec(
         requirements=(
-            "audio-separator==0.23.0",
+            "audio-separator==0.44.3",
             "numpy==1.26.4",
             "numba==0.59.1",
             "llvmlite==0.42.0",


### PR DESCRIPTION
## Scope
- Linux ROCm main runtime only.
- Bumps Linux main audio-separator to 0.44.3.
- Keeps RX 9070/gfx1201 ROCm torch route on torch/torchaudio 2.10.0+rocm7.0 and torchvision 0.25.0+rocm7.0 where the existing runtime route uses torchvision.
- Keeps Linux main NumPy/numba/llvmlite/beartype boundary at 1.26.4 / 0.59.1 / 0.42.0 / 0.18.5.
- Adds an explicit Linux main fallback for the audio-separator 0.44.3 metadata conflict with NumPy 1.26.4: install pinned runtime deps, then install audio-separator without dependency resolution.

## Untouched
- DKS/DrumSep runtime remains audio-separator 0.34.1.
- No Windows changes.
- No macOS changes.
- No NVIDIA/CUDA torch pin changes.
- No runtime unification.
- No model registry changes.
- No Lua/UI changes.
- No tags, releases, or installer builds.

## Smoke Evidence
Throwaway root:
`/home/flark/stemwerk-rnd/linux-rocm-asep0443-main-runtime-20260714-055004`

Stack probe:
- Python 3.12.13
- audio-separator 0.44.3
- torch 2.10.0+rocm7.0
- torchaudio 2.10.0+rocm7.0
- torchvision 0.25.0+rocm7.0
- HIP 7.0.51831
- onnxruntime 1.27.0
- numpy 1.26.4
- numba 0.59.1
- llvmlite 0.42.0
- beartype 0.18.5
- torch.cuda.is_available=True
- device_count=2: AMD Radeon RX 9070, AMD Radeon 780M Graphics

20s model smokes on RX 9070:
- htdemucs: rc=0, 22s
- htdemucs_ft: rc=0, 19s
- htdemucs_6s: rc=0, 9s
- bs_roformer_viperx dev-only route: rc=0, 46s

Device normalization evidence:
- `--device cuda`: rc=0, normalized_device=cuda:0, effective_backend=rocm, device=AMD Radeon RX 9070
- `--device cuda:0`: covered by model smokes, effective_backend=rocm, device=AMD Radeon RX 9070
- `--device cuda:1`: rc=2, skipped with ROCm rocBLAS Tensile library missing for gfx1103 / AMD Radeon 780M Graphics
- `--device cuda:9`: rc=2, cuda_index_out_of_range:index=9:count=2

Known metadata note:
- `pip check` reports `audio-separator 0.44.3 has requirement numpy>=2, but you have numpy 1.26.4`.
- This PR intentionally preserves the requested NumPy 1.26.4 boundary and uses a controlled no-deps audio-separator install after pinned runtime dependencies.

## Tests
- `python -m pytest -q tests/test_dependency_constraints.py -k "linux or rocm or audio_separator or wheelhouse"` -> 92 passed, 1 skipped, 252 deselected
- `python -m pytest -q tests/test_device_normalization.py` -> 21 passed
- `python -m pytest -q tests/test_model_registry_schema.py` -> 12 passed
- `python -m pytest -q tests/test_macos_mps_fallback.py` -> 12 passed, 1 warning
- `python tools/release_gate.py --check` -> PASS
- `git diff --check` -> PASS
- CI Fast local equivalent after dependency install step -> 93 passed, 1 warning

Local CI note:
- The exact workflow `python -m pip install pytest pyyaml soundfile` step is blocked on this Arch host by PEP 668 externally-managed-environment. The dependencies were already available, so the remaining workflow commands were run locally.
