### PR TITLE
linux: prefer unified ROCm runtime for DKS when capable

### DIFF
--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -2004,6 +2004,63 @@ def _macos_ready_drumsep_main_runtime_candidates(runtime_base: Optional[Path] = 
     return []
 
 
+def _version_at_least(raw_version: Any, minimum: Tuple[int, int, int]) -> bool:
+    text = str(raw_version or "").strip()
+    match = re.match(r"^(\d+)(?:\.(\d+))?(?:\.(\d+))?", text)
+    if not match:
+        return False
+    parts = tuple(int(item or "0") for item in match.groups())
+    return parts >= minimum
+
+
+def _linux_rocm_dks_main_runtime_candidates(runtime_base: Optional[Path] = None) -> Tuple[List[Path], str]:
+    if not sys.platform.startswith("linux"):
+        return [], "platform_not_linux"
+    ready = _ready_to_go_state(runtime_base)
+    ready_status = str(ready.get("READY_TO_GO_STATUS") or "").strip().lower()
+    main_status = str(ready.get("MAIN_RUNTIME_STATUS") or "").strip().lower()
+    model_status = str(ready.get("DRUMSEP_READY_MODEL_STATUS") or "").strip().lower()
+    if ready_status != "ok":
+        return [], f"ready_to_go_status_{ready_status or 'missing'}"
+    if main_status != "ok":
+        return [], f"main_runtime_status_{main_status or 'missing'}"
+    if model_status != "ok":
+        return [], f"dks_model_status_{model_status or 'missing'}"
+    return [_main_runtime_python_path(runtime_base)], "ready_state_ok"
+
+
+def _dks_unified_runtime_capability_detail(payload: Dict[str, Any]) -> str:
+    versions = payload.get("versions") if isinstance(payload.get("versions"), dict) else {}
+    audio_separator_version = str(versions.get("audio-separator") or "").strip()
+    numpy_version = str(versions.get("numpy") or "").strip()
+    if not _version_at_least(audio_separator_version, (0, 44, 3)):
+        return f"audio_separator_lt_0_44_3:{audio_separator_version or 'missing'}"
+    if not _version_at_least(numpy_version, (2, 0, 0)):
+        return f"numpy_lt_2:{numpy_version or 'missing'}"
+    if not str(payload.get("torch_hip") or "").strip():
+        return "rocm_no_hip"
+    if not bool(payload.get("torch_cuda_available")):
+        return "rocm_cuda_unavailable"
+    device_names = payload.get("device_names") or []
+    if not isinstance(device_names, list) or not any(str(item).strip() for item in device_names):
+        return "rocm_no_device_names"
+    return "ok"
+
+
+def _emit_dks_runtime_selection_markers(
+    selection: str,
+    python_path: Optional[Path],
+    reason: str,
+    unified_candidate: bool,
+    legacy_fallback_available: bool,
+) -> None:
+    print(f"dks_runtime_selection={selection}", file=sys.stderr)
+    print(f"dks_runtime_python={python_path or ''}", file=sys.stderr)
+    print(f"dks_runtime_reason={reason}", file=sys.stderr)
+    print(f"dks_unified_candidate={'true' if unified_candidate else 'false'}", file=sys.stderr)
+    print(f"dks_legacy_fallback_available={'true' if legacy_fallback_available else 'false'}", file=sys.stderr)
+
+
 def _drumsep_state_python_candidates(state: Dict[str, str], fallback: Path) -> List[Path]:
     candidates: List[Path] = []
     seen: Set[str] = set()
@@ -2560,6 +2617,101 @@ def _select_drumsep_runtime(
             "selection_policy": "bench_helper_cuda_failed",
         }
         reason = "missing" if cuda_detail == "missing" else "broken"
+        return None, reason, info
+
+    linux_rocm_selection = sys.platform.startswith("linux") and (
+        explicit_rocm or normalized_request in {"auto", "gpu"}
+    )
+    unified_candidates, unified_state_detail = _linux_rocm_dks_main_runtime_candidates(runtime_base)
+    legacy_rocm_candidate_exists = any(candidate.exists() for candidate in rocm_candidates)
+    if linux_rocm_selection and (explicit_rocm or unified_candidates):
+        selection_policy = "explicit_rocm" if explicit_rocm else ("gpu_prefer_rocm" if normalized_request == "gpu" else "auto_prefer_rocm")
+        print(f"drumsep_runtime_selection_policy={selection_policy}", file=sys.stderr)
+        main_detail = unified_state_detail
+        main_attempts: List[Dict[str, Any]] = []
+        if unified_candidates:
+            print(f"timing_utc={_ts()} dks_runtime_probe_main_unified_start", file=sys.stderr)
+            selected_main_python, main_detail, main_payload, main_attempts = _probe_drumsep_runtime_candidates(
+                unified_candidates,
+                require_gpu=True,
+            )
+            print(f"timing_utc={_ts()} dks_runtime_probe_main_unified_end detail={main_detail}", file=sys.stderr)
+            if selected_main_python is not None:
+                capability_detail = _dks_unified_runtime_capability_detail(main_payload)
+                if capability_detail == "ok":
+                    info = dict(main_payload or {})
+                    info["kind"] = "rocm"
+                    info["detail"] = "main_unified"
+                    info["fallback_reason"] = ""
+                    info["selection_policy"] = selection_policy
+                    info["dks_runtime_selection"] = "main_unified"
+                    info["dks_runtime_reason"] = "main_unified_capable"
+                    info["dks_unified_candidate"] = True
+                    info["dks_legacy_fallback_available"] = legacy_rocm_candidate_exists
+                    info["main_unified_python_attempts"] = main_attempts
+                    _emit_dks_runtime_selection_markers(
+                        "main_unified",
+                        selected_main_python,
+                        "main_unified_capable",
+                        True,
+                        legacy_rocm_candidate_exists,
+                    )
+                    return selected_main_python, "rocm", info
+                main_detail = capability_detail
+
+        print(f"timing_utc={_ts()} drumsep_runtime_probe_rocm_start", file=sys.stderr)
+        selected_rocm_python, rocm_detail, rocm_payload, rocm_attempts = _probe_drumsep_runtime_candidates(rocm_candidates, require_gpu=True)
+        print(f"timing_utc={_ts()} drumsep_runtime_probe_rocm_end detail={rocm_detail}", file=sys.stderr)
+        if selected_rocm_python is None and rocm_detail in {"rocm_cuda_unavailable", "rocm_no_device_names"}:
+            time.sleep(1.0)
+            print(f"timing_utc={_ts()} drumsep_runtime_probe_rocm_retry_start", file=sys.stderr)
+            selected_rocm_python, rocm_detail, rocm_payload, rocm_attempts = _probe_drumsep_runtime_candidates(rocm_candidates, require_gpu=True)
+            print(f"timing_utc={_ts()} drumsep_runtime_probe_rocm_retry_end detail={rocm_detail}", file=sys.stderr)
+        if selected_rocm_python is not None:
+            selection = "fallback_legacy" if unified_candidates else "legacy_drumsep_rocm"
+            reason = f"main_unified_skipped:{main_detail}" if unified_candidates else "legacy_rocm_capable"
+            info = dict(rocm_payload or {})
+            info["kind"] = "rocm"
+            info["detail"] = rocm_detail
+            info["fallback_reason"] = reason if unified_candidates else ""
+            info["selection_policy"] = selection_policy
+            info["dks_runtime_selection"] = selection
+            info["dks_runtime_reason"] = reason
+            info["dks_unified_candidate"] = bool(unified_candidates)
+            info["dks_legacy_fallback_available"] = True
+            info["main_unified_python_attempts"] = main_attempts
+            info["rocm_python_attempts"] = rocm_attempts
+            _emit_dks_runtime_selection_markers(
+                selection,
+                selected_rocm_python,
+                reason,
+                bool(unified_candidates),
+                True,
+            )
+            return selected_rocm_python, "rocm", info
+
+        info = {
+            "rocm_detail": rocm_detail,
+            "main_unified_detail": main_detail,
+            "rocm_python": str(rocm_python),
+            "main_unified_python": str(unified_candidates[0]) if unified_candidates else str(_main_runtime_python_path(runtime_base)),
+            "main_unified_python_attempts": main_attempts,
+            "rocm_python_attempts": rocm_attempts,
+            "selection_policy": selection_policy,
+            "normalized_request": normalized_request,
+            "dks_runtime_selection": "unavailable",
+            "dks_runtime_reason": f"main_unified:{main_detail};legacy_rocm:{rocm_detail}",
+            "dks_unified_candidate": bool(unified_candidates),
+            "dks_legacy_fallback_available": False,
+        }
+        _emit_dks_runtime_selection_markers(
+            "unavailable",
+            None,
+            info["dks_runtime_reason"],
+            bool(unified_candidates),
+            False,
+        )
+        reason = "missing" if main_detail.startswith("ready_to_go_status_") and rocm_detail == "missing" else "broken"
         return None, reason, info
 
     selection_policy = "gpu_prefer_rocm" if normalized_request == "gpu" else "auto_prefer_rocm"

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -6760,6 +6760,128 @@ def test_drumsep_runtime_selector_reads_state_python_candidates_before_dedicated
     assert "selected_rocm_python, rocm_detail, rocm_payload, rocm_attempts = _probe_drumsep_runtime_candidates(rocm_candidates, require_gpu=True)" in script
 
 
+def _write_linux_ready_state(runtime_base, *, ready="ok", main="ok", model="ok"):
+    state_dir = runtime_base / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "ready_to_go.env").write_text(
+        "\n".join(
+            [
+                f"READY_TO_GO_STATUS={ready}",
+                f"MAIN_RUNTIME_STATUS={main}",
+                f"DRUMSEP_READY_MODEL_STATUS={model}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _touch_executable(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\n", encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _rocm_probe_payload(*, audio_separator="0.44.3", numpy="2.4.4"):
+    return {
+        "versions": {
+            "audio-separator": audio_separator,
+            "numpy": numpy,
+            "torch": "2.10.0+rocm7.0",
+        },
+        "torch_hip": "7.0.0",
+        "torch_cuda_available": True,
+        "device_names": ["AMD Radeon RX 9070"],
+    }
+
+
+def test_linux_rocm_dks_selector_prefers_main_unified_runtime_when_capable(monkeypatch, tmp_path, capsys):
+    module = _load_audio_separator_process_module()
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    _write_linux_ready_state(tmp_path)
+    main_python = tmp_path / ".venv" / "bin" / "python"
+    legacy_python = tmp_path / ".venv-drumsep-rocm" / "bin" / "python"
+    _touch_executable(main_python)
+    _touch_executable(legacy_python)
+
+    def fake_probe(candidates, **kwargs):
+        assert kwargs.get("require_gpu") is True
+        first = Path(candidates[0])
+        if first == main_python:
+            return main_python, "ok", _rocm_probe_payload(), [{"python": str(main_python), "ok": True}]
+        return None, "should_not_probe_legacy", {}, []
+
+    monkeypatch.setattr(module, "_probe_drumsep_runtime_candidates", fake_probe)
+
+    selected, kind, info = module._select_drumsep_runtime("rocm", tmp_path)
+
+    captured = capsys.readouterr()
+    assert selected == main_python
+    assert kind == "rocm"
+    assert info["dks_runtime_selection"] == "main_unified"
+    assert "dks_runtime_selection=main_unified" in captured.err
+    assert f"dks_runtime_python={main_python}" in captured.err
+    assert "dks_unified_candidate=true" in captured.err
+    assert "dks_legacy_fallback_available=true" in captured.err
+
+
+def test_linux_rocm_dks_selector_falls_back_to_legacy_when_main_not_capable(monkeypatch, tmp_path, capsys):
+    module = _load_audio_separator_process_module()
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    _write_linux_ready_state(tmp_path)
+    main_python = tmp_path / ".venv" / "bin" / "python"
+    legacy_python = tmp_path / ".venv-drumsep-rocm" / "bin" / "python"
+    _touch_executable(main_python)
+    _touch_executable(legacy_python)
+
+    def fake_probe(candidates, **kwargs):
+        assert kwargs.get("require_gpu") is True
+        first = Path(candidates[0])
+        if first == main_python:
+            return main_python, "ok", _rocm_probe_payload(audio_separator="0.23.0", numpy="1.26.4"), [
+                {"python": str(main_python), "ok": True}
+            ]
+        if first == legacy_python:
+            return legacy_python, "ok", _rocm_probe_payload(), [{"python": str(legacy_python), "ok": True}]
+        return None, "missing", {}, []
+
+    monkeypatch.setattr(module, "_probe_drumsep_runtime_candidates", fake_probe)
+
+    selected, kind, info = module._select_drumsep_runtime("rocm", tmp_path)
+
+    captured = capsys.readouterr()
+    assert selected == legacy_python
+    assert kind == "rocm"
+    assert info["dks_runtime_selection"] == "fallback_legacy"
+    assert info["fallback_reason"].startswith("main_unified_skipped:audio_separator_lt_0_44_3")
+    assert "dks_runtime_selection=fallback_legacy" in captured.err
+    assert f"dks_runtime_python={legacy_python}" in captured.err
+    assert "dks_legacy_fallback_available=true" in captured.err
+
+
+def test_linux_rocm_dks_selector_reports_unavailable_without_cpu_fallback(monkeypatch, tmp_path, capsys):
+    module = _load_audio_separator_process_module()
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    _write_linux_ready_state(tmp_path, ready="missing", main="missing", model="missing")
+    probed = []
+
+    def fake_probe(candidates, **kwargs):
+        probed.extend(str(item) for item in candidates)
+        return None, "missing", {}, [{"python": str(candidates[0]), "ok": False}]
+
+    monkeypatch.setattr(module, "_probe_drumsep_runtime_candidates", fake_probe)
+
+    selected, kind, info = module._select_drumsep_runtime("rocm", tmp_path)
+
+    captured = capsys.readouterr()
+    assert selected is None
+    assert kind == "missing"
+    assert info["dks_runtime_selection"] == "unavailable"
+    assert all(".venv-drumsep/bin/python" not in item for item in probed)
+    assert "dks_runtime_selection=unavailable" in captured.err
+    assert "dks_legacy_fallback_available=false" in captured.err
+
+
 def test_cached_capability_devices_ignore_stale_raw_gpu_blocks_when_runtime_is_cpu_only():
     script = Path("scripts/reaper/_internal/STEMwerk_Devices.lua").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

Prefer the unified Linux ROCm main runtime for Direct Drum Kit Split when it is DKS-capable.

This builds on:

- #78: Linux main runtime moved to ASEP 0.44.3 + NumPy 2 stack.
- #79: DKS ASEP 0.44.3 catalog/cache migration fixed old-cache, fresh-cache, and mixed-cache handling.

## Behavior

On Linux ROCm DKS routes, the parent runtime selector now:

- probes main `.venv` first when `ready_to_go.env` says the main runtime and DKS model readiness are OK;
- accepts main `.venv` only when it has `audio-separator >= 0.44.3`, `NumPy >= 2`, Torch ROCm HIP, CUDA availability, and ROCm device names;
- keeps `.venv-drumsep-rocm` as the fallback when main `.venv` is not DKS-capable;
- reports unavailable for explicit ROCm when neither main unified nor legacy ROCm runtime is usable, instead of silently selecting CPU.

New markers:

- `dks_runtime_selection=main_unified|fallback_legacy|legacy_drumsep_rocm|unavailable`
- `dks_runtime_python=<path>`
- `dks_runtime_reason=<reason>`
- `dks_unified_candidate=true|false`
- `dks_legacy_fallback_available=true|false`

## Scope Boundaries

- Selection-only change.
- `.venv-drumsep-rocm` remains fallback.
- No cleanup or deletion.
- No Lua UI redesign.
- No Windows/macOS behavior changes intended.
- No DirectML behavior changes.
- No tags, releases, installer builds, or production runtime cleanup.
- `artifacts/` left untouched.

## Validation

Targeted tests:

- `python -m pytest -q tests/test_device_normalization.py`: PASS, 21 passed
- `python -m pytest -q tests/test_model_registry_schema.py`: PASS, 12 passed
- `python -m pytest -q tests/test_macos_mps_fallback.py`: PASS, 12 passed, 1 warning
- `python -m pytest -q tests/test_dependency_constraints.py -k "dks or drumsep or runtime or rocm or linux"`: PASS, 191 passed, 1 skipped
- `python tools/release_gate.py --check`: PASS
- `git diff --check`: PASS

Local CI Fast curated command:

- `python tools/version_sync.py --check`: PASS (`tools/STEMwerk_Setup_Guide_Linux_macOS.md: no version marker found` existing note)
- `python tools/release_gate.py --check`: PASS
- `python scripts/reaper/audio_separator_process.py --list-models`: PASS
- `python scripts/reaper/audio_separator_process.py --help`: PASS
- `python tests/i18n/test_languages.py`: PASS
- curated pytest coverage from `.github/workflows/ci-full.yml`: PASS, 93 passed, 1 warning

## Throwaway Smoke

Smoke root:

`/home/flark/stemwerk-rnd/linux-rocm-unified-runtime-selection-20260715-003542`

Scenario 1, parent-route DKS with unified main runtime:

- command used throwaway `XDG_DATA_HOME` under the smoke root and ran parent `audio_separator_process.py` from the ASEP 0.44.3 / NumPy 2 ROCm env.
- exit code: `0`
- elapsed: `43s`
- marker: `dks_runtime_selection=main_unified`
- helper python: `/home/flark/stemwerk-rnd/linux-rocm-unified-runtime-selection-20260715-003542/xdg/STEMwerk/.venv/bin/python`
- helper device/backend: `rocm`
- `audio_separator_version=0.44.3`
- output stems: `kick.wav`, `snare.wav`, `toms.wav`, `hi-hat.wav`, `ride.wav`, `crash.wav`
- DKS catalog/cache marker: `dks_model_migration_action=mixed_cache_use_new`

Scenario 2, fallback legacy selector smoke:

- simulated main `.venv` not DKS-capable with `audio-separator 0.23.0` / `NumPy 1.26.4` in throwaway state.
- marker: `dks_runtime_selection=fallback_legacy`
- reason: `main_unified_skipped:audio_separator_lt_0_44_3:0.23.0`
- selected legacy ROCm python under throwaway runtime root.

Scenario 3, unavailable selector smoke:

- simulated missing main and missing legacy in throwaway state.
- marker: `dks_runtime_selection=unavailable`
- selected: `None`
- kind: `missing`
- no CPU runtime selected.


## Additional Fallback Parent-Route Smoke

Smoke root:

`/home/flark/stemwerk-rnd/linux-rocm-unified-runtime-selection-fallback-parent-20260715-004350`

Scenario 2b, parent-route DKS with main not DKS-capable and legacy ROCm fallback available:

- throwaway `XDG_DATA_HOME` and throwaway modeldir under the smoke root.
- main `.venv` candidate was intentionally not DKS-capable: `audio-separator 0.23.0`, `NumPy 1.26.4`.
- legacy `.venv-drumsep-rocm` fallback was available through the throwaway runtime root.
- first attempt proved selector fallback but failed because the throwaway runtime env lacked `ffmpeg`; retry added a throwaway `ffmpeg` symlink under the smoke root only.
- retry exit code: `0`
- elapsed: `27s`
- marker: `dks_runtime_selection=fallback_legacy`
- reason: `main_unified_skipped:audio_separator_lt_0_44_3:0.23.0`
- helper python: `/home/flark/stemwerk-rnd/linux-rocm-unified-runtime-selection-fallback-parent-20260715-004350/xdg/STEMwerk/.venv-drumsep-rocm/bin/python`
- helper device/backend: `rocm`
- output stems: `kick.wav`, `snare.wav`, `toms.wav`, `hi-hat.wav`, `ride.wav`, `crash.wav`
- DKS catalog/cache marker: `dks_model_migration_action=mixed_cache_use_new`
- no production modeldir was used directly.

Unavailable selector gate rerun:

- main not ready and legacy ROCm missing in throwaway state.
- marker: `dks_runtime_selection=unavailable`
- selected: `None`
- kind: `missing`
- no CPU fallback selected.
