### PR TITLE
fix(linux): preserve healthy ROCm runtime during repair

### DIFF
--- a/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
+++ b/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
@@ -1672,6 +1672,25 @@ PY
   return 1
 }
 
+select_active_torch_policy() {
+  _policy_backend="$1"
+  ACTIVE_TORCH_VERSION="${PINNED_TORCH_VERSION}"
+  ACTIVE_TORCHVISION_VERSION="${PINNED_TORCHVISION_VERSION}"
+  ACTIVE_TORCHAUDIO_VERSION="${PINNED_TORCHAUDIO_VERSION}"
+  TORCH_RUNTIME_POLICY="service_line_default_torch_lt_2_6"
+  if [ "${_policy_backend}" = "rocm" ] && [ "${ROCM_GFX1201}" -eq 1 ]; then
+    ACTIVE_TORCH_VERSION="${ROCM7_GFX1201_TORCH_VERSION}"
+    ACTIVE_TORCHVISION_VERSION="${ROCM7_GFX1201_TORCHVISION_VERSION}"
+    ACTIVE_TORCHAUDIO_VERSION="${ROCM7_GFX1201_TORCHAUDIO_VERSION}"
+    TORCH_RUNTIME_POLICY="rocm_gfx1201_allow_2_10_rocm7"
+  fi
+  log_step "ACTIVE_TORCH_POLICY_BACKEND=${_policy_backend}"
+  log_step "ACTIVE_TORCH_VERSION=${ACTIVE_TORCH_VERSION}"
+  log_step "ACTIVE_TORCHVISION_VERSION=${ACTIVE_TORCHVISION_VERSION}"
+  log_step "ACTIVE_TORCHAUDIO_VERSION=${ACTIVE_TORCHAUDIO_VERSION}"
+  log_step "PIN_ASSERT_POLICY=torch==${ACTIVE_TORCH_VERSION} torchvision==${ACTIVE_TORCHVISION_VERSION} torchaudio==${ACTIVE_TORCHAUDIO_VERSION}"
+}
+
 linux_torch_install_args() {
   printf 'torch==%s torchvision==%s torchaudio==%s' \
     "${ACTIVE_TORCH_VERSION:-${PINNED_TORCH_VERSION}}" \
@@ -1991,6 +2010,7 @@ elif [ "${ROCM_MODE}" -eq 1 ]; then
   PROFILE="linux-rocm"
   BACKEND="rocm"
 fi
+select_active_torch_policy "${BACKEND}"
 
 if [ "${MODE}" = "ready-to-go-verify" ]; then
   run_ready_to_go_verify_only
@@ -2320,6 +2340,9 @@ else
       log_step "Removing existing virtual environment: ${RUNTIME_BASE}/.venv"
       rm -rf "${RUNTIME_BASE}/.venv"
     elif probe_main_runtime_ready "${RUNTIME_BASE}/.venv/bin/python" "${BACKEND}" >/dev/null; then
+      select_active_torch_policy "${BACKEND}"
+      PRESERVED_RUNTIME_TORCH_VERSION="$("${RUNTIME_BASE}/.venv/bin/python" -c 'import torch; print(getattr(torch, "__version__", "unknown"))' 2>/dev/null || true)"
+      log_step "PRESERVED_RUNTIME_TORCH_VERSION=${PRESERVED_RUNTIME_TORCH_VERSION:-unknown}"
       EXISTING_MAIN_RUNTIME_HEALTHY="1"
       log_step "Preserving healthy existing ${BACKEND} runtime; dependency installation is a no-op"
     else

--- a/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
+++ b/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
@@ -1575,7 +1575,9 @@ resolve_core_target() {
 venv_torch_requires_rebuild() {
   _venv_py="$1"
   [ -x "${_venv_py}" ] || return 1
-  _probe="$("${_venv_py}" - <<'PY' 2>/dev/null || true
+  _probe="$(STEMWERK_BACKEND="${BACKEND}" "${_venv_py}" - <<'PY' 2>/dev/null || true
+import os
+
 try:
     import torch
     ver = getattr(torch, "__version__", "")
@@ -1583,7 +1585,27 @@ try:
     parts = core.split(".")
     major = int(parts[0])
     minor = int(parts[1])
-    if major > 2 or (major == 2 and minor >= 6):
+    backend = os.environ.get("STEMWERK_BACKEND", "cpu")
+    hip = getattr(getattr(torch, "version", None), "hip", None)
+    cuda_available = bool(torch.cuda.is_available())
+    cuda_count = int(torch.cuda.device_count()) if cuda_available else 0
+    names = []
+    if cuda_available:
+        for index in range(cuda_count):
+            try:
+                names.append(str(torch.cuda.get_device_name(index)))
+            except Exception:
+                pass
+    dev_text = "|".join(names).lower()
+    allow_rocm7_gfx1201 = (
+        backend == "rocm"
+        and (major, minor) == (2, 10)
+        and hip is not None
+        and cuda_available
+        and cuda_count > 0
+        and ("rx 9070" in dev_text or "gfx1201" in dev_text)
+    )
+    if (major > 2 or (major == 2 and minor >= 6)) and not allow_rocm7_gfx1201:
         print("rebuild|" + ver)
     else:
         print("ok|" + ver)
@@ -1622,7 +1644,8 @@ for name, wanted in expected.items():
     try:
         installed = md.version(name)
     except md.PackageNotFoundError:
-        continue
+        print("rebuild|missing_package:" + name)
+        raise SystemExit(0)
     if name == "numpy":
         try:
             major = int(installed.split(".", 1)[0])
@@ -2291,9 +2314,19 @@ else
   fi
   log_stage "Creating venv"
   log_step "Creating STEMwerk virtual environment..."
-  if [ -x "${RUNTIME_BASE}/.venv/bin/python" ] && { venv_torch_requires_rebuild "${RUNTIME_BASE}/.venv/bin/python" || main_runtime_requires_rebuild "${RUNTIME_BASE}/.venv/bin/python"; }; then
-    log_step "Removing existing virtual environment: ${RUNTIME_BASE}/.venv"
-    rm -rf "${RUNTIME_BASE}/.venv"
+  EXISTING_MAIN_RUNTIME_HEALTHY="0"
+  if [ -x "${RUNTIME_BASE}/.venv/bin/python" ]; then
+    if venv_torch_requires_rebuild "${RUNTIME_BASE}/.venv/bin/python" || main_runtime_requires_rebuild "${RUNTIME_BASE}/.venv/bin/python"; then
+      log_step "Removing existing virtual environment: ${RUNTIME_BASE}/.venv"
+      rm -rf "${RUNTIME_BASE}/.venv"
+    elif probe_main_runtime_ready "${RUNTIME_BASE}/.venv/bin/python" "${BACKEND}" >/dev/null; then
+      EXISTING_MAIN_RUNTIME_HEALTHY="1"
+      log_step "Preserving healthy existing ${BACKEND} runtime; dependency installation is a no-op"
+    else
+      log_step "Existing venv runtime probe failed; rebuilding .venv"
+      log_step "Removing existing virtual environment: ${RUNTIME_BASE}/.venv"
+      rm -rf "${RUNTIME_BASE}/.venv"
+    fi
   fi
   if [ ! -x "${RUNTIME_BASE}/.venv/bin/python" ]; then
     if ! create_venv_with_selected_python; then
@@ -2321,9 +2354,12 @@ else
       set_status "venv_failed" "${VENV_CREATE_REASON}"
     fi
   fi
-  if [ "${STATUS}" = "ok" ] && [ -x "${RUNTIME_BASE}/.venv/bin/python" ]; then
-    set_progress "3" "${STEP_TOTAL}" "Installing STEMwerk runtime"
+  if [ -x "${RUNTIME_BASE}/.venv/bin/python" ]; then
     VENV_PY="${RUNTIME_BASE}/.venv/bin/python"
+  fi
+  if [ "${STATUS}" = "ok" ] && [ -x "${RUNTIME_BASE}/.venv/bin/python" ]; then
+    if [ "${EXISTING_MAIN_RUNTIME_HEALTHY}" -ne 1 ]; then
+      set_progress "3" "${STEP_TOTAL}" "Installing STEMwerk runtime"
     clear_stale_python_backend_reason
     log_step "Upgrading pip/setuptools/wheel"
     pip_install_with_scope main "${VENV_PY}" --upgrade pip setuptools wheel >> "${LOG_FILE}" 2>&1 || set_status "pip_failed" "pip_upgrade_failed"
@@ -2771,6 +2807,7 @@ PY
       fi
     else
       log_step "Skipping torch pin repair and ONNX install after audio-separator dependency failure"
+    fi
     fi
   fi
 fi

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -2252,6 +2252,39 @@ def test_linux_main_runtime_rebuilds_old_numpy1_audio_separator_venv():
     assert script.index("main_runtime_requires_rebuild()") < script.index('log_stage "Creating venv"')
 
 
+def test_linux_repair_preserves_a_healthy_rocm7_gfx1201_main_runtime():
+    script = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
+    gate = script[
+        script.index("venv_torch_requires_rebuild()") :
+        script.index("main_runtime_requires_rebuild()")
+    ]
+
+    assert 'STEMWERK_BACKEND="${BACKEND}"' in gate
+    assert 'hip = getattr(getattr(torch, "version", None), "hip", None)' in gate
+    assert '"rx 9070" in dev_text or "gfx1201" in dev_text' in gate
+    assert "allow_rocm7_gfx1201" in gate
+    assert 'EXISTING_MAIN_RUNTIME_HEALTHY="0"' in script
+    assert 'probe_main_runtime_ready "${RUNTIME_BASE}/.venv/bin/python" "${BACKEND}"' in script
+    assert 'EXISTING_MAIN_RUNTIME_HEALTHY="1"' in script
+    assert 'Preserving healthy existing ${BACKEND} runtime; dependency installation is a no-op' in script
+    assert '[ "${EXISTING_MAIN_RUNTIME_HEALTHY}" -ne 1 ]' in script
+    install_gate = script[script.index('log_stage "Creating venv"') :]
+    assert install_gate.index('EXISTING_MAIN_RUNTIME_HEALTHY="1"') < install_gate.index('log_step "Installing pinned STEMwerk backend packages..."')
+
+
+def test_linux_repair_keeps_corrupt_runtimes_rebuildable_without_cpu_route_for_healthy_rocm():
+    script = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
+    rebuild_gate = script[
+        script.index("main_runtime_requires_rebuild()") :
+        script.index("linux_torch_install_args()")
+    ]
+
+    assert 'print("rebuild|missing_package:" + name)' in rebuild_gate
+    assert 'Existing venv runtime probe failed; rebuilding .venv' in script
+    assert 'EXISTING_MAIN_RUNTIME_HEALTHY="1"' in script
+    assert script.index('EXISTING_MAIN_RUNTIME_HEALTHY="1"') < script.index('log_stage "Installing ROCm torch"')
+
+
 def test_linux_torch_stack_verify_helper_checks_backend_and_all_three_packages():
     script = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
 

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -103,6 +103,24 @@ def _rocm_gfx1201_runtime_status(
     return allow
 
 
+def _active_linux_torch_policy(backend, *, gfx1201=False):
+    if backend == "rocm" and gfx1201:
+        return {
+            "backend": "rocm",
+            "torch": "2.10.0",
+            "torchvision": "0.25.0",
+            "torchaudio": "2.10.0",
+            "policy": "rocm_gfx1201_allow_2_10_rocm7",
+        }
+    return {
+        "backend": backend,
+        "torch": "2.5.1",
+        "torchvision": "0.20.1",
+        "torchaudio": "2.5.1",
+        "policy": "service_line_default_torch_lt_2_6",
+    }
+
+
 def _core_version(ver):
     return ver.split("+", 1)[0]
 
@@ -2283,6 +2301,57 @@ def test_linux_repair_keeps_corrupt_runtimes_rebuildable_without_cpu_route_for_h
     assert 'Existing venv runtime probe failed; rebuilding .venv' in script
     assert 'EXISTING_MAIN_RUNTIME_HEALTHY="1"' in script
     assert script.index('EXISTING_MAIN_RUNTIME_HEALTHY="1"') < script.index('log_stage "Installing ROCm torch"')
+
+
+def test_linux_active_torch_policy_keeps_cpu_cuda_and_rocm_profiles_separate():
+    assert _active_linux_torch_policy("cpu") == {
+        "backend": "cpu",
+        "torch": "2.5.1",
+        "torchvision": "0.20.1",
+        "torchaudio": "2.5.1",
+        "policy": "service_line_default_torch_lt_2_6",
+    }
+    assert _active_linux_torch_policy("cuda")["backend"] == "cuda"
+    assert _active_linux_torch_policy("cuda")["torch"] == "2.5.1"
+    assert _active_linux_torch_policy("rocm", gfx1201=True)["torch"] == "2.10.0"
+    assert _active_linux_torch_policy("rocm", gfx1201=True)["torchaudio"] == "2.10.0"
+
+
+def test_linux_rocm_preserve_path_selects_policy_before_accepting_noop_runtime():
+    script = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
+    preserve = script[script.index('log_stage "Creating venv"') :]
+
+    assert "select_active_torch_policy()" in script
+    assert 'select_active_torch_policy "${BACKEND}"' in preserve
+    assert preserve.index('select_active_torch_policy "${BACKEND}"') < preserve.index('EXISTING_MAIN_RUNTIME_HEALTHY="1"')
+    assert 'PRESERVED_RUNTIME_TORCH_VERSION=' in preserve
+    assert 'ACTIVE_TORCH_POLICY_BACKEND=${_policy_backend}' in script
+    assert 'ACTIVE_TORCH_VERSION=${ACTIVE_TORCH_VERSION}' in script
+    assert 'ACTIVE_TORCHAUDIO_VERSION=${ACTIVE_TORCHAUDIO_VERSION}' in script
+    assert 'PIN_ASSERT_POLICY=torch==${ACTIVE_TORCH_VERSION}' in script
+
+
+def test_linux_rocm_preserve_policy_matches_current_failure_runtime_and_local_suffix():
+    policy = _active_linux_torch_policy("rocm", gfx1201=True)
+    runtime_torch = "2.10.0+rocm7.0"
+    runtime_torchaudio = "2.10.0+rocm7.0"
+
+    assert runtime_torch.split("+", 1)[0] == policy["torch"]
+    assert runtime_torchaudio.split("+", 1)[0] == policy["torchaudio"]
+    assert policy["torch"] != "2.5.1"
+    assert not _rocm_gfx1201_runtime_status("2.11.0", "2.11.0", True, True, 2, "AMD Radeon RX 9070")
+
+
+def test_linux_preserve_policy_does_not_install_delete_or_fallback_and_keeps_hard_assert():
+    script = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
+    preserve = script[script.index('elif probe_main_runtime_ready') : script.index('if [ ! -x "${RUNTIME_BASE}/.venv/bin/python" ]')]
+
+    assert "pip_install_with_scope" not in preserve
+    assert "install_linux_torch_stack" not in preserve
+    assert "falling back to CPU" not in preserve
+    assert 'rm -rf "${RUNTIME_BASE}/.venv"' not in preserve.split("else", 1)[0]
+    assert 'if ! assert_pinned_torch_stack "${VENV_PY}"; then' in script
+    assert 'set_status "deps_failed" "torch_pin_assert_failed"' in script
 
 
 def test_linux_torch_stack_verify_helper_checks_backend_and_all_three_packages():


### PR DESCRIPTION
## Root cause 1

`venv_torch_requires_rebuild` rejected every torch version >=2.6
before the approved ROCm7/gfx1201 exception could apply, causing a
healthy torch 2.10.0+rocm7.0 environment to be rebuilt.

## Root cause 2

After preserving the healthy ROCm runtime, the no-op path retained
the CPU default `ACTIVE_TORCH_VERSION=2.5.1`, so the final pinned
stack assertion rejected the same validated ROCm runtime.

## Fix

- preserve the approved ROCm7/gfx1201 runtime;
- derive the active Torch policy from the validated backend/profile;
- use that policy in the final pinned-stack assertion;
- keep corrupt and truly incompatible runtimes rebuildable;
- prevent CPU fallback or venv mutation for a healthy ROCm runtime.

## Native validation

- runtime before Repair: torch 2.10.0+rocm7.0, HIP 7.0.51831, 63 packages, pip check clean;
- one official Repair;
- `STATUS=ok`;
- packagefreeze unchanged;
- venv unchanged;
- models/config unchanged;
- backend remains ROCm;
- no network;
- no CPU fallback.

Evidence root: `/home/flark/stemwerk-rnd/linux-rocm-active-policy-noop-20260718-010852`

## Relation to PR #96

PR #96 remains draft and unchanged. This repair fix must merge
first; PR #96 will then be updated with main and its native ROCm
validation resumed.
