### PR TITLE
fix(dks): support audio-separator 0.44.3 catalog migration

### DIFF
--- a/scripts/reaper/_internal/stemwerk_drumsep_process.py
+++ b/scripts/reaper/_internal/stemwerk_drumsep_process.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import hashlib
 import importlib.metadata as metadata
 import inspect
 import json
@@ -22,6 +23,9 @@ EXPECTED_STEMS = ("kick", "snare", "toms", "hihat", "ride", "crash")
 DRUMSEP_MODEL_ALIAS = "MDX23C-DrumSep-aufr33-jarredou.ckpt"
 DRUMSEP_MODEL_FILENAME = "aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.ckpt"
 DRUMSEP_MODEL_YAML = "aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.yaml"
+ASEP_0443_DRUMSEP_MODEL_FILENAME = "MDX23C-DrumSep-aufr33-jarredou.ckpt"
+ASEP_0443_DRUMSEP_CONFIG_FILENAME = "config_drumsep_mdx23c.yaml"
+LEGACY_DRUMSEP_MODEL_SHA256 = "d2a4aa53eb584d21eead358a4e66d1882ad182911be018f052b5da73be9096d0"
 REAPER_FILENAMES = {
     "kick": "kick.wav",
     "snare": "snare.wav",
@@ -39,6 +43,25 @@ class DirectDemixValidationError(RuntimeError):
     def __init__(self, reason: str, message: str):
         super().__init__(message)
         self.reason = reason
+
+
+class DrumSepCatalogCacheResolution:
+    def __init__(
+        self,
+        *,
+        model_name: str,
+        action: str,
+        legacy_model_detected: bool,
+        resolved_model_file: Path,
+        resolved_config_file: Path,
+        markers: dict[str, str],
+    ):
+        self.model_name = model_name
+        self.action = action
+        self.legacy_model_detected = legacy_model_detected
+        self.resolved_model_file = resolved_model_file
+        self.resolved_config_file = resolved_config_file
+        self.markers = markers
 
 
 def _probe_gpu_device(device: str) -> tuple[bool, str, dict[str, str]]:
@@ -206,12 +229,104 @@ def _model_download_checks_path(model_dir: Path) -> Path:
     return model_dir / "download_checks.json"
 
 
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _resolve_drumsep_catalog_cache_for_runtime(
+    model_dir: Path,
+    requested_model: str,
+    expected_legacy_sha256: str = LEGACY_DRUMSEP_MODEL_SHA256,
+) -> DrumSepCatalogCacheResolution:
+    model_dir = Path(model_dir)
+    requested_name = Path(str(requested_model or "")).name
+    requested_stem = Path(requested_name).stem
+    legacy_model = model_dir / DRUMSEP_MODEL_FILENAME
+    resolved_model = model_dir / ASEP_0443_DRUMSEP_MODEL_FILENAME
+    resolved_config = model_dir / ASEP_0443_DRUMSEP_CONFIG_FILENAME
+    legacy_detected = legacy_model.exists()
+    requested_is_drumsep = requested_name in {
+        "",
+        DRUMSEP_MODEL_ALIAS,
+        DRUMSEP_MODEL_FILENAME,
+        ASEP_0443_DRUMSEP_MODEL_FILENAME,
+    } or requested_stem in {
+        Path(DRUMSEP_MODEL_ALIAS).stem,
+        Path(DRUMSEP_MODEL_FILENAME).stem,
+        Path(ASEP_0443_DRUMSEP_MODEL_FILENAME).stem,
+    }
+
+    if not requested_is_drumsep:
+        action = "none"
+        model_name = str(requested_model or "")
+        resolved_model = model_dir / Path(model_name).name
+    elif resolved_model.exists() and legacy_detected:
+        action = "mixed_cache_use_new"
+        model_name = ASEP_0443_DRUMSEP_MODEL_FILENAME
+    elif resolved_model.exists():
+        action = "use_existing_new"
+        model_name = ASEP_0443_DRUMSEP_MODEL_FILENAME
+    elif legacy_detected:
+        model_name = ASEP_0443_DRUMSEP_MODEL_FILENAME
+        action = "download_new"
+        checksum_ok = False
+        try:
+            expected = str(expected_legacy_sha256 or "").strip().lower()
+            checksum_ok = not expected or _sha256_file(legacy_model).lower() == expected
+        except Exception:
+            checksum_ok = False
+        if checksum_ok:
+            try:
+                shutil.copy2(legacy_model, resolved_model)
+                action = "copy_alias"
+            except Exception:
+                action = "download_new"
+    else:
+        action = "download_new"
+        model_name = ASEP_0443_DRUMSEP_MODEL_FILENAME if requested_is_drumsep else str(requested_model or "")
+
+    markers = {
+        "dks_catalog_version": "asep_0443" if requested_is_drumsep else "passthrough",
+        "dks_legacy_model_detected": "true" if legacy_detected else "false",
+        "dks_model_migration_action": action,
+        "dks_resolved_model_file": str(resolved_model),
+        "dks_resolved_config_file": str(resolved_config),
+    }
+    return DrumSepCatalogCacheResolution(
+        model_name=model_name,
+        action=action,
+        legacy_model_detected=legacy_detected,
+        resolved_model_file=resolved_model,
+        resolved_config_file=resolved_config,
+        markers=markers,
+    )
+
+
+def _emit_catalog_cache_resolution_markers(resolution: DrumSepCatalogCacheResolution) -> None:
+    for key in (
+        "dks_catalog_version",
+        "dks_legacy_model_detected",
+        "dks_model_migration_action",
+        "dks_resolved_model_file",
+        "dks_resolved_config_file",
+    ):
+        print(f"{key}={resolution.markers.get(key, '')}", file=sys.stderr)
+
+
 def _resolve_model_yaml_path(model_dir: Path, model_name: str) -> tuple[Path | None, str]:
     known_names = {
         str(model_name or "").strip(),
         Path(str(model_name or "")).name,
         Path(str(model_name or "")).stem,
     }
+    if ASEP_0443_DRUMSEP_MODEL_FILENAME in known_names or Path(ASEP_0443_DRUMSEP_MODEL_FILENAME).stem in known_names:
+        asep_0443_yaml = model_dir / ASEP_0443_DRUMSEP_CONFIG_FILENAME
+        if asep_0443_yaml.exists():
+            return asep_0443_yaml, "asep_0443_config"
     if DRUMSEP_MODEL_ALIAS in known_names or DRUMSEP_MODEL_FILENAME in known_names or Path(DRUMSEP_MODEL_ALIAS).stem in known_names:
         canonical_yaml = model_dir / DRUMSEP_MODEL_YAML
         if canonical_yaml.exists():
@@ -540,7 +655,9 @@ def run(args: argparse.Namespace) -> int:
     output_dir = Path(args.output_dir).expanduser().resolve()
     model_dir = Path(args.model_dir).expanduser().resolve()
     result_json = Path(args.result_json).expanduser().resolve()
-    model_name = str(args.model)
+    requested_model_name = str(args.model)
+    model_resolution = _resolve_drumsep_catalog_cache_for_runtime(model_dir, requested_model_name)
+    model_name = model_resolution.model_name
 
     output_dir.mkdir(parents=True, exist_ok=True)
     before = {p.resolve() for p in output_dir.glob("*.wav")}
@@ -582,8 +699,10 @@ def run(args: argparse.Namespace) -> int:
         print(f"timing_utc={time.strftime('%Y-%m-%dT%H:%M:%S', time.gmtime())} drumsep_helper_model_load_start", file=sys.stderr)
         print(f"drumsep_helper_start input={input_path}", file=sys.stderr)
         print(f"drumsep_helper_model_dir={model_dir}", file=sys.stderr)
+        print(f"drumsep_helper_requested_model={requested_model_name}", file=sys.stderr)
         print(f"drumsep_helper_model={model_name}", file=sys.stderr)
         print(f"drumsep_helper_output_dir={output_dir}", file=sys.stderr)
+        _emit_catalog_cache_resolution_markers(model_resolution)
         separator_kwargs = {
             "model_file_dir": str(model_dir),
             "output_dir": str(output_dir),
@@ -619,6 +738,7 @@ def run(args: argparse.Namespace) -> int:
                 "drumsep_model_load_failed",
                 "stage2_model_load",
                 f"{type(exc).__name__}: {exc}",
+                **model_resolution.markers,
                 traceback=traceback.format_exc(),
             ),
         )
