### PR TITLE
fix(macos): update main runtime to audio-separator 0.44.3

### DIFF
--- a/.github/workflows/apple-silicon-mps-rd.yml
+++ b/.github/workflows/apple-silicon-mps-rd.yml
@@ -66,20 +66,21 @@ jobs:
           . .venv/bin/activate
           python -m pip install --upgrade pip
           pip install -c scripts/reaper/constraints/macos.txt \
-            "numpy==1.26.4" \
+            "numpy==2.4.4" \
             "torch==2.5.1" \
             "torchvision==0.20.1" \
             "torchaudio==2.5.1"
-          pip install "llvmlite==0.42.0" "numba==0.59.1"
+          pip install "llvmlite==0.48.0" "numba==0.66.0"
           pip install "soundfile>=0.12.1"
           pip install ./scripts/reaper/vendor/stemwerk-core
-          pip install -c scripts/reaper/constraints/macos.txt "audio-separator==0.23.0"
+          pip install -c scripts/reaper/constraints/macos.txt "audio-separator==0.44.3"
           pip install --force-reinstall --no-deps \
-            "numpy==1.26.4" \
+            "numpy==2.4.4" \
             "torch==2.5.1" \
             "torchvision==0.20.1" \
             "torchaudio==2.5.1"
           pip install onnxruntime-silicon || pip install onnxruntime
+          pip check
 
       - name: Show torch MPS diagnostics
         run: |

--- a/.github/workflows/macos-apple-silicon-backend-sanity.yml
+++ b/.github/workflows/macos-apple-silicon-backend-sanity.yml
@@ -51,24 +51,20 @@ jobs:
           . .venv/bin/activate
           python -m pip install --upgrade pip
           pip install -c scripts/reaper/constraints/macos.txt \
-            "numpy==1.26.4" \
+            "numpy==2.4.4" \
             "torch==2.5.1" \
             "torchvision==0.20.1" \
             "torchaudio==2.5.1"
-          pip install "llvmlite==0.42.0" "numba==0.59.1"
+          pip install "llvmlite==0.48.0" "numba==0.66.0"
           pip install ./scripts/reaper/vendor/stemwerk-core
-          pip install -c scripts/reaper/constraints/macos.txt "audio-separator==0.23.0"
+          pip install -c scripts/reaper/constraints/macos.txt "audio-separator==0.44.3"
           pip install --force-reinstall --no-deps \
-            "numpy==1.26.4" \
+            "numpy==2.4.4" \
             "torch==2.5.1" \
             "torchvision==0.20.1" \
             "torchaudio==2.5.1"
           pip install onnxruntime-silicon || pip install onnxruntime
-
-      - name: Run samplerate arm64 repair guard (bootstrap parity)
-        run: |
-          . .venv/bin/activate
-          python scripts/reaper/_internal/stemwerk_samplerate_guard.py --python "$(pwd)/.venv/bin/python"
+          pip check
 
       - name: Run Apple Silicon dependency and backend assertions
         run: |
@@ -84,12 +80,9 @@ jobs:
           import numba
           import onnxruntime
           import stemwerk_core
-          import samplerate
           import torch
           import torchvision
           import torchaudio
-          from pathlib import Path
-          import subprocess
 
           def core(ver):
               return str(ver).split("+", 1)[0]
@@ -116,37 +109,17 @@ jobs:
               "audio_separator_import": audio_separator.__name__,
               "stemwerk_core_import": stemwerk_core.__name__,
           }
-          samplerate_root = Path(samplerate.__file__).resolve().parent
-          dylib_candidates = sorted({str(p.resolve()) for p in samplerate_root.rglob("*.dylib")})
-          payload["samplerate_version"] = getattr(samplerate, "__version__", "unknown")
-          payload["samplerate_module"] = str(Path(samplerate.__file__).resolve())
-          payload["samplerate_dylib_candidates"] = dylib_candidates
-          dylib_files = {}
-          x86_only = []
-          arm_or_universal = []
-          for candidate in dylib_candidates:
-              file_output = subprocess.check_output(["file", candidate], text=True).strip()
-              dylib_files[candidate] = file_output
-              lower = file_output.lower()
-              if "x86_64" in lower and "arm64" not in lower and "universal" not in lower:
-                  x86_only.append(candidate)
-              if "arm64" in lower or "universal" in lower:
-                  arm_or_universal.append(candidate)
-          payload["samplerate_dylib_file_outputs"] = dylib_files
-          payload["samplerate_dylib_x86_only"] = x86_only
-          payload["samplerate_dylib_arm_or_universal"] = arm_or_universal
+          payload["samplerate_version"] = version("samplerate")
           print("SANITY_DIAGNOSTICS_JSON=" + json.dumps(payload, sort_keys=True))
 
           assert platform.system() == "Darwin", f"Expected Darwin, got {platform.system()!r}"
           assert platform.machine() == "arm64", f"Expected arm64, got {platform.machine()!r}"
