### PR TITLE
linux: include Cython for diffq wheelhouse completeness

### DIFF
--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -5288,6 +5288,27 @@ def test_linux_wheelhouse_builder_separates_bootstrap_downloads_from_pytorch_ind
     assert '"linux_x86_64"' in script
 
 
+def test_linux_wheelhouse_includes_cython_for_preloaded_diffq_dependency():
+    script = Path("tools/build_linux_wheelhouse.py").read_text()
+    diffq_wheel = Path(
+        "installer/linux/payload/wheels/linux-x86_64-cp312/"
+        "diffq-0.2.4-cp312-cp312-linux_x86_64.whl"
+    )
+
+    with zipfile.ZipFile(diffq_wheel) as archive:
+        metadata_name = next(name for name in archive.namelist() if name.endswith(".dist-info/METADATA"))
+        diffq_metadata = archive.read(metadata_name).decode("utf-8", errors="replace")
+
+    bootstrap_block = script.split("BOOTSTRAP_REQUIREMENTS = (", 1)[1].split(")", 1)[0]
+    assert "Requires-Dist: Cython" in diffq_metadata
+    assert '"Cython"' in bootstrap_block
+    assert "diffq offline dependency completeness" in bootstrap_block
+    assert script.count('"audio-separator==0.44.3"') >= 2
+    assert '"audio-separator[gpu]==0.44.3"' in script
+    assert script.count('"numpy==2.4.4"') >= 3
+    assert '"audio-separator==0.34.1"' in script
+
+
 def test_linux_main_wheelhouse_pins_numpy2_compatible_runtime_stack():
     script = Path("tools/build_linux_wheelhouse.py").read_text()
 

--- a/tools/build_linux_wheelhouse.py
+++ b/tools/build_linux_wheelhouse.py
@@ -20,6 +20,7 @@ BOOTSTRAP_REQUIREMENTS = (
     "pip",
     "setuptools",
     "wheel",
+    "Cython",  # diffq offline dependency completeness for preloaded wheels
 )
 
 TORCH_REQUIREMENTS = (


### PR DESCRIPTION
## Problem

The vendored Linux `diffq 0.2.4` CPython 3.12 wheel declares `Requires-Dist: Cython`. Linux payload builds preload that wheel through `--extra-wheel-dir`, and the wheelhouse resolver skips dependency traversal for preloaded distributions. As a result, Cython could be absent from an otherwise complete offline wheelhouse.

## Solution

- include unpinned `Cython` in the shared Linux wheelhouse bootstrap requirements, consistent with the existing build-tool policy and Windows wheelhouse input
- add a static regression test that reads the vendored diffq metadata, requires Cython in the Linux bootstrap set, and guards the existing ASEP, NumPy, and legacy DrumSep pins

This affects Linux CPU, CUDA, and ROCm wheelhouse completeness. It does not change runtime selection or bootstrap behavior.

## Validation

- `python -m pytest -q tests/test_dependency_constraints.py -k "linux or wheelhouse or diffq or cython or audio_separator"`: `85 passed, 1 skipped, 272 deselected`
- `python tools/release_gate.py --check`: PASS
- `git diff --check`: PASS
- `python tools/build_linux_wheelhouse.py --help`: PASS; the builder has no dry-run/list mode

No full wheelhouse build was run. A later merge gate can run these download-producing commands with a throwaway output root and the vendored diffq wheel directory:

```bash
python tools/build_linux_wheelhouse.py --runtime main --backend cpu --output-dir /tmp/stemwerk-wheelhouse-main-cpu --extra-wheel-dir installer/linux/payload/wheels/linux-x86_64-cp312
python tools/build_linux_wheelhouse.py --runtime main --backend cuda --output-dir /tmp/stemwerk-wheelhouse-main-cuda --extra-wheel-dir installer/linux/payload/wheels/linux-x86_64-cp312
python tools/build_linux_wheelhouse.py --runtime main --backend rocm --output-dir /tmp/stemwerk-wheelhouse-main-rocm --extra-wheel-dir installer/linux/payload/wheels/linux-x86_64-cp312
```

## Scope

- no runtime behavior change
- no Torch, NumPy, audio-separator, onnxruntime, or legacy DrumSep pin changes
- no production runtime mutation or cleanup
- no tags, releases, installer builds, or full wheelhouse builds
- existing `artifacts/` left untouched