@@ -683,6 +803,7 @@ def run(args: argparse.Namespace) -> int:
                 gpu_low_vram=gpu_probe.get("low_vram", ""),
                 gpu_total_memory_gib=gpu_probe.get("total_memory_gib", ""),
                 gpu_device_name=gpu_probe.get("device_name", ""),
+                **model_resolution.markers,
             ),
         )
         return 1
@@ -783,6 +904,7 @@ def run(args: argparse.Namespace) -> int:
             "model_device": _direct_demix_model_device(sep),
             "separator_onnx_provider": list(getattr(sep, "onnx_execution_provider", []) or []),
             "direct_demix_keys": list(DIRECT_DEMIX_KEYS) if args.route in {"mps-direct-demix", "direct-demix"} else [],
+            **model_resolution.markers,
         },
     )
     print("drumsep_helper_ok=true", file=sys.stderr)

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -31,6 +31,15 @@ def _load_audio_separator_process_module():
     return module
 
 
+def _load_drumsep_helper_module():
+    path = Path("scripts/reaper/_internal/stemwerk_drumsep_process.py")
+    spec = importlib.util.spec_from_file_location("stemwerk_drumsep_process_dependency_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
 class _OsProxy:
     def __init__(self, real_os, *, name: str):
         self._real_os = real_os
@@ -2465,6 +2474,93 @@ def test_drumkit_direct_dks_mode_wires_stage2_preflight_markers():
     assert "if not ok:" in script
     assert 'emit_phase("model_setup_start")' in script
     assert '_is_direct_dks_source(getattr(args, "workflow_mode", ""), getattr(args, "workflow_source", ""))' in script
+
+
+def test_drumsep_helper_migrates_legacy_asep0443_catalog_cache_without_deleting_old_files(tmp_path):
+    helper = _load_drumsep_helper_module()
+    legacy_ckpt = tmp_path / helper.DRUMSEP_MODEL_FILENAME
+    legacy_yaml = tmp_path / helper.DRUMSEP_MODEL_YAML
+    legacy_ckpt.write_bytes(b"legacy-model")
+    legacy_yaml.write_text("audio: {}\nmodel: {}\ntraining: {}\n", encoding="utf-8")
+
+    result = helper._resolve_drumsep_catalog_cache_for_runtime(
+        tmp_path,
+        helper.DRUMSEP_MODEL_FILENAME,
+        expected_legacy_sha256="",
+    )
+
+    assert result.model_name == helper.ASEP_0443_DRUMSEP_MODEL_FILENAME
+    assert result.action == "copy_alias"
+    assert result.legacy_model_detected is True
+    assert (tmp_path / helper.ASEP_0443_DRUMSEP_MODEL_FILENAME).read_bytes() == b"legacy-model"
+    assert legacy_ckpt.exists()
+    assert legacy_yaml.exists()
+    assert result.markers["dks_catalog_version"] == "asep_0443"
+    assert result.markers["dks_model_migration_action"] == "copy_alias"
+    assert result.markers["dks_resolved_model_file"].endswith(helper.ASEP_0443_DRUMSEP_MODEL_FILENAME)
+    assert result.markers["dks_resolved_config_file"].endswith(helper.ASEP_0443_DRUMSEP_CONFIG_FILENAME)
+
+
+def test_drumsep_helper_uses_fresh_asep0443_catalog_name_for_empty_cache(tmp_path):
+    helper = _load_drumsep_helper_module()
+
+    result = helper._resolve_drumsep_catalog_cache_for_runtime(
+        tmp_path,
+        helper.DRUMSEP_MODEL_ALIAS,
+        expected_legacy_sha256="",
+    )
+
+    assert result.model_name == helper.ASEP_0443_DRUMSEP_MODEL_FILENAME
+    assert result.action == "download_new"
+    assert result.legacy_model_detected is False
+    assert not (tmp_path / helper.ASEP_0443_DRUMSEP_MODEL_FILENAME).exists()
+    assert result.markers["dks_model_migration_action"] == "download_new"
+    assert result.markers["dks_legacy_model_detected"] == "false"
+
+
+def test_drumsep_helper_does_not_alias_legacy_model_when_checksum_differs(tmp_path):
+    helper = _load_drumsep_helper_module()
+    legacy_ckpt = tmp_path / helper.DRUMSEP_MODEL_FILENAME
+    legacy_ckpt.write_bytes(b"unexpected-model-content")
+
+    result = helper._resolve_drumsep_catalog_cache_for_runtime(
+        tmp_path,
+        helper.DRUMSEP_MODEL_FILENAME,
+        expected_legacy_sha256="definitely-not-this-model",
+    )
+
+    assert result.model_name == helper.ASEP_0443_DRUMSEP_MODEL_FILENAME
+    assert result.action == "download_new"
+    assert result.legacy_model_detected is True
+    assert not (tmp_path / helper.ASEP_0443_DRUMSEP_MODEL_FILENAME).exists()
+    assert legacy_ckpt.read_bytes() == b"unexpected-model-content"
+    assert result.markers["dks_model_migration_action"] == "download_new"
+
+
+def test_drumsep_helper_prefers_existing_asep0443_model_in_mixed_cache(tmp_path):
+    helper = _load_drumsep_helper_module()
+    legacy_ckpt = tmp_path / helper.DRUMSEP_MODEL_FILENAME
+    new_ckpt = tmp_path / helper.ASEP_0443_DRUMSEP_MODEL_FILENAME
+    legacy_ckpt.write_bytes(b"legacy-model")
+    new_ckpt.write_bytes(b"new-model")
+    (tmp_path / helper.DRUMSEP_MODEL_YAML).write_text("audio: {}\nmodel: {}\ntraining: {}\n", encoding="utf-8")
+    (tmp_path / helper.ASEP_0443_DRUMSEP_CONFIG_FILENAME).write_text(
+        "audio: {}\nmodel: {}\ntraining: {}\n",
+        encoding="utf-8",
+    )
+
+    result = helper._resolve_drumsep_catalog_cache_for_runtime(
+        tmp_path,
+        helper.DRUMSEP_MODEL_ALIAS,
+        expected_legacy_sha256="",
+    )
+
+    assert result.model_name == helper.ASEP_0443_DRUMSEP_MODEL_FILENAME
+    assert result.action == "mixed_cache_use_new"
+    assert result.legacy_model_detected is True
+    assert legacy_ckpt.read_bytes() == b"legacy-model"
+    assert new_ckpt.read_bytes() == b"new-model"
+    assert result.markers["dks_model_migration_action"] == "mixed_cache_use_new"
 
 
 def test_drumkit_extract_route_runs_normal_stage1_before_drumsep_stage2():


### PR DESCRIPTION
## Summary

Fixes the DKS/DrumSep catalog/cache migration blocker found during the Linux ROCm unified runtime feasibility gate:

`UNIFIED_RUNTIME_FEASIBILITY_BLOCKED_DKS_CATALOG`

The old STEMwerk DKS cache uses:

- `aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.ckpt`
- `aufr33-jarredou_DrumSep_model_mdx23c_ep_141_sdr_10.8059.yaml`

`audio-separator==0.44.3` supports the catalog entry:

- `MDX23C-DrumSep-aufr33-jarredou.ckpt`
- `config_drumsep_mdx23c.yaml`

The helper now resolves DKS runtime requests to the ASEP 0.44.3 catalog name and handles legacy caches non-destructively.

## Migration Strategy

- Fresh cache: use the ASEP 0.44.3 catalog filename and let audio-separator resolve/download the model/config.
- Old cache only: if the legacy ckpt checksum matches the known compatible model, copy it non-destructively to the ASEP 0.44.3 filename. The old files are kept.
- Mixed cache: prefer the existing ASEP 0.44.3 filename deterministically.
- If the legacy checksum is unknown/different: do not alias it; fall through to the new catalog/download path.
- No old cache files are deleted, renamed, or cleaned up.

New markers:

- `dks_catalog_version=asep_0443`
- `dks_legacy_model_detected=true|false`
- `dks_model_migration_action=none|copy_alias|download_new|use_existing_new|mixed_cache_use_new`
- `dks_resolved_model_file=...`
- `dks_resolved_config_file=...`

## Smoke Evidence

Smoke root:

`/home/flark/stemwerk-rnd/dks-asep0443-catalog-migration-20260715-011535`

Unified ASEP 0.44.3 env:

- `python -m pip check`: PASS

Old-cache only:

- input modeldir contained only the legacy ckpt/yaml
- exit code: `0`
- elapsed: `22s`
- migration marker: `dks_model_migration_action=copy_alias`
- outputs: `kick.wav`, `snare.wav`, `toms.wav`, `hi-hat.wav`, `ride.wav`, `crash.wav`
- `audio_separator_version=0.44.3`, `backend_runtime=rocm`, `model_device=cuda:0`

Fresh-cache:

- input modeldir empty
- exit code: `0`
- elapsed: `64s`
- migration marker: `dks_model_migration_action=download_new`
- modeldir after: `MDX23C-DrumSep-aufr33-jarredou.ckpt`, `config_drumsep_mdx23c.yaml`, `download_checks.json`
- outputs: `kick.wav`, `snare.wav`, `toms.wav`, `hi-hat.wav`, `ride.wav`, `crash.wav`

Mixed-cache:

- input modeldir contained old + new names
- exit code: `0`
- elapsed: `20s`
- migration marker: `dks_model_migration_action=mixed_cache_use_new`
- outputs: `kick.wav`, `snare.wav`, `toms.wav`, `hi-hat.wav`, `ride.wav`, `crash.wav`

## Validation

- `python -m pytest -q tests/test_device_normalization.py`: PASS, 21 passed
- `python -m pytest -q tests/test_model_registry_schema.py`: PASS, 12 passed
- `python -m pytest -q tests/test_macos_mps_fallback.py`: PASS, 12 passed, 1 warning
- `python -m pytest -q tests/test_dependency_constraints.py -k "dks or drumsep or model or catalog or linux or audio_separator"`: PASS, 146 passed, 1 skipped
- Local CI Fast curated checks: PASS, 93 passed, 1 warning
- `python tools/version_sync.py --check`: PASS
- `python tools/release_gate.py --check`: PASS
- `git diff --check`: PASS

## Scope Boundaries

- No runtime unification yet.
- DKS runtime remains separate in production until a later PR.
- No deletion of old cache files.
- No `.venv-drumsep-rocm` deletion or cleanup.
- No Lua/runtime-selection simplification.
- No installer builds.
- No tags or releases.
- No production runtime mutation.
- `artifacts/` left untouched.