-          assert core(payload["numpy_version"]) == "1.26.4", payload["numpy_version"]
+          assert core(payload["numpy_version"]) == "2.4.4", payload["numpy_version"]
           assert core(payload["torch_version"]) == "2.5.1", payload["torch_version"]
           assert core(payload["torchvision_version"]) == "0.20.1", payload["torchvision_version"]
           assert core(payload["torchaudio_version"]) == "2.5.1", payload["torchaudio_version"]
-          assert core(payload["audio_separator_version"]) == "0.23.0", payload["audio_separator_version"]
-          assert len(payload["samplerate_dylib_x86_only"]) == 0, payload["samplerate_dylib_file_outputs"]
-          if payload["samplerate_dylib_candidates"]:
-              assert len(payload["samplerate_dylib_arm_or_universal"]) > 0, payload["samplerate_dylib_file_outputs"]
+          assert core(payload["audio_separator_version"]) == "0.44.3", payload["audio_separator_version"]
+          assert core(payload["samplerate_version"]) == "0.1.0", payload["samplerate_version"]
           assert onnxruntime is not None
           assert torch.backends.mps.is_built() is True, "Expected torch wheel with MPS support built in"
           PY

--- a/.github/workflows/macos-apple-silicon-backend-smoke.yml
+++ b/.github/workflows/macos-apple-silicon-backend-smoke.yml
@@ -64,12 +64,13 @@ jobs:
           python -m venv .venv
           . .venv/bin/activate
           python -m pip install --upgrade pip
-          pip install "numpy<2.0" "soundfile>=0.12.1"
+          pip install -c scripts/reaper/constraints/macos.txt "numpy==2.4.4" "soundfile>=0.12.1"
           pip install "torch==2.5.1" "torchvision==0.20.1" "torchaudio==2.5.1"
           pip install ./scripts/reaper/vendor/stemwerk-core
-          pip install -c scripts/reaper/constraints/macos.txt "audio-separator==0.23.0"
-          pip install --force-reinstall --no-deps "torch==2.5.1" "torchvision==0.20.1" "torchaudio==2.5.1"
+          pip install -c scripts/reaper/constraints/macos.txt "audio-separator==0.44.3"
+          pip install --force-reinstall --no-deps "numpy==2.4.4" "torch==2.5.1" "torchvision==0.20.1" "torchaudio==2.5.1"
           pip install onnxruntime-silicon || pip install onnxruntime
+          pip check
           pip install pytest
 
       - name: Show backend smoke dependency diagnostics

--- a/scripts/reaper/STEMwerk_Bootstrap_macOS.sh
+++ b/scripts/reaper/STEMwerk_Bootstrap_macOS.sh
@@ -7,7 +7,18 @@ BUNDLED_PAYLOAD_DIR="${SCRIPT_DIR}/_bundled/macos/apple-silicon"
 MACOS_ARM_CONSTRAINTS_FILE="${SCRIPT_DIR}/constraints/macos.txt"
 MACOS_INTEL_CONSTRAINTS_FILE="${SCRIPT_DIR}/constraints/macos-intel.txt"
 MACOS_CONSTRAINTS_FILE=""
-PINNED_NUMPY_VERSION="1.26.4"
+PINNED_NUMPY_VERSION=""
+PINNED_NUMPY_VERSION_ARM64="2.4.4"
+PINNED_NUMPY_VERSION_INTEL="1.26.4"
+PINNED_NUMBA_VERSION=""
+PINNED_NUMBA_VERSION_ARM64="0.66.0"
+PINNED_NUMBA_VERSION_INTEL="0.59.1"
+PINNED_LLVM_VERSION=""
+PINNED_LLVM_VERSION_ARM64="0.48.0"
+PINNED_LLVM_VERSION_INTEL="0.42.0"
+PINNED_AUDIO_SEPARATOR_VERSION=""
+PINNED_AUDIO_SEPARATOR_VERSION_ARM64="0.44.3"
+PINNED_AUDIO_SEPARATOR_VERSION_INTEL="0.23.0"
 PINNED_TORCH_VERSION=""
 PINNED_TORCHVISION_VERSION=""
 PINNED_TORCHAUDIO_VERSION=""
