### PR TITLE
fix(linux): route Numba caches outside the runtime venv

### DIFF
--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -4673,7 +4673,6 @@ def main():
     emit_phase("python_start")
     ffmpeg_path, ffmpeg_wrapper, ffmpeg_path_prefix = _configure_ffmpeg_runtime()
     model_cache_dir = _configure_model_cache_runtime()
-    _configure_linux_numba_cache_runtime()
     if ffmpeg_path is not None:
         print(f"STEMWERK_DIAG ffmpeg_path={ffmpeg_path}", file=sys.stderr)
         print(
@@ -4720,6 +4719,7 @@ def main():
         parser.print_help()
         return 1
 
+    _configure_linux_numba_cache_runtime()
     _require_core()
     if stemwerk_core_file:
         print(f"STEMWERK_DIAG stemwerk_core_file={stemwerk_core_file}", file=sys.stderr)

--- a/scripts/reaper/audio_separator_process.py
+++ b/scripts/reaper/audio_separator_process.py
@@ -3328,6 +3328,55 @@ def _configure_model_cache_runtime() -> Path:
     return model_dir
 
 
+def _linux_numba_cache_path_is_safe(runtime_base: Path, cache_dir: Path) -> bool:
+    runtime_base = Path(runtime_base).expanduser().resolve(strict=False)
+    cache_dir = Path(cache_dir).expanduser().resolve(strict=False)
+    try:
+        relative = cache_dir.relative_to(runtime_base)
+    except ValueError:
+        return False
+    if not relative.parts:
+        return False
+    first = relative.parts[0].lower()
+    if first == ".venv" or first.startswith(".venv-"):
+        return False
+    return first not in {"models", "config", "configs", "assets", "source", "sources"}
+
+
+def _configure_linux_numba_cache_runtime(runtime_base: Optional[Path] = None) -> Dict[str, str]:
+    if not sys.platform.startswith("linux"):
+        return {}
+
+    candidates = _runtime_base_candidates()
+    effective_base = Path(runtime_base or (candidates[0] if candidates else Path.home() / ".local" / "share" / "STEMwerk"))
+    effective_base = effective_base.expanduser().resolve(strict=False)
+    cache_dir = (effective_base / "cache" / "numba").resolve(strict=False)
+    if not _linux_numba_cache_path_is_safe(effective_base, cache_dir):
+        raise RuntimeError(f"unsafe Linux Numba cache path: {cache_dir}")
+
+    configured_override = str(os.environ.get("NUMBA_CACHE_DIR") or "").strip()
+    override_rejected = bool(
+        configured_override
+        and Path(configured_override).expanduser().resolve(strict=False) != cache_dir
+    )
+    existed = cache_dir.is_dir()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    if not cache_dir.is_dir() or not os.access(cache_dir, os.W_OK):
+        raise RuntimeError(f"Linux Numba cache is not writable: {cache_dir}")
+
+    os.environ["NUMBA_CACHE_DIR"] = str(cache_dir)
+    status = "rejected_override" if override_rejected else ("exists_valid" if existed else "created")
+    policy = {
+        "numba_cache_dir": str(cache_dir),
+        "numba_cache_source": "runtime_policy",
+        "numba_cache_status": status,
+        "numba_cache_inside_venv": "false",
+    }
+    for key, value in policy.items():
+        print(f"{key}={value}", file=sys.stderr)
+    return policy
+
+
 def emit_progress(percent: float, stage: str = ""):
     """Output progress in machine-readable format for Lua to parse."""
     line = f"PROGRESS:{int(percent)}:{stage}\n"
@@ -3896,6 +3945,8 @@ def build_drumsep_subprocess_env(
         "drumsep_cuda_helper_runtime_venv": str(runtime_venv) if backend == "cuda" else "",
         "drumsep_cuda_runtime_lib_dirs": "|".join(_runtime_cuda_library_dirs(runtime_venv)) if backend == "cuda" else "",
         "drumsep_path_starts_with_drumsep_venv": "yes" if sanitized_path and _path_text(sanitized_path[0]) == _path_text(runtime_bin) else "no",
+        "numba_cache_dir": str(env.get("NUMBA_CACHE_DIR", "")),
+        "numba_cache_inherited": "yes" if str(env.get("NUMBA_CACHE_DIR", "")).strip() else "no",
     }
     return env, diagnostics
 
@@ -3992,6 +4043,8 @@ def _emit_drumsep_subprocess_env_diagnostics(diagnostics: Dict[str, str]) -> Non
         "drumsep_cuda_helper_runtime_venv",
         "drumsep_cuda_runtime_lib_dirs",
         "drumsep_path_starts_with_drumsep_venv",
+        "numba_cache_dir",
+        "numba_cache_inherited",
     ):
         print(f"{key}={diagnostics.get(key, '')}", file=sys.stderr)
 
