### PR TITLE
Linux ROCm main runtime: audio-separator 0.44.3 with NumPy 2

### DIFF
--- a/docs/research/ASEP_0443_PIN_MATRIX_2026-07-14.md
+++ b/docs/research/ASEP_0443_PIN_MATRIX_2026-07-14.md
@@ -102,11 +102,22 @@ Proposed first branch candidate:
 - torchvision: 0.25.0+rocm7.0 only if required by resolved payload/tests
 - onnxruntime: 1.27.0, or keep the current unpinned policy if it resolves to
   1.27.0 in the target environment
-- numpy: keep 1.26.4 for the main runtime first branch
-- numba: keep 0.59.1 for the main runtime first branch
-- llvmlite: keep 0.42.0 for the main runtime first branch
+- numpy: 2.4.4
+- scipy: 1.18.0
+- numba: 0.66.0
+- llvmlite: 0.48.0
 - beartype: 0.18.5 is acceptable on Python 3.12; Python 3.14 is known-bad for
   Viperx with this beartype/toolchain combination
+
+NumPy 2 compatibility addendum: the first Linux ROCm pin branch with
+`audio-separator==0.44.3` and `numpy==1.26.4` was superseded because
+audio-separator 0.44.3 package metadata declares `numpy>=2`, making the NumPy
+1.x strategy fail `pip check`. The pip-consistent R&D root
+`/home/flark/stemwerk-rnd/linux-rocm-asep0443-numpy2-rd-20260714-153559`
+validated the NumPy 2 stack above with `pip check` PASS plus htdemucs,
+htdemucs_ft, htdemucs_6s, and Viperx PASS on RX 9070. This does not change
+DrumSep/DKS release policy; keep DrumSep/DKS on audio-separator 0.34.1 until
+the catalog/model rename scenarios are handled.
 
 Evidence confidence is high. The branch still needs normal installer/bootstrap
 smokes because wheelhouse and offline payload behavior are separate from R&D

--- a/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
+++ b/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
@@ -7,12 +7,15 @@ BUNDLED_PAYLOAD_DIR="${SCRIPT_DIR}/_bundled"
 PINNED_TORCH_VERSION="2.5.1"
 PINNED_TORCHAUDIO_VERSION="2.5.1"
 PINNED_TORCHVISION_VERSION="0.20.1"
+PINNED_AUDIO_SEPARATOR_VERSION="0.44.3"
 ROCM7_GFX1201_TORCH_VERSION="2.10.0"
 ROCM7_GFX1201_TORCHAUDIO_VERSION="2.10.0"
 ROCM7_GFX1201_TORCHVISION_VERSION="0.25.0"
-PINNED_NUMPY_VERSION="1.26.4"
-PINNED_NUMBA_VERSION="0.59.1"
-PINNED_LLVM_VERSION="0.42.0"
+PINNED_NUMPY_VERSION="2.4.4"
+PINNED_SCIPY_VERSION="1.18.0"
+PINNED_NUMBA_VERSION="0.66.0"
+PINNED_LLVM_VERSION="0.48.0"
+PINNED_BEARTYPE_VERSION="0.18.5"
 PINNED_IMAGEIO_FFMPEG_VERSION="0.6.0"
 DRUMSEP_AUDIO_SEPARATOR_VERSION="0.34.1"
 DRUMSEP_NUMPY_VERSION="2.4.6"
@@ -1487,7 +1490,7 @@ PY
 )"
   case "${_probe}" in
     rebuild\|*)
-      log_step "Existing venv has incompatible torch ${_probe#rebuild|}; rebuilding .venv for audio-separator 0.23.0 compatibility"
+      log_step "Existing venv has incompatible torch ${_probe#rebuild|}; rebuilding .venv for audio-separator ${PINNED_AUDIO_SEPARATOR_VERSION} compatibility"
       return 0
       ;;
     ok\|*)
@@ -1672,10 +1675,12 @@ enforce_runtime_python_pins() {
   if [ -z "${VENV_PY}" ] || [ ! -x "${VENV_PY}" ]; then
     return 1
   fi
-  log_step "Enforcing runtime Python deps: numpy==${PINNED_NUMPY_VERSION} numba==${PINNED_NUMBA_VERSION} llvmlite==${PINNED_LLVM_VERSION}"
+  log_step "Enforcing runtime Python deps: numpy==${PINNED_NUMPY_VERSION} scipy==${PINNED_SCIPY_VERSION} numba==${PINNED_NUMBA_VERSION} llvmlite==${PINNED_LLVM_VERSION} beartype==${PINNED_BEARTYPE_VERSION}"
   pip_install_with_scope main "${VENV_PY}" --upgrade --force-reinstall --no-cache-dir \
     "numpy==${PINNED_NUMPY_VERSION}" \
+    "scipy==${PINNED_SCIPY_VERSION}" \
     "llvmlite==${PINNED_LLVM_VERSION}" \
+    "beartype==${PINNED_BEARTYPE_VERSION}" \
     "numba==${PINNED_NUMBA_VERSION}" >> "${LOG_FILE}" 2>&1
 }
 