@@ -336,12 +347,13 @@ verify_audio_separator_runtime_deps() {
   fi
   _probe="$("${VENV_PY}" - <<'PY' 2>/dev/null || true
 import importlib
+from importlib.metadata import PackageNotFoundError, version
 errors = []
 try:
     import audio_separator  # noqa: F401
 except Exception as exc:
     errors.append("audio_separator:" + str(exc))
-for name in (
+dependencies = [
     "beartype",
     "diffq",
     "einops",
@@ -360,7 +372,13 @@ for name in (
     "six",
     "tqdm",
     "yaml",
-):
+]
+try:
+    if version("audio-separator") == "0.44.3":
+        dependencies.remove("samplerate")
+except PackageNotFoundError:
+    pass
+for name in dependencies:
     try:
         importlib.import_module(name)
     except Exception as exc:
@@ -445,6 +463,11 @@ PY
 repair_samplerate_if_arch_mismatch() {
   _guard_phase="${1:-unspecified}"
   [ "${MAC_ARCH}" = "arm64" ] || return 0
+  if [ "${PINNED_AUDIO_SEPARATOR_VERSION}" = "0.44.3" ]; then
+    log "samplerate_guard_skipped phase=${_guard_phase} reason=asep_0443_requires_samplerate_010"
+    SAMPLERATE_ARCH_MATCH="not_required_for_main_runtime"
+    return 0
+  fi
   [ -n "${VENV_PY}" ] || return 0
   [ -x "${VENV_PY}" ] || return 0
 
@@ -588,7 +611,7 @@ PY
 )"
   case "${_probe}" in
     rebuild\|*)
-      log "Existing venv has incompatible torch ${_probe#rebuild|}; rebuilding .venv for audio-separator 0.23.0 compatibility"
+      log "Existing venv has incompatible torch ${_probe#rebuild|}; rebuilding .venv for audio-separator ${PINNED_AUDIO_SEPARATOR_VERSION} compatibility"
       return 0
       ;;
     ok\|*)
@@ -673,7 +696,7 @@ expected_numpy = "${PINNED_NUMPY_VERSION}"
 expected_torch = "${PINNED_TORCH_VERSION}"
 expected_torchvision = "${PINNED_TORCHVISION_VERSION}"
 expected_torchaudio = "${PINNED_TORCHAUDIO_VERSION}"
-expected_audio_separator = "0.23.0"
+expected_audio_separator = "${PINNED_AUDIO_SEPARATOR_VERSION}"
 expected_profile = "${PINNED_TORCH_STACK_LABEL}"
 mac_arch = "${MAC_ARCH}"
 
@@ -1074,6 +1097,10 @@ log "Downloaded models are kept at: $(model_cache_dir)"
 MAC_ARCH="$(uname -m 2>/dev/null || echo unknown)"
 if [ "${MAC_ARCH}" = "x86_64" ]; then
   MACOS_CONSTRAINTS_FILE="${MACOS_INTEL_CONSTRAINTS_FILE}"
+  PINNED_NUMPY_VERSION="${PINNED_NUMPY_VERSION_INTEL}"
+  PINNED_NUMBA_VERSION="${PINNED_NUMBA_VERSION_INTEL}"
+  PINNED_LLVM_VERSION="${PINNED_LLVM_VERSION_INTEL}"
+  PINNED_AUDIO_SEPARATOR_VERSION="${PINNED_AUDIO_SEPARATOR_VERSION_INTEL}"
   PINNED_TORCH_VERSION="${PINNED_TORCH_VERSION_INTEL}"
   PINNED_TORCHVISION_VERSION="${PINNED_TORCHVISION_VERSION_INTEL}"
   PINNED_TORCHAUDIO_VERSION="${PINNED_TORCHAUDIO_VERSION_INTEL}"