@@ -4620,6 +4673,7 @@ def main():
     emit_phase("python_start")
     ffmpeg_path, ffmpeg_wrapper, ffmpeg_path_prefix = _configure_ffmpeg_runtime()
     model_cache_dir = _configure_model_cache_runtime()
+    _configure_linux_numba_cache_runtime()
     if ffmpeg_path is not None:
         print(f"STEMWERK_DIAG ffmpeg_path={ffmpeg_path}", file=sys.stderr)
         print(

--- a/tests/test_linux_numba_cache_routing.py
+++ b/tests/test_linux_numba_cache_routing.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import subprocess
 import sys
 
+import pytest
+
 
 PROCESS_SCRIPT = Path("scripts/reaper/audio_separator_process.py")
 
@@ -74,6 +76,51 @@ def test_non_linux_launch_behavior_does_not_change_numba_environment(monkeypatch
     assert not (tmp_path / "STEMwerk" / "cache" / "numba").exists()
 
 
+def _assert_cli_route_does_not_configure_numba_cache(monkeypatch, argv, route_stub=None):
+    module = _load_process_module()
+    configured = []
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    monkeypatch.setattr(module.sys, "argv", ["audio_separator_process.py", *argv])
+    monkeypatch.setattr(module, "_setup_reaper_io", lambda _output_dir: None)
+    monkeypatch.setattr(module, "emit_phase", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(module, "_configure_ffmpeg_runtime", lambda: (None, None, None))
+    monkeypatch.setattr(module, "_configure_model_cache_runtime", lambda: Path("models"))
+    monkeypatch.setattr(module, "_configure_linux_numba_cache_runtime", lambda: configured.append(True))
+    if route_stub:
+        route_stub(module)
+
+    return module, configured
+
+
+def test_list_models_does_not_configure_linux_numba_cache(monkeypatch, capsys):
+    module, configured = _assert_cli_route_does_not_configure_numba_cache(monkeypatch, ["--list-models"])
+
+    assert module.main() == 0
+    assert configured == []
+    assert "Popular models:" in capsys.readouterr().out
+
+
+def test_environment_probe_does_not_configure_linux_numba_cache(monkeypatch):
+    module, configured = _assert_cli_route_does_not_configure_numba_cache(
+        monkeypatch,
+        ["--env-json"],
+        lambda loaded: monkeypatch.setattr(loaded, "list_devices_machine", lambda _skips: None),
+    )
+
+    assert module.main() == 0
+    assert configured == []
+
+
+def test_help_does_not_configure_linux_numba_cache(monkeypatch):
+    module, configured = _assert_cli_route_does_not_configure_numba_cache(monkeypatch, ["--help"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main()
+
+    assert exc_info.value.code == 0
+    assert configured == []
+
+
 def test_normal_direct_and_kit_split_share_policy_and_helper_inherits_exact_path(monkeypatch, tmp_path):
     module = _load_process_module()
     runtime_base = tmp_path / "STEMwerk"
@@ -133,11 +180,7 @@ def test_real_librosa_jit_cache_is_outside_site_packages_and_results_match(monke
         text=True,
         env=dict(os.environ),
     )
-    if probe.returncode != 0:
-        assert os.environ["NUMBA_CACHE_DIR"] == str(runtime_base / "cache" / "numba")
-        assert venv_fixture.read_text(encoding="utf-8") == "venv-stable"
-        assert model_fixture.read_text(encoding="utf-8") == "model-stable"
-        return
+    assert probe.returncode == 0, probe.stderr
     librosa_root = Path(probe.stdout.strip()).resolve().parent
     site_cache_before = {p.resolve() for pattern in ("*.nbc", "*.nbi") for p in librosa_root.rglob(pattern)}
     env = dict(os.environ)

--- a/tests/test_linux_numba_cache_routing.py
+++ b/tests/test_linux_numba_cache_routing.py
@@ -1,0 +1,168 @@
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+PROCESS_SCRIPT = Path("scripts/reaper/audio_separator_process.py")
+
+
+def _load_process_module():
+    spec = importlib.util.spec_from_file_location("audio_separator_process_numba_cache_test", PROCESS_SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_linux_runtime_policy_creates_controlled_numba_cache_before_processing(monkeypatch, tmp_path, capsys):
+    module = _load_process_module()
+    runtime_base = tmp_path / "STEMwerk"
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    monkeypatch.setattr(module, "_runtime_base_candidates", lambda: [runtime_base])
+    monkeypatch.delenv("NUMBA_CACHE_DIR", raising=False)
+
+    policy = module._configure_linux_numba_cache_runtime()
+
+    expected = runtime_base / "cache" / "numba"
+    assert policy == {
+        "numba_cache_dir": str(expected),
+        "numba_cache_source": "runtime_policy",
+        "numba_cache_status": "created",
+        "numba_cache_inside_venv": "false",
+    }
+    assert expected.is_dir()
+    assert os.environ["NUMBA_CACHE_DIR"] == str(expected)
+    stderr = capsys.readouterr().err
+    assert f"numba_cache_dir={expected}" in stderr
+    assert "numba_cache_source=runtime_policy" in stderr
+    assert "numba_cache_status=created" in stderr
+    assert "numba_cache_inside_venv=false" in stderr
+
+
+def test_linux_runtime_policy_overrides_safe_and_unsafe_user_paths(monkeypatch, tmp_path):
+    module = _load_process_module()
+    runtime_base = tmp_path / "STEMwerk"
+    controlled = runtime_base / "cache" / "numba"
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    monkeypatch.setattr(module, "_runtime_base_candidates", lambda: [runtime_base])
+
+    for override in (tmp_path / "user-cache", runtime_base / ".venv" / "numba"):
+        monkeypatch.setenv("NUMBA_CACHE_DIR", str(override))
+        policy = module._configure_linux_numba_cache_runtime()
+        assert policy["numba_cache_status"] == "rejected_override"
+        assert policy["numba_cache_source"] == "runtime_policy"
+        assert policy["numba_cache_inside_venv"] == "false"
+        assert os.environ["NUMBA_CACHE_DIR"] == str(controlled)
+        assert not module._path_is_within_root(controlled, runtime_base / ".venv")
+        assert not module._path_is_within_root(controlled, runtime_base / ".venv-drumsep-rocm")
+        assert not module._path_is_within_root(controlled, runtime_base / "models")
+
+
+def test_non_linux_launch_behavior_does_not_change_numba_environment(monkeypatch, tmp_path):
+    module = _load_process_module()
+    existing = tmp_path / "platform-cache"
+    monkeypatch.setattr(module.sys, "platform", "darwin")
+    monkeypatch.setenv("NUMBA_CACHE_DIR", str(existing))
+
+    policy = module._configure_linux_numba_cache_runtime(tmp_path / "STEMwerk")
+
+    assert policy == {}
+    assert os.environ["NUMBA_CACHE_DIR"] == str(existing)
+    assert not (tmp_path / "STEMwerk" / "cache" / "numba").exists()
+
+
+def test_normal_direct_and_kit_split_share_policy_and_helper_inherits_exact_path(monkeypatch, tmp_path):
+    module = _load_process_module()
+    runtime_base = tmp_path / "STEMwerk"
+    main_python = runtime_base / ".venv" / "bin" / "python"
+    helper_python = runtime_base / ".venv-drumsep-rocm" / "bin" / "python"
+    main_python.parent.mkdir(parents=True)
+    helper_python.parent.mkdir(parents=True)
+    main_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    helper_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    monkeypatch.setattr(module.sys, "executable", str(main_python))
+    monkeypatch.setattr(module, "_runtime_base_candidates", lambda: [runtime_base])
+
+    policy = module._configure_linux_numba_cache_runtime()
+    parent_env = module._clean_env()
+    helper_env, diagnostics = module.build_drumsep_subprocess_env(
+        parent_env,
+        helper_python,
+        helper_python.parent.parent,
+        "rocm",
+    )
+
+    expected = str(runtime_base / "cache" / "numba")
+    assert os.environ["NUMBA_CACHE_DIR"] == expected
+    assert parent_env["NUMBA_CACHE_DIR"] == expected
+    assert helper_env["NUMBA_CACHE_DIR"] == expected
+    assert diagnostics["numba_cache_dir"] == expected
+    assert diagnostics["numba_cache_inherited"] == "yes"
+    source = PROCESS_SCRIPT.read_text(encoding="utf-8")
+    assert source.index("_configure_linux_numba_cache_runtime()") < source.index("_require_core()", source.index("def main()"))
+    assert "NUMBA_DISABLE_JIT" not in source
+    assert "NUMBA_DISABLE_CACHING" not in source
+    assert "rglob(\"*.nbc\")" not in source
+    assert "rglob(\"*.nbi\")" not in source
+
+
+def test_real_librosa_jit_cache_is_outside_site_packages_and_results_match(monkeypatch, tmp_path):
+    module = _load_process_module()
+    runtime_base = tmp_path / "STEMwerk"
+    models = runtime_base / "models"
+    venv_fixture = runtime_base / ".venv" / "fixture.txt"
+    model_fixture = models / "fixture-model.bin"
+    venv_fixture.parent.mkdir(parents=True)
+    models.mkdir(parents=True)
+    venv_fixture.write_text("venv-stable", encoding="utf-8")
+    model_fixture.write_text("model-stable", encoding="utf-8")
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    monkeypatch.setattr(module, "_runtime_base_candidates", lambda: [runtime_base])
+    module._configure_linux_numba_cache_runtime()
+
+    runtime_python = Path.home() / ".local" / "share" / "STEMwerk" / ".venv" / "bin" / "python"
+    if not runtime_python.is_file():
+        runtime_python = Path(sys.executable)
+    probe = subprocess.run(
+        [str(runtime_python), "-c", "import librosa, numba; print(librosa.__file__)"],
+        capture_output=True,
+        text=True,
+        env=dict(os.environ),
+    )
+    if probe.returncode != 0:
+        assert os.environ["NUMBA_CACHE_DIR"] == str(runtime_base / "cache" / "numba")
+        assert venv_fixture.read_text(encoding="utf-8") == "venv-stable"
+        assert model_fixture.read_text(encoding="utf-8") == "model-stable"
+        return
+    librosa_root = Path(probe.stdout.strip()).resolve().parent
+    site_cache_before = {p.resolve() for pattern in ("*.nbc", "*.nbi") for p in librosa_root.rglob(pattern)}
+    env = dict(os.environ)
+    code = """
+import json
+import librosa
+import numpy as np
+samples = np.array([0.0, 1.0, -1.0, 0.5, -0.5, 0.0] * 256, dtype=np.float32)
+zero_crossings = librosa.zero_crossings(samples)
+peaks = librosa.util.peak_pick(np.abs(samples), pre_max=2, post_max=2, pre_avg=2, post_avg=2, delta=0.01, wait=1)
+print(json.dumps({"zero_crossings": int(zero_crossings.sum()), "peak_count": int(peaks.size)}))
+"""
+    completed = subprocess.run(
+        [str(runtime_python), "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert json.loads(completed.stdout) == {"zero_crossings": 1025, "peak_count": 256}
+    runtime_cache = runtime_base / "cache" / "numba"
+    cache_files = {p for pattern in ("*.nbc", "*.nbi") for p in runtime_cache.rglob(pattern)}
+    assert cache_files
+    site_cache_after = {p.resolve() for pattern in ("*.nbc", "*.nbi") for p in librosa_root.rglob(pattern)}
+    assert site_cache_after == site_cache_before
+    assert venv_fixture.read_text(encoding="utf-8") == "venv-stable"
+    assert model_fixture.read_text(encoding="utf-8") == "model-stable"

--- a/tests/test_windows_normal_route_matrix.py
+++ b/tests/test_windows_normal_route_matrix.py
@@ -155,6 +155,7 @@ def test_windows_dks_extract_stage1_reuses_normal_route_mapping_across_backends(
     monkeypatch, tmp_path, requested_device, resolved_device, _device_label, model_name
 ):
     module = _load_audio_separator_process()
+    monkeypatch.setattr(module.sys, "platform", "win32")
     stem_separator_inits = []
     helper_calls = []
 
@@ -243,6 +244,7 @@ def test_windows_direct_dks_route_stays_on_drumsep_helper_per_backend(
     monkeypatch, tmp_path, requested_device, _resolved_device, _device_label
 ):
     module = _load_audio_separator_process()
+    monkeypatch.setattr(module.sys, "platform", "win32")
     helper_calls = []
 
     def fail_if_normal_route_used(*_args, **_kwargs):


### PR DESCRIPTION
## Root cause

First-use Librosa/Numba processing created 46 `.nbc` and `.nbi`
JIT-cache files inside writable Librosa site-packages directories
in the production venv, violating the closed-world venv inventory.

## Fix

- derive `<runtime-base>/cache/numba`;
- set `NUMBA_CACHE_DIR` lazily before Librosa/Numba processing imports;
- keep non-processing CLI routes free of runtime-cache writes;
- create and validate the controlled cache;
- propagate it to normal stems, Direct Kit and Kit Split helpers;
- keep JIT enabled;
- perform no post-processing cleanup;
- change no dependencies or pins.

## Test hardening

The original fixture could return successfully when Librosa was
unavailable. The second test commit requires the real Librosa/Numba
JIT path and observable `.nbc`/`.nbi` artifacts. Three regressions
cover lazy CLI routing, and Windows route tests explicitly simulate
Windows platform behavior.

## Local validation

- fresh Python 3.12 throwaway-testvenv created from `requirements-dev.txt`;
- test-environment fail-fast gate 3/3 green;
- Exact CI Fast green, including curated pytest 93/93;
- cache-routing fixture 8/8 green (original fixture suite 5/5);
- real Librosa/Numba JIT execution produced 36 `.nbc` and 10 `.nbi` files;
- cache created only under the temporary runtime cache;
- fixture site-packages immutable;
- production runtime inventory unchanged;
- throwaway-testvenv removed.

## Known baseline exceptions

- six Linux asset-distribution conformance reds are identical to
  current main and await PR #96;
- the local `direct_url.json` metadata exception is host-specific
  and must not reproduce in GitHub CI.

## Follow-up

PR #96 remains draft and unchanged. It will only be updated after
this cachefix merges.