@@ -1722,7 +1727,7 @@ SUPPORTED_PYTHON_FOUND="no"
 DETECTED_PYTHON_VERSION=""
 DETECTED_PYTHON_PATH=""
 # Conservative default on Linux to avoid extra GPU deps unless explicitly needed.
-PACKAGE="audio-separator==0.23.0"
+PACKAGE="audio-separator==${PINNED_AUDIO_SEPARATOR_VERSION}"
 ONNX_PACKAGE="onnxruntime"
 CORE_EXTRA=""
 PROFILE="linux-cpu"
@@ -1804,7 +1809,7 @@ if [ "${ROCM_MODE}" -eq 1 ] && [ "${GPU_MODE}" -eq 0 ]; then
   BACKEND="rocm"
 elif [ "${GPU_MODE}" -eq 1 ]; then
   log_step "CUDA-capable NVIDIA detected; enabling GPU packages"
-  PACKAGE="audio-separator[gpu]==0.23.0"
+  PACKAGE="audio-separator[gpu]==${PINNED_AUDIO_SEPARATOR_VERSION}"
   CORE_EXTRA="[gpu]"
   PROFILE="linux-cuda"
   BACKEND="cuda"
@@ -2180,7 +2185,7 @@ else
       log_stage "Installing CPU torch"
       install_linux_torch_stack "cpu" || set_status "deps_failed" "torch_cpu_install_failed"
       log_nvidia_packages "CPU torch install"
-      PACKAGE="audio-separator==0.23.0"
+      PACKAGE="audio-separator==${PINNED_AUDIO_SEPARATOR_VERSION}"
       CORE_EXTRA=""
     elif [ "${BACKEND}" = "cuda" ]; then
       log_stage "Installing CUDA torch"
@@ -2381,7 +2386,7 @@ EOF
         PROFILE="linux-cpu"
         BACKEND="cpu"
         BACKEND_REASON="${rocm_fail_reason}"
-        PACKAGE="audio-separator==0.23.0"
+        PACKAGE="audio-separator==${PINNED_AUDIO_SEPARATOR_VERSION}"
         CORE_EXTRA=""
       fi
     fi
@@ -2397,7 +2402,9 @@ PY
       log_step "Pinned torch version for downstream installs: ${TORCH_VER}"
       {
         echo "numpy==${PINNED_NUMPY_VERSION}"
+        echo "scipy==${PINNED_SCIPY_VERSION}"
         echo "llvmlite==${PINNED_LLVM_VERSION}"
+        echo "beartype==${PINNED_BEARTYPE_VERSION}"
         echo "numba==${PINNED_NUMBA_VERSION}"
         "${VENV_PY}" - <<'PY' 2>/dev/null
 import importlib
@@ -2478,7 +2485,7 @@ PY
     "${VENV_PY}" -c "import audio_separator" >/dev/null 2>&1 || audio_import_rc=$?
     if [ "${audio_import_rc}" -ne 0 ] && [ "${audio_install_rc}" -eq 0 ]; then
       if [ -n "${CONSTRAINTS_FILE}" ]; then
-        log_step "Installing audio-separator 0.23.0 with constraints (torch pinned)"
+        log_step "Installing audio-separator ${PINNED_AUDIO_SEPARATOR_VERSION} with constraints (torch pinned)"
         if [ "${managed_diffq_required}" -eq 1 ] && [ "${managed_diffq_ready}" -eq 1 ]; then
           pip_install_with_scope main "${VENV_PY}" -c "${CONSTRAINTS_FILE}" --only-binary=diffq "${PACKAGE}" >> "${audio_install_log}" 2>&1 || audio_install_rc=$?
         else
@@ -2493,12 +2500,12 @@ PY
       fi
       cat "${audio_install_log}" >> "${LOG_FILE}" 2>/dev/null || true
     fi
-    if [ "${audio_install_rc}" -ne 0 ] && [ "${PACKAGE}" != "audio-separator==0.23.0" ]; then
+    if [ "${audio_install_rc}" -ne 0 ] && [ "${PACKAGE}" != "audio-separator==${PINNED_AUDIO_SEPARATOR_VERSION}" ]; then
       if detect_build_tools_missing_log "${audio_install_log}"; then
         mark_build_tools_missing
       fi
       log_step "GPU audio-separator install failed; falling back to CPU package"
-      PACKAGE="audio-separator==0.23.0"
+      PACKAGE="audio-separator==${PINNED_AUDIO_SEPARATOR_VERSION}"
       PROFILE="linux-cpu"
       BACKEND="cpu"
       BACKEND_REASON="${BACKEND_REASON:-backend_install_failed}"
@@ -2515,9 +2522,7 @@ PY
       if detect_build_tools_missing_log "${audio_install_log}"; then
         mark_build_tools_missing
       fi
-      log_step "audio-separator dependency install failed; retrying package install without dependency resolution"
-      audio_install_rc=0
-      pip_install_with_scope main "${VENV_PY}" --no-deps "${PACKAGE}" >> "${LOG_FILE}" 2>&1 || audio_install_rc=$?
+      log_step "audio-separator dependency install failed; no --no-deps fallback is allowed for the NumPy 2 runtime"
     elif [ "${audio_install_rc}" -ne 0 ]; then
       log_step "Managed wheel path required for Linux managed Python 3.12; skipping no-deps fallback"
     fi
@@ -2527,7 +2532,7 @@ PY
     if [ "${audio_install_rc}" -ne 0 ]; then
       log_step "audio-separator runtime dependencies incomplete; attempting full dependency repair install"
       audio_repair_attempted=1
-      PACKAGE="audio-separator==0.23.0"
+      PACKAGE="audio-separator==${PINNED_AUDIO_SEPARATOR_VERSION}"
       audio_repair_rc=0
       : > "${audio_install_log}" || true
       if [ "${managed_diffq_required}" -eq 1 ]; then

--- a/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
+++ b/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
@@ -1500,6 +1500,52 @@ PY
   return 1
 }
 