@@ -1081,6 +1108,10 @@ if [ "${MAC_ARCH}" = "x86_64" ]; then
   log "Using macOS Intel constraints: ${MACOS_CONSTRAINTS_FILE}"
 else
   MACOS_CONSTRAINTS_FILE="${MACOS_ARM_CONSTRAINTS_FILE}"
+  PINNED_NUMPY_VERSION="${PINNED_NUMPY_VERSION_ARM64}"
+  PINNED_NUMBA_VERSION="${PINNED_NUMBA_VERSION_ARM64}"
+  PINNED_LLVM_VERSION="${PINNED_LLVM_VERSION_ARM64}"
+  PINNED_AUDIO_SEPARATOR_VERSION="${PINNED_AUDIO_SEPARATOR_VERSION_ARM64}"
   PINNED_TORCH_VERSION="${PINNED_TORCH_VERSION_ARM64}"
   PINNED_TORCHVISION_VERSION="${PINNED_TORCHVISION_VERSION_ARM64}"
   PINNED_TORCHAUDIO_VERSION="${PINNED_TORCHAUDIO_VERSION_ARM64}"
@@ -1121,7 +1152,7 @@ PYTHON=""
 FFMPEG=""
 VENV_PY=""
 # Conservative default on macOS to avoid GPU extras with limited wheel support.
-PACKAGE="audio-separator==0.23.0"
+PACKAGE="audio-separator==${PINNED_AUDIO_SEPARATOR_VERSION}"
 ONNX_PACKAGE="onnxruntime"
 ONNX_FALLBACK_PACKAGE=""
 if [ "$(uname -m)" = "arm64" ]; then
@@ -1326,7 +1357,7 @@ else
     fi
 
     log "Preinstalling numba/llvmlite (macOS wheels)"
-    install_with_optional_bundled_wheels "${VENV_PY}" --only-binary=:all: "llvmlite==0.42.0" "numba==0.59.1" >> "${LOG_FILE}" 2>&1 || \
+    install_with_optional_bundled_wheels "${VENV_PY}" --only-binary=:all: "llvmlite==${PINNED_LLVM_VERSION}" "numba==${PINNED_NUMBA_VERSION}" >> "${LOG_FILE}" 2>&1 || \
       log "WARN: numba/llvmlite wheel install failed; continuing with audio-separator install"
 
     if ! "${VENV_PY}" -m pip show audio-separator >/dev/null 2>&1; then
@@ -1458,6 +1489,10 @@ if [ -n "${VENV_PY}" ] && [ -x "${VENV_PY}" ]; then
   if ! assert_pinned_torch_stack "${VENV_PY}"; then
     FINAL_RUNTIME_VERIFIED="no"
     set_status "deps_failed" "torch_pin_assert_failed"
+  fi
+  if ! "${VENV_PY}" -m pip check >> "${LOG_FILE}" 2>&1; then
+    FINAL_RUNTIME_VERIFIED="no"
+    set_status "deps_failed" "pip_check_failed"
   fi
   if [ "${FINAL_RUNTIME_VERIFIED}" = "yes" ]; then
     case "${STATUS_REASON}" in

--- a/scripts/reaper/constraints/macos.txt
+++ b/scripts/reaper/constraints/macos.txt
@@ -1,4 +1,4 @@
-numpy==1.26.4
+numpy==2.4.4
 torch==2.5.1
 torchvision==0.20.1
 torchaudio==2.5.1

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -330,6 +330,34 @@ def test_macos_bootstrap_pip_check_blocks_ready_false_positive():
     assert script.index(pip_check) < script.index('write_ready_to_go_state "${READY_RUNTIME_KIND}"')
 
 
