### PR TITLE
docs: update 2.3.0.5 notes for drum kit toolbar icons

### DIFF
--- a/docs/release/STEMwerk_2.3.0.5_RELEASE_NOTES.md
+++ b/docs/release/STEMwerk_2.3.0.5_RELEASE_NOTES.md
@@ -37,6 +37,7 @@ Status: release planning. No tag, release, or installer build has been created.
 - Device requests are normalized before processing.
 - Invalid GPU requests fail explicitly instead of silently changing to CPU.
 - Dependency runtime probes are platform-aware while static dependency-policy checks remain hard.
+- Optional REAPER toolbar icons and actions make the existing Direct Kit and Kit Split workflows easier to access.
 
 ## Platform Evidence
 


### PR DESCRIPTION
## Summary

- updates the STEMwerk 2.3.0.5 release notes after PR #89
- records the optional REAPER toolbar icons/actions for the existing Direct Kit and Kit Split workflows

Docs-only change. No code, runtime, build, tag, or release changes. `artifacts/` remains untouched.

## Validation

- `python tools/release_gate.py --check`: PASS
- `python tools/version_sync.py --check`: PASS
- `git diff --check`: PASS