+main_runtime_requires_rebuild() {
+  _venv_py="$1"
+  [ -x "${_venv_py}" ] || return 1
+  _probe="$("${_venv_py}" - <<PY 2>/dev/null || true
+from importlib import metadata as md
+
+expected = {
+    "audio-separator": "${PINNED_AUDIO_SEPARATOR_VERSION}",
+    "numpy": "${PINNED_NUMPY_VERSION}",
+    "scipy": "${PINNED_SCIPY_VERSION}",
+    "numba": "${PINNED_NUMBA_VERSION}",
+    "llvmlite": "${PINNED_LLVM_VERSION}",
+    "beartype": "${PINNED_BEARTYPE_VERSION}",
+}
+
+for name, wanted in expected.items():
+    try:
+        installed = md.version(name)
+    except md.PackageNotFoundError:
+        continue
+    if name == "numpy":
+        try:
+            major = int(installed.split(".", 1)[0])
+        except Exception:
+            major = 0
+        if major < 2:
+            print("rebuild|numpy_major_lt_2:" + installed)
+            raise SystemExit(0)
+    if installed != wanted:
+        print("rebuild|" + name + ":" + installed + "!=" + wanted)
+        raise SystemExit(0)
+print("ok")
+PY
+)"
+  case "${_probe}" in
+    rebuild\|*)
+      log_step "Existing venv has incompatible main runtime ${_probe#rebuild|}; rebuilding .venv for audio-separator ${PINNED_AUDIO_SEPARATOR_VERSION} / NumPy ${PINNED_NUMPY_VERSION}"
+      return 0
+      ;;
+    ok)
+      log_step "Existing venv main runtime pins are compatible"
+      ;;
+  esac
+  return 1
+}
+
 linux_torch_install_args() {
   printf 'torch==%s torchvision==%s torchaudio==%s' \
     "${ACTIVE_TORCH_VERSION:-${PINNED_TORCH_VERSION}}" \
@@ -2142,7 +2188,7 @@ else
   fi
   log_stage "Creating venv"
   log_step "Creating STEMwerk virtual environment..."
-  if [ -x "${RUNTIME_BASE}/.venv/bin/python" ] && venv_torch_requires_rebuild "${RUNTIME_BASE}/.venv/bin/python"; then
+  if [ -x "${RUNTIME_BASE}/.venv/bin/python" ] && { venv_torch_requires_rebuild "${RUNTIME_BASE}/.venv/bin/python" || main_runtime_requires_rebuild "${RUNTIME_BASE}/.venv/bin/python"; }; then
     log_step "Removing existing virtual environment: ${RUNTIME_BASE}/.venv"
     rm -rf "${RUNTIME_BASE}/.venv"
   fi
@@ -2675,8 +2721,8 @@ backend = os.environ.get("STEMWERK_BACKEND", "cpu")
 errors = []
 try:
     import numpy as np
-    if int(str(getattr(np, "__version__", "0")).split(".", 1)[0]) >= 2:
-        errors.append("numpy_major_gte_2")
+    if int(str(getattr(np, "__version__", "0")).split(".", 1)[0]) < 2:
+        errors.append("numpy_major_lt_2")
 except Exception as exc:
     errors.append("numpy_import_failed:" + str(exc))
 try:

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -19,7 +19,7 @@ import pytest
 EXPECTED_TORCH = "2.5.1"
 EXPECTED_TORCHVISION = "0.20.1"
 EXPECTED_TORCHAUDIO = "2.5.1"
-EXPECTED_AUDIO_SEPARATOR = "0.44.3"
+EXPECTED_AUDIO_SEPARATOR = "0.23.0"
 
 
 def _load_audio_separator_process_module():
@@ -2070,6 +2070,23 @@ def test_linux_repair_skips_torch_pin_reapply_after_successful_same_run_install(
     assert script.index('torch_pin_reapply_skipped=already_installed_this_run') < script.index('log_stage "Re-applying pinned torch stack"')
 
 
+def test_linux_main_runtime_rebuilds_old_numpy1_audio_separator_venv():
+    script = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
+
+    assert "main_runtime_requires_rebuild()" in script
+    assert '"audio-separator": "${PINNED_AUDIO_SEPARATOR_VERSION}"' in script
+    assert '"numpy": "${PINNED_NUMPY_VERSION}"' in script
+    assert '"scipy": "${PINNED_SCIPY_VERSION}"' in script
+    assert '"numba": "${PINNED_NUMBA_VERSION}"' in script
+    assert '"llvmlite": "${PINNED_LLVM_VERSION}"' in script
+    assert '"beartype": "${PINNED_BEARTYPE_VERSION}"' in script
+    assert 'print("rebuild|numpy_major_lt_2:" + installed)' in script
+    assert 'print("rebuild|" + name + ":" + installed + "!=" + wanted)' in script
+    assert "rebuilding .venv for audio-separator ${PINNED_AUDIO_SEPARATOR_VERSION} / NumPy ${PINNED_NUMPY_VERSION}" in script
+    assert 'venv_torch_requires_rebuild "${RUNTIME_BASE}/.venv/bin/python" || main_runtime_requires_rebuild "${RUNTIME_BASE}/.venv/bin/python"' in script
+    assert script.index("main_runtime_requires_rebuild()") < script.index('log_stage "Creating venv"')
+
+
 def test_linux_torch_stack_verify_helper_checks_backend_and_all_three_packages():
     script = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
 
@@ -2189,6 +2206,8 @@ def test_linux_final_verification_requires_audio_separator_dependency_imports():
     assert 'set_status "deps_failed" "audio_separator_install_failed"' in linux_script
     assert "if ! verify_audio_separator_runtime_deps; then" in mac_script
     assert 'set_status "deps_failed" "audio_separator_install_failed"' in mac_script
+    assert "numpy_major_gte_2" not in linux_script
+    assert 'errors.append("numpy_major_lt_2")' in linux_script
     assert '[ "${AUDIO_SEPARATOR_DEPS_COMPLETE}" = "yes" ]' in linux_script
     assert 'log_step "Venv runtime incomplete; refusing to set PYTHON_PATH"' in linux_script
     assert 'log_step "Venv runtime verified; PYTHON_PATH set to venv"' in linux_script

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -19,7 +19,7 @@ import pytest
 EXPECTED_TORCH = "2.5.1"
 EXPECTED_TORCHVISION = "0.20.1"
 EXPECTED_TORCHAUDIO = "2.5.1"
-EXPECTED_AUDIO_SEPARATOR = "0.23.0"
+EXPECTED_AUDIO_SEPARATOR = "0.44.3"
 
 
 def _load_audio_separator_process_module():
@@ -2021,16 +2021,22 @@ def test_command_path_noise_is_ignored_for_python_resolution():
 def test_linux_managed_flow_installs_audio_separator_runtime_deps_after_torch():
     script = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
 
-    assert 'PINNED_NUMPY_VERSION="1.26.4"' in script
-    assert 'PINNED_NUMBA_VERSION="0.59.1"' in script
-    assert 'PINNED_LLVM_VERSION="0.42.0"' in script
+    assert 'PINNED_AUDIO_SEPARATOR_VERSION="0.44.3"' in script
+    assert 'PINNED_NUMPY_VERSION="2.4.4"' in script
+    assert 'PINNED_SCIPY_VERSION="1.18.0"' in script
+    assert 'PINNED_NUMBA_VERSION="0.66.0"' in script
+    assert 'PINNED_LLVM_VERSION="0.48.0"' in script
+    assert 'PINNED_BEARTYPE_VERSION="0.18.5"' in script
     assert "enforce_runtime_python_pins" in script
     assert '"numpy==${PINNED_NUMPY_VERSION}"' in script
+    assert '"scipy==${PINNED_SCIPY_VERSION}"' in script
     assert '"llvmlite==${PINNED_LLVM_VERSION}"' in script
+    assert '"beartype==${PINNED_BEARTYPE_VERSION}"' in script
     assert '"numba==${PINNED_NUMBA_VERSION}"' in script
     assert 'log_stage "Checking/installing audio_separator"' in script
-    assert 'Installing audio-separator 0.23.0 with constraints (torch pinned)' in script
-    assert 'pip_install_with_scope main "${VENV_PY}" --no-deps "${PACKAGE}"' in script
+    assert 'Installing audio-separator ${PINNED_AUDIO_SEPARATOR_VERSION} with constraints (torch pinned)' in script
+    assert 'pip_install_with_scope main "${VENV_PY}" --no-deps "${PACKAGE}"' not in script
+    assert "no --no-deps fallback is allowed for the NumPy 2 runtime" in script
     assert script.index('install_linux_torch_stack "cpu"') < script.index('log_stage "Checking/installing audio_separator"')
     assert script.index('log_stage "Checking/installing audio_separator"') < script.index("Final verification")
 
@@ -2082,7 +2088,9 @@ def test_linux_constraints_use_public_torch_versions_and_runtime_pins():
 
     assert 'str(getattr(m, "__version__", "")).split("+", 1)[0]' in script
     assert 'echo "numpy==${PINNED_NUMPY_VERSION}"' in script
+    assert 'echo "scipy==${PINNED_SCIPY_VERSION}"' in script
     assert 'echo "llvmlite==${PINNED_LLVM_VERSION}"' in script
+    assert 'echo "beartype==${PINNED_BEARTYPE_VERSION}"' in script
     assert 'echo "numba==${PINNED_NUMBA_VERSION}"' in script
     assert 'for name in ("torch","torchvision","torchaudio"):' in script
 
@@ -2134,20 +2142,19 @@ def test_linux_genuine_no_python_case_still_uses_python_missing():
     assert 'errors[#errors + 1] = "python_missing"' in script
 
 
-def test_linux_no_deps_audio_separator_fallback_requires_runtime_deps():
+def test_linux_main_audio_separator_install_has_no_no_deps_fallback():
     script = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
 
-    assert 'pip_install_with_scope main "${VENV_PY}" --no-deps "${PACKAGE}"' in script
+    assert 'pip_install_with_scope main "${VENV_PY}" --no-deps "${PACKAGE}"' not in script
     assert "verify_audio_separator_runtime_deps || audio_install_rc=1" in script
     assert 'log_step "audio-separator runtime dependencies incomplete; attempting full dependency repair install"' in script
     assert 'audio_repair_attempted=1' in script
-    assert 'PACKAGE="audio-separator==0.23.0"' in script
+    assert 'PACKAGE="audio-separator==${PINNED_AUDIO_SEPARATOR_VERSION}"' in script
     assert 'if [ "${audio_repair_rc}" -eq 0 ]; then' in script
     assert "verify_audio_separator_runtime_deps || audio_repair_rc=1" in script
     assert "AUDIO_SEPARATOR_DEPS_COMPLETE=\"no\"" in script
     assert "BACKEND_DEPS_COMPLETE=\"no\"" in script
     assert "audio_separator_dep_import_failed:" in script
-    assert script.index('pip_install_with_scope main "${VENV_PY}" --no-deps "${PACKAGE}"') < script.index("verify_audio_separator_runtime_deps || audio_install_rc=1")
     assert "Skipping torch pin repair and ONNX install after audio-separator dependency failure" in script
     assert 'if [ "${audio_install_rc}" -eq 0 ] && [ "${STATUS}" = "ok" ]; then' in script
     assert script.index('set_status "deps_failed" "audio_separator_install_failed"') < script.index('if [ "${audio_install_rc}" -eq 0 ] && [ "${STATUS}" = "ok" ]; then')
@@ -5116,14 +5123,22 @@ def test_linux_wheelhouse_builder_separates_bootstrap_downloads_from_pytorch_ind
     assert '"linux_x86_64"' in script
 
 
-def test_linux_main_wheelhouse_pins_scipy_below_numpy_2_breakpoint():
+def test_linux_main_wheelhouse_pins_numpy2_compatible_runtime_stack():
     script = Path("tools/build_linux_wheelhouse.py").read_text()
 
     assert '("main", "cpu")' in script
     assert '("main", "cuda")' in script
     assert '("main", "rocm")' in script
-    assert script.count('"scipy==1.17.1"') >= 3
-    assert '"numpy==1.26.4"' in script
+    assert script.count('"audio-separator==0.44.3"') >= 2
+    assert '"audio-separator[gpu]==0.44.3"' in script
+    assert script.count('"numpy==2.4.4"') >= 3
+    assert script.count('"scipy==1.18.0"') >= 3
+    assert script.count('"numba==0.66.0"') >= 3
+    assert script.count('"llvmlite==0.48.0"') >= 3
+    assert script.count('"beartype==0.18.5"') >= 3
+    assert '"numpy==1.26.4"' not in script
+    assert '"numba==0.59.1"' not in script
+    assert '"llvmlite==0.42.0"' not in script
 
 
 def test_linux_rocm_main_wheelhouse_skips_bundled_torch_transitives():
@@ -5183,7 +5198,12 @@ def test_linux_wheelhouse_builder_targets_cp312_manylinux_and_uses_name_preload(
     assert '"pip"' not in main_cpu_block
     assert '"setuptools"' not in main_cpu_block
     assert '"wheel"' not in main_cpu_block
-    assert '"audio-separator==0.23.0"' in main_cpu_block
+    assert '"audio-separator==0.44.3"' in main_cpu_block
+    assert '"numpy==2.4.4"' in main_cpu_block
+    assert '"scipy==1.18.0"' in main_cpu_block
+    assert '"numba==0.66.0"' in main_cpu_block
+    assert '"llvmlite==0.48.0"' in main_cpu_block
+    assert '"beartype==0.18.5"' in main_cpu_block
 
     torch_requirements_block = script.split("TORCH_REQUIREMENTS = (", 1)[1].split(")", 1)[0]
     assert '"torch"' in torch_requirements_block
@@ -5204,6 +5224,37 @@ def test_linux_wheelhouse_builder_targets_cp312_manylinux_and_uses_name_preload(
     assert "cuda-toolkit" not in drumsep_cpu_block
 
     assert '"linux-x86_64-cp312"' in payload_builder
+
+
+def test_linux_rocm_main_runtime_pins_asep_0443_numpy2_and_preserves_drumsep():
+    linux_bootstrap = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
+    linux_wheelhouse = Path("tools/build_linux_wheelhouse.py").read_text()
+    main_rocm_block = linux_wheelhouse.split('("main", "rocm"): WheelhouseSpec(', 1)[1].split('("drumsep", "cpu")', 1)[0]
+
+    assert 'PINNED_AUDIO_SEPARATOR_VERSION="0.44.3"' in linux_bootstrap
+    assert 'PINNED_NUMPY_VERSION="2.4.4"' in linux_bootstrap
+    assert 'PINNED_SCIPY_VERSION="1.18.0"' in linux_bootstrap
+    assert 'PINNED_NUMBA_VERSION="0.66.0"' in linux_bootstrap
+    assert 'PINNED_LLVM_VERSION="0.48.0"' in linux_bootstrap
+    assert 'PINNED_BEARTYPE_VERSION="0.18.5"' in linux_bootstrap
+    assert 'ROCM7_GFX1201_TORCH_VERSION="2.10.0"' in linux_bootstrap
+    assert 'ROCM7_GFX1201_TORCHAUDIO_VERSION="2.10.0"' in linux_bootstrap
+    assert 'ROCM7_GFX1201_TORCHVISION_VERSION="0.25.0"' in linux_bootstrap
+    assert 'IDX_LIST="https://download.pytorch.org/whl/rocm7.0 https://download.pytorch.org/whl/rocm7.1 https://download.pytorch.org/whl/rocm7.2"' in linux_bootstrap
+    assert 'DRUMSEP_AUDIO_SEPARATOR_VERSION="0.34.1"' in linux_bootstrap
+    assert 'PACKAGE="audio-separator==${PINNED_AUDIO_SEPARATOR_VERSION}"' in linux_bootstrap
+    assert 'PACKAGE="audio-separator[gpu]==${PINNED_AUDIO_SEPARATOR_VERSION}"' in linux_bootstrap
+    assert 'audio-separator==0.23.0' not in linux_bootstrap
+    assert 'numpy==1.26.4' not in linux_bootstrap
+
+    assert '"audio-separator==0.44.3"' in main_rocm_block
+    assert '"numpy==2.4.4"' in main_rocm_block
+    assert '"scipy==1.18.0"' in main_rocm_block
+    assert '"numba==0.66.0"' in main_rocm_block
+    assert '"llvmlite==0.48.0"' in main_rocm_block
+    assert '"beartype==0.18.5"' in main_rocm_block
+    assert '"onnxruntime"' in main_rocm_block
+    assert '"audio-separator==0.34.1"' in linux_wheelhouse
 
 
 def test_macos_build_script_supports_package_variants_without_wiping_dist():

--- a/tools/build_linux_wheelhouse.py
+++ b/tools/build_linux_wheelhouse.py
@@ -74,11 +74,12 @@ class WheelhouseSpec:
 SPECS: Dict[tuple[str, str], WheelhouseSpec] = {
     ("main", "cpu"): WheelhouseSpec(
         requirements=(
-            "audio-separator==0.23.0",
-            "numpy==1.26.4",
-            "numba==0.59.1",
-            "llvmlite==0.42.0",
-            "scipy==1.17.1",
+            "audio-separator==0.44.3",
+            "numpy==2.4.4",
+            "numba==0.66.0",
+            "llvmlite==0.48.0",
+            "scipy==1.18.0",
+            "beartype==0.18.5",
             "onnxruntime",
             "torch==2.5.1",
             "torchvision==0.20.1",
@@ -88,11 +89,12 @@ SPECS: Dict[tuple[str, str], WheelhouseSpec] = {
     ),
     ("main", "cuda"): WheelhouseSpec(
         requirements=(
-            "audio-separator[gpu]==0.23.0",
-            "numpy==1.26.4",
-            "numba==0.59.1",
-            "llvmlite==0.42.0",
-            "scipy==1.17.1",
+            "audio-separator[gpu]==0.44.3",
+            "numpy==2.4.4",
+            "numba==0.66.0",
+            "llvmlite==0.48.0",
+            "scipy==1.18.0",
+            "beartype==0.18.5",
             "onnxruntime",
             "torch==2.5.1",
             "torchvision==0.20.1",
@@ -101,11 +103,12 @@ SPECS: Dict[tuple[str, str], WheelhouseSpec] = {
     ),
     ("main", "rocm"): WheelhouseSpec(
         requirements=(
-            "audio-separator==0.23.0",
-            "numpy==1.26.4",
-            "numba==0.59.1",
-            "llvmlite==0.42.0",
-            "scipy==1.17.1",
+            "audio-separator==0.44.3",
+            "numpy==2.4.4",
+            "numba==0.66.0",
+            "llvmlite==0.48.0",
+            "scipy==1.18.0",
+            "beartype==0.18.5",
             "onnxruntime",
         ),
         index_url="https://download.pytorch.org/whl/rocm6.4",


### PR DESCRIPTION
## Summary

Supersedes PR #77.

PR77_NUMPY_METADATA_CONFLICT is addressed by moving the Linux main runtime candidate to a NumPy 2-compatible stack instead of forcing audio-separator with `--no-deps`.

Linux main runtime candidate:
- audio-separator 0.44.3
- numpy 2.4.4
- scipy 1.18.0
- numba 0.66.0
- llvmlite 0.48.0
- beartype 0.18.5
- torch/torchaudio 2.10.0+rocm7.0 for gfx1201 ROCm route
- torchvision 0.25.0+rocm7.0
- onnxruntime 1.27.0 resolved in clean install

Scope boundaries:
- DKS/DrumSep remains audio-separator 0.34.1
- no Windows pin changes
- no macOS pin changes
- no NVIDIA/CUDA torch pin changes
- no CPU torch pin changes
- no runtime unification
- no installer builds, tags, or releases

## Scope impact

Linux bootstrap paths touched:
- CPU main runtime: audio-separator moves to 0.44.3; NumPy/SciPy/numba/llvmlite/beartype pins move to the NumPy 2 stack; CPU torch remains 2.5.1 / torchvision 0.20.1 / torchaudio 2.5.1.
- ROCm main runtime: audio-separator moves to 0.44.3; NumPy 2 stack is enforced; gfx1201/RX 9070 keeps torch/torchaudio 2.10.0+rocm7.0 and torchvision 0.25.0+rocm7.0.
- CUDA/NVIDIA main runtime: audio-separator[gpu] moves to 0.44.3; NumPy 2 stack is enforced; CUDA torch pins remain unchanged.

Linux wheelhouse entries touched:
- main/cpu: audio-separator 0.44.3 and NumPy 2 stack.
- main/rocm: audio-separator 0.44.3 and NumPy 2 stack; torch transitive wheels remain skipped for the dynamic bootstrap ROCm path.
- main/cuda: audio-separator[gpu] 0.44.3 and NumPy 2 stack; CUDA torch pins unchanged.

## Validation

Local targeted validation:
- `python -m pytest -q tests/test_dependency_constraints.py -k "linux or rocm or audio_separator or numpy or numba or llvmlite or scipy or wheelhouse"`: PASS before guard patch, then 93 passed / 1 skipped / 252 deselected after guard patch.
- `python -m pytest -q tests/test_dependency_constraints.py::test_audio_separator_pin_and_import tests/test_dependency_constraints.py::test_linux_main_runtime_rebuilds_old_numpy1_audio_separator_venv tests/test_dependency_constraints.py::test_linux_final_verification_requires_audio_separator_dependency_imports`: 2 passed, 1 skipped.
- `python -m pytest -q tests/test_device_normalization.py tests/test_model_registry_schema.py tests/test_macos_mps_fallback.py`: 45 passed, 1 warning.
- `python tools/release_gate.py --check`: PASS.
- `git diff --check`: PASS.

CI Fast curated local command:
- `python tools/version_sync.py --check`: PASS.
- `python scripts/reaper/audio_separator_process.py --list-models`: PASS.
- `python scripts/reaper/audio_separator_process.py --help`: PASS.
- `python tests/i18n/test_languages.py`: PASS.
- curated pytest set: 93 passed, 1 warning.

Clean ROCm install gate root:
- `/home/flark/stemwerk-rnd/linux-rocm-asep0443-numpy2-clean-install-20260714-160552`

Clean ROCm install commands all exited 0:
- Python 3.12.9 venv
- `pip install --index-url https://download.pytorch.org/whl/rocm7.0 torch==2.10.0+rocm7.0 torchaudio==2.10.0+rocm7.0 torchvision==0.25.0+rocm7.0`
- `pip install --upgrade --force-reinstall --no-cache-dir numpy==2.4.4 scipy==1.18.0 llvmlite==0.48.0 beartype==0.18.5 numba==0.66.0`
- `pip install -c constraints.txt audio-separator==0.44.3`
- `pip install -c constraints.txt onnxruntime`
- `python -m pip check`: PASS, `No broken requirements found.`

Resolved ROCm versions:
- audio-separator 0.44.3
- numpy 2.4.4
- scipy 1.18.0
- numba 0.66.0
- llvmlite 0.48.0
- beartype 0.18.5
- torch 2.10.0+rocm7.0
- torchaudio 2.10.0+rocm7.0
- torchvision 0.25.0+rocm7.0
- onnxruntime 1.27.0

ROCm smoke gate on RX 9070/gfx1201 from the clean install env:
- import checks: exit 0, torch HIP 7.0.51831, cuda available, devices RX 9070 and AMD Radeon 780M.
- `htdemucs --device cuda`: exit 0, bass/drums/other/vocals.
- `htdemucs_ft --device cuda`: exit 0, bass/drums/other/vocals.
- `htdemucs_6s --device cuda`: exit 0, bass/drums/other/vocals/guitar/piano.
- Viperx dev-only route: exit 0, other/vocals.
- `--device cuda`: exit 0, selected/effective `cuda:0`, ROCm backend.
- `--device cuda:0`: exit 0.
- `--device cuda:1`: exit 2, expected gfx1103 rocBLAS Tensile skip reason.
- `--device cuda:9`: exit 2, expected `cuda_index_out_of_range:index=9:count=2`.

Linux CPU gate:
- Label: `LINUX_CPU_ASEP0443_NUMPY2_INSTALL_PASS`.
- Root: `/home/flark/stemwerk-rnd/linux-cpu-asep0443-numpy2-install-20260714-162410`.
- `pip check`: PASS, `No broken requirements found.`
- Resolved versions: audio-separator 0.44.3, numpy 2.4.4, scipy 1.18.0, numba 0.66.0, llvmlite 0.48.0, torch 2.5.1+cpu, torchaudio 2.5.1+cpu, torchvision 0.20.1+cpu, onnxruntime 1.27.0.
- Import checks: PASS.
- `htdemucs --device cpu` on 20s input: exit 0, bass/drums/other/vocals.

Linux CUDA/NVIDIA gate:
- Label: `LINUX_CUDA_NVIDIA_HARDWARE_SMOKE_DEFERRED`.
- This machine has AMD ROCm devices, not an NVIDIA CUDA device.
- Linux CUDA/NVIDIA install path is touched by the audio-separator[gpu] 0.44.3 package bump and NumPy 2 stack, but CUDA processing validation is deferred to the planned NVIDIA reconfirm branch/smoke.
- No CUDA smoke result is claimed in this PR.
- First fresh NVIDIA install after this merge should trigger the rebuild guard for old ASEP 0.23.x / NumPy 1.x main runtimes before installing the NumPy 2 stack.
- S1/S2 NVIDIA reconfirm is the first follow-up action once suitable NVIDIA hardware is available.
- Release-tag decision remains with flark after the NVIDIA reconfirm result.

Wheelhouse builder gate:
- Label: `LINUX_WHEELHOUSE_BUILD_PASS_WITH_KNOWN_PREEXISTING_GAP`.
- Evidence path: `/home/flark/stemwerk-rnd/wheelhouse-asep0443-numpy2-20260714-163333`.
- `main-rocm` build: exit 0, 49 wheels, 178M.
- `main-cpu` build: exit 0, 60 wheels, 363M.
- NumPy 2 pinset present in both built wheelhouses: audio-separator 0.44.3, numpy 2.4.4, scipy 1.18.0, numba 0.66.0, llvmlite 0.48.0, beartype 0.18.5.
- No `numpy-1.x` wheels found in either `main-rocm` or `main-cpu`.
- `main-cpu` includes torch 2.5.1+cpu, torchaudio 2.5.1+cpu, torchvision 0.20.1+cpu, and onnxruntime 1.27.0.
- `main-rocm` intentionally omits torch/torchaudio/torchvision because the Linux bootstrap chooses the ROCm torch stack dynamically for the detected GPU/ROCm service line.
- Known pre-existing strict offline resolver gap: the vendored `diffq-0.2.4-cp312-cp312-linux_x86_64.whl` metadata declares `Requires-Dist: Cython`, but the wheelhouse does not include a Cython wheel.
- The gap is pre-existing since `cb3bf07`, where the vendored `diffq` wheel was added; PR #78 does not modify `scripts/reaper/vendor/wheels`.
- The real bootstrap flow is not newly broken by this gap because managed Linux Python installs the vendored `diffq` wheel with `--no-deps`, then installs audio-separator using the managed `--only-binary=diffq` path.
- Follow-up: make a separate micro-PR after merge to either strip/repair the `diffq` wheel metadata or add a Cython wheel to the Linux wheelhouse.

Upgrade path for existing Linux main installs:
- Policy: `REBUILD_ON_VERSION_MISMATCH`.
- Existing Linux main `.venv` with audio-separator 0.23.0 / numpy 1.26.4 / numba 0.59.1 / llvmlite 0.42.0 is now detected before dependency install and the `.venv` is rebuilt instead of half-upgraded across the NumPy 1 -> 2 ABI boundary.
- Throwaway guard simulation root: `/home/flark/stemwerk-rnd/linux-main-runtime-upgrade-guard-20260714-162651`.
- Old fake venv result: `Existing venv has incompatible main runtime audio-separator:0.23.0!=0.44.3`, guard rc 0, rebuild required.
- Current NumPy2 CPU venv result: `Existing venv main runtime pins are compatible`, guard rc 1, no rebuild required.