+def test_apple_silicon_workflows_follow_asep_0443_numpy2_policy():
+    workflow_paths = [
+        Path(".github/workflows/macos-apple-silicon-backend-smoke.yml"),
+        Path(".github/workflows/macos-apple-silicon-backend-sanity.yml"),
+        Path(".github/workflows/apple-silicon-mps-rd.yml"),
+    ]
+
+    for workflow_path in workflow_paths:
+        workflow = workflow_path.read_text()
+        assert 'audio-separator==0.44.3' in workflow, workflow_path
+        assert 'numpy==2.4.4' in workflow, workflow_path
+        assert 'audio-separator==0.23.0' not in workflow, workflow_path
+        assert 'numpy<2.0' not in workflow, workflow_path
+        assert 'numpy==1.26.4' not in workflow, workflow_path
+        assert 'pip check' in workflow, workflow_path
+
+    sanity = workflow_paths[1].read_text()
+    assert 'payload["samplerate_version"] = version("samplerate")' in sanity
+    assert 'core(payload["samplerate_version"]) == "0.1.0"' in sanity
+
+    bootstrap = Path("scripts/reaper/STEMwerk_Bootstrap_macOS.sh").read_text()
+    intel_constraints = Path("scripts/reaper/constraints/macos-intel.txt").read_text().splitlines()
+    assert 'PINNED_AUDIO_SEPARATOR_VERSION_ARM64="0.44.3"' in bootstrap
+    assert 'PINNED_NUMPY_VERSION_ARM64="2.4.4"' in bootstrap
+    assert 'PINNED_AUDIO_SEPARATOR_VERSION_INTEL="0.23.0"' in bootstrap
+    assert "numpy==1.26.4" in intel_constraints
+
+
 def test_macos_bootstrap_assertion_does_not_require_mps_availability_on_intel():
     from pathlib import Path
 
@@ -6716,18 +6744,14 @@ def test_setup_internal_surfaces_samplerate_arch_mismatch_reason_and_capabilitie
     assert "SAMPLERATE_REPAIR_ATTEMPTED" in script
 
 
-def test_macos_apple_silicon_sanity_workflow_asserts_samplerate_dylib_architecture():
+def test_macos_apple_silicon_sanity_workflow_keeps_asep_samplerate_metadata_pin():
     workflow = Path(".github/workflows/macos-apple-silicon-backend-sanity.yml").read_text()
 
-    assert "Run samplerate arm64 repair guard (bootstrap parity)" in workflow
-    assert "python scripts/reaper/_internal/stemwerk_samplerate_guard.py" in workflow
-    assert "import samplerate" in workflow
-    assert 'samplerate_root.rglob("*.dylib")' in workflow
-    assert 'payload["samplerate_dylib_file_outputs"]' in workflow
-    assert 'assert len(payload["samplerate_dylib_x86_only"]) == 0' in workflow
-    assert 'if payload["samplerate_dylib_candidates"]:' in workflow
-    assert 'assert len(payload["samplerate_dylib_arm_or_universal"]) > 0' in workflow
-    assert workflow.index("Run samplerate arm64 repair guard (bootstrap parity)") < workflow.index("Run Apple Silicon dependency and backend assertions")
+    assert "Run samplerate arm64 repair guard (bootstrap parity)" not in workflow
+    assert "python scripts/reaper/_internal/stemwerk_samplerate_guard.py" not in workflow
+    assert "import samplerate" not in workflow
+    assert 'payload["samplerate_version"] = version("samplerate")' in workflow
+    assert 'assert core(payload["samplerate_version"]) == "0.1.0"' in workflow
 
 
 def test_normal_workflow_device_preflight_blocks_silent_cpu_fallback():

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -19,7 +19,7 @@ import pytest
 EXPECTED_TORCH = "2.5.1"
 EXPECTED_TORCHVISION = "0.20.1"
 EXPECTED_TORCHAUDIO = "2.5.1"
-EXPECTED_AUDIO_SEPARATOR = "0.23.0"
+EXPECTED_AUDIO_SEPARATOR = "0.44.3"
 
 
 def _load_audio_separator_process_module():
@@ -236,7 +236,7 @@ def test_macos_arm_constraints_include_matching_torchvision_pin():
     from pathlib import Path
 
     constraints_lines = Path("scripts/reaper/constraints/macos.txt").read_text().splitlines()
-    assert "numpy==1.26.4" in constraints_lines
+    assert "numpy==2.4.4" in constraints_lines
     assert "torch==2.5.1" in constraints_lines
     assert "torchvision==0.20.1" in constraints_lines
     assert "torchaudio==2.5.1" in constraints_lines
@@ -259,7 +259,12 @@ def test_macos_bootstrap_repairs_after_audio_separator_install():
     audio_install_marker = 'install_with_optional_bundled_wheels "${VENV_PY}" -c "${MACOS_CONSTRAINTS_FILE}" "${PACKAGE}"'
     repair_marker = 'set_status "deps_failed" "torch_pin_repair_failed"'
 
