### PR TITLE
fix(macos): exclude AppleDouble sidecars from package staging

### DIFF
--- a/installer/macos/build_pkg.sh
+++ b/installer/macos/build_pkg.sh
@@ -67,12 +67,45 @@ esac
 STAGE="$ROOT_DIR/installer/macos/build/$VARIANT/root"
 PAYLOAD_DEST="$STAGE/Users/Shared/STEMwerk-reaper/_bundled/macos/apple-silicon"
 OUTPUT_PKG="$OUT_DIR/STEMwerk-$VERSION$OUTPUT_SUFFIX.pkg"
+PACKAGE_REPACK_DIR=""
+
+cleanup() {
+  if [[ -n "$PACKAGE_REPACK_DIR" && -d "$PACKAGE_REPACK_DIR" ]]; then
+    rm -rf "$PACKAGE_REPACK_DIR"
+  fi
+}
+trap cleanup EXIT
+
+remove_appledouble_sidecars() {
+  find "$1" -name '._*' -delete
+}
+
+repack_pkg_without_appledouble() {
+  PACKAGE_REPACK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/stemwerk-macos-pkg-repack.XXXXXX")"
+  (
+    cd "$PACKAGE_REPACK_DIR"
+    xar -xf "$OUTPUT_PKG"
+  )
+
+  mkbom "$STAGE" "$PACKAGE_REPACK_DIR/Bom"
+  (
+    cd "$STAGE"
+    find . -print | cpio -o --format odc --owner 0:80 2>/dev/null | gzip -c > "$PACKAGE_REPACK_DIR/Payload"
+  )
+
+  rm -f "$OUTPUT_PKG"
+  (
+    cd "$PACKAGE_REPACK_DIR"
+    xar --compression none -cf "$OUTPUT_PKG" Bom Payload Scripts PackageInfo
+  )
+}
 
 rm -rf "$STAGE"
 mkdir -p "$OUT_DIR" "$STAGE/Users/Shared/STEMwerk-reaper"
 
 # Copy only what we need
 rsync -a --delete \
+  --exclude='._*' \
   --exclude='*.bak' \
   --exclude='*.bak2' \
   --exclude='sync_to_reaper.sh' \
@@ -97,7 +130,7 @@ case "$VARIANT" in
   bundled-apple-silicon|offline-bundled-apple-silicon-mps-allmodels)
     if [[ -d "$BUNDLED_PAYLOAD_ROOT" ]]; then
       mkdir -p "$(dirname "$PAYLOAD_DEST")"
-      rsync -a --delete "$BUNDLED_PAYLOAD_ROOT/" "$PAYLOAD_DEST/"
+      rsync -a --delete --exclude='._*' "$BUNDLED_PAYLOAD_ROOT/" "$PAYLOAD_DEST/"
     else
       mkdir -p "$PAYLOAD_DEST"
       cat > "$PAYLOAD_DEST/.variant-placeholder" <<EOF
@@ -108,6 +141,8 @@ EOF
     ;;
 esac
 
+remove_appledouble_sidecars "$STAGE"
+
 # Ensure pkg scripts are executable
 chmod +x "$SCRIPTS_DIR/postinstall" 2>/dev/null || true
 
@@ -117,5 +152,7 @@ pkgbuild \
   --identifier "$PKG_ID" \
   --version "$VERSION" \
   "$OUTPUT_PKG"
+
+repack_pkg_without_appledouble
 
 echo "Built: $OUTPUT_PKG"

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -5516,6 +5516,7 @@ def test_macos_build_script_supports_package_variants_without_wiping_dist():
     assert 'rm -rf "$STAGE"' in script
     assert 'rm -rf "$OUT_DIR"' not in script
     assert 'OUTPUT_PKG="$OUT_DIR/STEMwerk-$VERSION$OUTPUT_SUFFIX.pkg"' in script
+    assert 'PACKAGE_REPACK_DIR=""' in script
     assert 'Built: $OUTPUT_PKG' in script
 
 
@@ -5532,9 +5533,25 @@ def test_macos_online_variant_excludes_bundled_payload_and_other_variants_stage_
 
     assert 'BUNDLED_PAYLOAD_ROOT="$ROOT_DIR/scripts/reaper/_bundled/macos/apple-silicon"' in script
     assert 'rm -rf "$STAGE/Users/Shared/STEMwerk-reaper/_bundled/macos/apple-silicon"' in script
-    assert 'rsync -a --delete "$BUNDLED_PAYLOAD_ROOT/" "$PAYLOAD_DEST/"' in script
+    assert 'rsync -a --delete --exclude=\'._*\' "$BUNDLED_PAYLOAD_ROOT/" "$PAYLOAD_DEST/"' in script
     assert 'cat > "$PAYLOAD_DEST/.variant-placeholder" <<EOF' in script
     assert 'payload_status=missing' in script
+
+
+def test_macos_build_script_excludes_appledouble_sidecars_and_repacks_clean_payload():
+    script = Path("installer/macos/build_pkg.sh").read_text()
+
+    assert "--exclude='._*' \\" in script
+    assert "remove_appledouble_sidecars()" in script
+    assert "find \"$1\" -name '._*' -delete" in script
+    assert 'remove_appledouble_sidecars "$STAGE"' in script
+    assert "repack_pkg_without_appledouble()" in script
+    assert 'mkbom "$STAGE" "$PACKAGE_REPACK_DIR/Bom"' in script
+    assert "find . -print | cpio -o --format odc --owner 0:80" in script
+    assert 'xar -xf "$OUTPUT_PKG"' in script
+    assert 'xar --compression none -cf "$OUTPUT_PKG" Bom Payload Scripts PackageInfo' in script
+    assert script.index('remove_appledouble_sidecars "$STAGE"') < script.index("pkgbuild \\")
+    assert script.index("pkgbuild \\") < script.index("repack_pkg_without_appledouble\n")
 
 
 def test_macos_payload_builder_declares_expected_layout_and_manifest():


### PR DESCRIPTION
## Probleem

macOS kan `._*` AppleDouble-sidecars meenemen in package staging en ze tijdens `pkgbuild` alsnog in de package-BOM of payload opnemen.

## Oplossing

- Sluit `._*` sidecars uit bij macOS staging- en payload-copy-stappen.
- Verwijder eventuele resterende sidecars vóór packaging.
- Regenereer na `pkgbuild` de BOM en Payload vanuit de opgeschoonde staging tree, met behoud van `Scripts` en `PackageInfo`.

## Scope

- macOS installer hygiene only.
- Geen runtime policy change.
- Geen Intel-DKS policy change.
- Geen Apple Silicon ASEP policy change.
- Geen Linux change.
- Bestaande `fix/mac-intel-dks-unsupported-ui` WIP onaangeraakt.

## Tests

- Dependency constraint/static tests: 64 passed, 298 deselected.
- `tools/release_gate.py --check`: PASS.
- `git diff --check`: PASS.
- `bash -n installer/macos/build_pkg.sh`: PASS.

Geen installer-builds, tags, releases of runtime-mutatie uitgevoerd.