-    assert 'PINNED_NUMPY_VERSION="1.26.4"' in script
+    assert 'PINNED_NUMPY_VERSION_ARM64="2.4.4"' in script
+    assert 'PINNED_NUMPY_VERSION_INTEL="1.26.4"' in script
+    assert 'PINNED_AUDIO_SEPARATOR_VERSION_ARM64="0.44.3"' in script
+    assert 'PINNED_AUDIO_SEPARATOR_VERSION_INTEL="0.23.0"' in script
+    assert 'PINNED_NUMBA_VERSION_ARM64="0.66.0"' in script
+    assert 'PINNED_LLVM_VERSION_ARM64="0.48.0"' in script
     assert '"numpy==${PINNED_NUMPY_VERSION}"' in script
     assert 'if core(numpy_ver) != expected_numpy:' in script
     assert 'import numba' in script
@@ -295,6 +300,34 @@ def test_macos_bootstrap_assertion_uses_audio_separator_metadata():
 
     assert 'version("audio-separator")' in script
     assert 'audio_separator.__version__' not in script
+
+
+def test_macos_main_runtime_uses_asep_0443_numpy2_without_samplerate_conflict():
+    script = Path("scripts/reaper/STEMwerk_Bootstrap_macOS.sh").read_text()
+    constraints = Path("scripts/reaper/constraints/macos.txt").read_text().splitlines()
+    payload = Path("tools/build_macos_apple_silicon_payload.py").read_text()
+
+    assert 'PINNED_AUDIO_SEPARATOR_VERSION_ARM64="0.44.3"' in script
+    assert 'PINNED_NUMPY_VERSION_ARM64="2.4.4"' in script
+    assert 'expected_audio_separator = "${PINNED_AUDIO_SEPARATOR_VERSION}"' in script
+    assert 'PACKAGE="audio-separator==${PINNED_AUDIO_SEPARATOR_VERSION}"' in script
+    assert "numpy==2.4.4" in constraints
+    assert "numpy==1.26.4" not in constraints
+    assert '"audio-separator==0.44.3"' in payload
+    assert '"numpy==2.4.4"' in payload
+    assert 'SAMPLERATE_REQUIREMENT = "samplerate==0.1.0"' in payload
+    assert 'SAMPLERATE_REPAIR_REQUIREMENT = "samplerate==0.2.4"' not in payload
+    assert 'if version("audio-separator") == "0.44.3":' in script
+    assert 'dependencies.remove("samplerate")' in script
+
+
+def test_macos_bootstrap_pip_check_blocks_ready_false_positive():
+    script = Path("scripts/reaper/STEMwerk_Bootstrap_macOS.sh").read_text()
+
+    pip_check = 'if ! "${VENV_PY}" -m pip check >> "${LOG_FILE}" 2>&1; then'
+    assert pip_check in script
+    assert 'set_status "deps_failed" "pip_check_failed"' in script
+    assert script.index(pip_check) < script.index('write_ready_to_go_state "${READY_RUNTIME_KIND}"')
 
 
 def test_macos_bootstrap_assertion_does_not_require_mps_availability_on_intel():
@@ -5496,11 +5529,14 @@ def test_macos_payload_builder_uses_native_python312_wheel_downloads():
     assert 'Path("/usr/local/bin/python3.12")' in script
     assert 'if version == (3, 12):' in script
     assert 'raise RuntimeError("Missing native Python 3.12 interpreter for macOS Apple Silicon payload wheel downloads")' in script
-    assert '"audio-separator==0.23.0"' in script
+    assert '"audio-separator==0.44.3"' in script
+    assert '"numpy==2.4.4"' in script
+    assert '"numba==0.66.0"' in script
+    assert '"llvmlite==0.48.0"' in script
     assert '"torch==2.5.1"' in script
     assert '"torchaudio==2.5.1"' in script
     assert '"onnxruntime"' in script
-    assert 'SAMPLERATE_REPAIR_REQUIREMENT = "samplerate==0.2.4"' in script
+    assert 'SAMPLERATE_REQUIREMENT = "samplerate==0.1.0"' in script
     assert '"onnxruntime-silicon"' not in script
     assert '"--only-binary=:all:"' in script
     assert '"--find-links"' in script
@@ -5509,7 +5545,7 @@ def test_macos_payload_builder_uses_native_python312_wheel_downloads():
     assert 'subprocess.run(cmd, check=True, env=command_env())' in script
     assert 'DIFFQ_REQUIREMENT = "diffq==0.2.4"' in script
     assert 'ensure_diffq_wheel(output_dir / "wheels")' in script
-    assert 'ensure_samplerate_repair_wheel(output_dir / "wheels")' in script
+    assert 'ensure_samplerate_wheel(output_dir / "wheels")' in script
 
 
 def test_macos_payload_builder_requires_local_ffmpeg_and_model_sources():
@@ -5527,7 +5563,7 @@ def test_macos_payload_builder_requires_local_ffmpeg_and_model_sources():
     assert 'Incomplete wheelhouse for offline Apple Silicon payload' in script
     assert 'REQUIRED_WHEEL_PREFIXES = (' in script
     assert 'REQUIRED_WHEEL_PATTERNS = (' in script
-    assert '"samplerate-0.2.4-*.whl"' in script
+    assert '"samplerate-0.1.0-*.whl"' in script
     assert '"stemwerk_core-"' in script
     assert '"--no-build-isolation"' in script
     assert 'copy_tree(managed_python_dir, output_dir / "python", "managed Python runtime payload")' in script
@@ -6567,6 +6603,8 @@ def test_macos_bootstrap_detects_and_repairs_samplerate_arch_mismatch_on_arm64()
     guard = Path("scripts/reaper/_internal/stemwerk_samplerate_guard.py").read_text()
 
     assert "repair_samplerate_if_arch_mismatch" in script
+    assert 'if [ "${PINNED_AUDIO_SEPARATOR_VERSION}" = "0.44.3" ]; then' in script
+    assert "asep_0443_requires_samplerate_010" in script
     assert "stemwerk_samplerate_guard.py" in script
     assert '_guard_out="$("${VENV_PY}" "${_guard_script}" --python "${VENV_PY}" 2>&1)"' in script
     assert '_guard_out="$("${VENV_PY}" "${_guard_script}" --python "${VENV_PY}" --find-links "${BUNDLED_WHEELS_DIR}" 2>&1)"' in script

--- a/tools/build_macos_apple_silicon_payload.py
+++ b/tools/build_macos_apple_silicon_payload.py
@@ -37,18 +37,18 @@ BOOTSTRAP_REQUIREMENTS = (
 )
 
 MAIN_REQUIREMENTS = (
-    "numpy==1.26.4",
+    "numpy==2.4.4",
     "torch==2.5.1",
     "torchvision==0.20.1",
     "torchaudio==2.5.1",
-    "audio-separator==0.23.0",
-    "llvmlite==0.42.0",
-    "numba==0.59.1",
+    "audio-separator==0.44.3",
+    "llvmlite==0.48.0",
+    "numba==0.66.0",
     "onnxruntime",
 )
 
 DIFFQ_REQUIREMENT = "diffq==0.2.4"
-SAMPLERATE_REPAIR_REQUIREMENT = "samplerate==0.2.4"
+SAMPLERATE_REQUIREMENT = "samplerate==0.1.0"
 
 REQUIRED_WHEEL_PREFIXES = (
     "pip-",
@@ -68,7 +68,7 @@ REQUIRED_WHEEL_PREFIXES = (
 )
 
 REQUIRED_WHEEL_PATTERNS = (
-    "samplerate-0.2.4-*.whl",
+    "samplerate-0.1.0-*.whl",
 )
 
 
@@ -190,8 +190,8 @@ def ensure_diffq_wheel(wheels_dir: Path) -> None:
     subprocess.run(cmd, check=True, env=command_env())
 
 
-def ensure_samplerate_repair_wheel(wheels_dir: Path) -> None:
-    if any(wheels_dir.glob("samplerate-0.2.4-*.whl")):
+def ensure_samplerate_wheel(wheels_dir: Path) -> None:
+    if any(wheels_dir.glob("samplerate-0.1.0-*.whl")):
         return
     cmd = [
         wheel_builder_python(),
@@ -202,7 +202,7 @@ def ensure_samplerate_repair_wheel(wheels_dir: Path) -> None:
         str(wheels_dir),
         "--only-binary=:all:",
         "--no-deps",
-        SAMPLERATE_REPAIR_REQUIREMENT,
+        SAMPLERATE_REQUIREMENT,
     ]
     subprocess.run(cmd, check=True, env=command_env())
 
@@ -266,7 +266,7 @@ def main() -> int:
     except subprocess.CalledProcessError:
         ensure_diffq_wheel(output_dir / "wheels")
         run_pip_download(BOOTSTRAP_REQUIREMENTS + MAIN_REQUIREMENTS, output_dir / "wheels", constraints_file, python_executable)
-    ensure_samplerate_repair_wheel(output_dir / "wheels")
+    ensure_samplerate_wheel(output_dir / "wheels")
     build_stemwerk_core_wheel(repo_root, output_dir / "wheels", python_executable)
     ensure_wheelhouse_complete(output_dir / "wheels")
     copy_tree(managed_python_dir, output_dir / "python", "managed Python runtime payload")


### PR DESCRIPTION
## Probleem

Current-main macOS Apple Silicon installeerde audio-separator 0.23.0 met NumPy 1.26.4. De samplerate architecture-repair verving de door ASEP vereiste samplerate 0.1.0 door 0.2.4, waardoor `pip check` faalde terwijl de bootstrap toch een groene ready-state kon schrijven.

## Oplossing

- Update Apple Silicon main runtime naar audio-separator 0.44.3.
- Gebruik een NumPy-2-compatible stack:
  - numpy 2.4.4
  - numba 0.66.0
  - llvmlite 0.48.0
- Behoud torch/torchaudio 2.5.1 en torchvision 0.20.1.
- Behoud macOS Intel ASEP 0.23.0/NumPy 1.26.4.
- Behoud Linux en DrumSep/DKS dependency policies.
- Houd `samplerate==0.1.0` voor ASEP 0.44.3.
- Voorkom dat de legacy architecture-repair samplerate vervangt door 0.2.4.
- Laat `pip check` de bootstrap hard laten falen vóór ready-state groen wordt.
- Werk Apple Silicon payload-policy en regressietests bij.

## Evidence

Validation root:

`/tmp/stemwerk-mac-m1-asep0443-fix-validation-20260715-061851`

Throwaway bootstrap:

- Exit: 0
- Tijd: 131 s
- Python: 3.12.13
- audio-separator: 0.44.3
- NumPy: 2.4.4
- SciPy: 1.18.0
- numba: 0.66.0
- llvmlite: 0.48.0
- torch: 2.5.1
- torchaudio: 2.5.1
- torchvision: 0.20.1
- onnxruntime: 1.27.0
- beartype: 0.18.5
- samplerate: 0.1.0
- `pip check`: PASS
- MPS tensorprobe: PASS

Normal-stems smokes:

- htdemucs explicit MPS: PASS, 16 s, 4 outputs
- htdemucs_ft explicit MPS: PASS, 22 s, 4 outputs
- htdemucs_6s explicit MPS: PASS, 10 s, 6 outputs
- htdemucs auto → MPS: PASS, 9 s, 4 outputs

All explicit-MPS runs reported:

- `effective_backend=mps`
- `effective_device=mps`
- no CPU fallback

Ready-state:

- `READY_TO_GO_STATUS=ok`
- `MAIN_RUNTIME_STATUS=ok`
- `NORMAL_STEMS_SUPPORTED=true`
- `DRUMSEP_STATUS=ready`
- `DKS_SUPPORTED=true`

Regression validation:

- Dependency tests: 143 passed, 1 skipped
- Release gate: PASS
- `git diff --check`: PASS

## Viperx diagnostic

Classification: `MAC_VIPERX_CPU_ONLY_ACCEPTABLE`

- Explicit MPS: 131 s including ~625 MiB download, 0 outputs, MPS OOM
- Explicit CPU: 70 s, 2 outputs, PASS
- One-shot MPS fallback env: 68 s, 0 outputs, MPS OOM

CPU produced:

- `vocals.wav`
- `other.wav`

Notes:

- Explicit MPS reached roughly 9.0 GiB peak footprint on this 8-GB M1.
- Swap increased from roughly 854 MiB to 3.87 GiB.
- `PYTORCH_ENABLE_MPS_FALLBACK` was used only for one diagnostic subprocess and is not set as product default.

## Scope

- Apple Silicon main runtime only.
- macOS Intel dependency policy unchanged.
- Linux dependency policy unchanged.
- DrumSep/DKS pins unchanged.
- No production-runtime mutation.
- No tags, releases or installer-builds.
- Existing `fix/mac-intel-dks-unsupported-ui` WIP left untouched.
