### PR TITLE
fix(linux): clean legacy Numba caches during repair

### DIFF
--- a/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
+++ b/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
@@ -833,6 +833,14 @@ write_state() {
       [ -n "${VENV_PY}" ] && echo "VENV_PYTHON=${VENV_PY}"
       [ -n "${VENV_PY}" ] && echo "VENV_PYTHON_PATH=${VENV_PY}"
       [ -n "${FFMPEG}" ] && echo "FFMPEG_PATH=${FFMPEG}"
+      echo "NUMBA_LEGACY_CACHE_DETECTED=${NUMBA_LEGACY_CACHE_DETECTED}"
+      echo "NUMBA_LEGACY_CACHE_REMOVED=${NUMBA_LEGACY_CACHE_REMOVED}"
+      echo "NUMBA_LEGACY_CACHE_UNEXPECTED_PATHS=${NUMBA_LEGACY_CACHE_UNEXPECTED_PATHS}"
+      echo "NUMBA_LEGACY_CACHE_ANOMALIES=${NUMBA_LEGACY_CACHE_ANOMALIES}"
+      echo "NUMBA_LEGACY_CACHE_POSTCHECK_REMAINING=${NUMBA_LEGACY_CACHE_POSTCHECK_REMAINING}"
+      echo "NUMBA_LEGACY_CACHE_NOT_REMOVED=${NUMBA_LEGACY_CACHE_NOT_REMOVED}"
+      echo "NUMBA_LEGACY_CACHE_RUNTIME_CACHE_TOUCHED=${NUMBA_LEGACY_CACHE_RUNTIME_CACHE_TOUCHED}"
+      echo "NUMBA_LEGACY_CACHE_CLEANUP_STATUS=${NUMBA_LEGACY_CACHE_CLEANUP_STATUS}"
       [ -n "${STEMWERK_INSTALLER:-}" ] && echo "INSTALLER=1"
       [ -n "${RUNTIME_BASE}" ] && echo "RUNTIME_BASE=${RUNTIME_BASE}"
     } > "${STATE_FILE}"
@@ -847,6 +855,217 @@ set_status() {
     write_state
   fi
 }
+
+cleanup_legacy_numba_caches() {
+  _cleanup_venv="$1"
+  _cleanup_detected=0
+  _cleanup_removed=0
+  _cleanup_unexpected=0
+  _cleanup_anomalies=0
+  _cleanup_remaining=0
+  _cleanup_status="not_required"
+  _cleanup_failed=0
+
+  _cleanup_emit() {
+    _cleanup_not_removed=$((_cleanup_detected - _cleanup_removed))
+    printf "NUMBA_LEGACY_CACHE_DETECTED=%s\n" "${_cleanup_detected}"
+    printf "NUMBA_LEGACY_CACHE_REMOVED=%s\n" "${_cleanup_removed}"
+    printf "NUMBA_LEGACY_CACHE_UNEXPECTED_PATHS=%s\n" "${_cleanup_unexpected}"
+    printf "NUMBA_LEGACY_CACHE_ANOMALIES=%s\n" "${_cleanup_anomalies}"
+    printf "NUMBA_LEGACY_CACHE_POSTCHECK_REMAINING=%s\n" "${_cleanup_remaining}"
+    printf "NUMBA_LEGACY_CACHE_NOT_REMOVED=%s\n" "${_cleanup_not_removed}"
+    printf "NUMBA_LEGACY_CACHE_RUNTIME_CACHE_TOUCHED=no\n"
+    printf "NUMBA_LEGACY_CACHE_CLEANUP_STATUS=%s\n" "${_cleanup_status}"
+  }
+
+  if [ ! -d "${_cleanup_venv}" ]; then
+    _cleanup_emit
+    return 0
+  fi
+
+  _cleanup_newline='
+'
+  _cleanup_carriage_return="$(printf '\r')"
+  case "${_cleanup_venv}" in
+    *"${_cleanup_newline}"*|*"${_cleanup_carriage_return}"*)
+      _cleanup_anomalies=1
+      _cleanup_status="blocked_anomaly"
+      _cleanup_emit
+      return 1
+      ;;
+  esac
+
+  _cleanup_venv_real="$(readlink -f -- "${_cleanup_venv}" 2>/dev/null || true)"
+  if [ -z "${_cleanup_venv_real}" ] || [ ! -d "${_cleanup_venv_real}" ]; then
+    _cleanup_anomalies=1
+    _cleanup_status="blocked_anomaly"
+    _cleanup_emit
+    return 1
+  fi
+
+  _cleanup_candidates="$(mktemp "${TMPDIR:-/tmp}/stemwerk-numba-legacy-candidates.XXXXXX")" || {
+    _cleanup_status="failed"
+    _cleanup_emit
+    return 1
+  }
+  trap '/bin/rm -f -- "${_cleanup_candidates}"' EXIT HUP INT TERM
+
+  for _cleanup_parent in \
+    "${_cleanup_venv}"/lib/python*/site-packages/librosa/core/__pycache__ \
+    "${_cleanup_venv}"/lib/python*/site-packages/librosa/util/__pycache__
+  do
+    if [ ! -e "${_cleanup_parent}" ] && [ ! -L "${_cleanup_parent}" ]; then
+      continue
+    fi
+    _cleanup_parent_real="$(readlink -f -- "${_cleanup_parent}" 2>/dev/null || true)"
+    _cleanup_parent_relative=${_cleanup_parent#"${_cleanup_venv}"/}
+    _cleanup_parent_expected="${_cleanup_venv_real}/${_cleanup_parent_relative}"
+    case "${_cleanup_parent_real}:${_cleanup_parent_expected}" in
+      "${_cleanup_venv_real}"/lib/python*/site-packages/librosa/core/__pycache__:"${_cleanup_venv_real}"/lib/python*/site-packages/librosa/core/__pycache__|\
+      "${_cleanup_venv_real}"/lib/python*/site-packages/librosa/util/__pycache__:"${_cleanup_venv_real}"/lib/python*/site-packages/librosa/util/__pycache__)
+        ;;
+      *)
+        _cleanup_anomalies=$((_cleanup_anomalies + 1))
+        continue
+        ;;
+    esac
+    if [ ! -d "${_cleanup_parent}" ] || [ -L "${_cleanup_parent}" ]; then
+      _cleanup_anomalies=$((_cleanup_anomalies + 1))
+      continue
+    fi
+
+    for _cleanup_path in \
+      "${_cleanup_parent}"/* \
+      "${_cleanup_parent}"/.[!.]* \
+      "${_cleanup_parent}"/..?*
+    do
+      if [ ! -e "${_cleanup_path}" ] && [ ! -L "${_cleanup_path}" ]; then
+        continue
+      fi
+      _cleanup_name=${_cleanup_path##*/}
+      if [ -L "${_cleanup_path}" ]; then
+        _cleanup_anomalies=$((_cleanup_anomalies + 1))
+        continue
+      fi
+      if [ -f "${_cleanup_path}" ]; then
+        case "${_cleanup_name}" in
+          *.nbc|*.nbi)
+            case "${_cleanup_name}" in
+              *[!A-Za-z0-9._-]*)
+                _cleanup_anomalies=$((_cleanup_anomalies + 1))
+                continue
+                ;;
+            esac
+            _cleanup_path_real="$(readlink -f -- "${_cleanup_path}" 2>/dev/null || true)"
+            case "${_cleanup_path_real}" in
+              "${_cleanup_parent_real}"/*)
+                printf "%s\n" "${_cleanup_path}" >> "${_cleanup_candidates}" || _cleanup_failed=1
+                _cleanup_detected=$((_cleanup_detected + 1))
+                ;;
+              *)
+                _cleanup_anomalies=$((_cleanup_anomalies + 1))
+                ;;
+            esac
+            ;;
+          *.nbc.*|*.nbi.*)
+            _cleanup_anomalies=$((_cleanup_anomalies + 1))
+            ;;
+        esac
+      else
+        _cleanup_anomalies=$((_cleanup_anomalies + 1))
+      fi
+    done
+  done
+
+  if ! _cleanup_all_marks="$(find "${_cleanup_venv}" -type f \( -name '*.nbc' -o -name '*.nbi' \) -printf x 2>/dev/null)"; then
+    _cleanup_failed=1
+  fi
+  _cleanup_all_count=${#_cleanup_all_marks}
+  if [ "${_cleanup_all_count}" -ge "${_cleanup_detected}" ]; then
+    _cleanup_unexpected=$((_cleanup_all_count - _cleanup_detected))
+  else
+    _cleanup_failed=1
+  fi
+
+  if [ "${_cleanup_failed}" -ne 0 ]; then
+    _cleanup_status="failed"
+    _cleanup_remaining=${_cleanup_detected}
+    _cleanup_emit
+    /bin/rm -f -- "${_cleanup_candidates}"
+    trap - EXIT HUP INT TERM
+    return 1
+  fi
+  if [ "${_cleanup_anomalies}" -ne 0 ]; then
+    _cleanup_status="blocked_anomaly"
+    _cleanup_remaining=${_cleanup_detected}
+    _cleanup_emit
+    /bin/rm -f -- "${_cleanup_candidates}"
+    trap - EXIT HUP INT TERM
+    return 1
+  fi
+
+  while IFS= read -r _cleanup_candidate; do
+    [ -n "${_cleanup_candidate}" ] || continue
+    _cleanup_candidate_parent=${_cleanup_candidate%/*}
+    _cleanup_candidate_real="$(readlink -f -- "${_cleanup_candidate}" 2>/dev/null || true)"
+    _cleanup_candidate_parent_real="$(readlink -f -- "${_cleanup_candidate_parent}" 2>/dev/null || true)"
+    case "${_cleanup_candidate_parent_real}" in
+      "${_cleanup_venv_real}"/lib/python*/site-packages/librosa/core/__pycache__|\
+      "${_cleanup_venv_real}"/lib/python*/site-packages/librosa/util/__pycache__)
+        ;;
+      *) _cleanup_failed=1 ;;
+    esac
+    case "${_cleanup_candidate_real}" in
+      "${_cleanup_candidate_parent_real}"/*) ;;
+      *) _cleanup_failed=1 ;;
+    esac
+    if [ ! -f "${_cleanup_candidate}" ] || [ -L "${_cleanup_candidate}" ]; then
+      _cleanup_failed=1
+    fi
+    if [ "${_cleanup_failed}" -ne 0 ]; then
+      break
+    fi
+    if rm -f -- "${_cleanup_candidate}" && [ ! -e "${_cleanup_candidate}" ] && [ ! -L "${_cleanup_candidate}" ]; then
+      _cleanup_removed=$((_cleanup_removed + 1))
+    else
+      _cleanup_failed=1
+      break
+    fi
+  done < "${_cleanup_candidates}"
+
+  _cleanup_remaining=0
+  for _cleanup_parent in \
+    "${_cleanup_venv}"/lib/python*/site-packages/librosa/core/__pycache__ \
+    "${_cleanup_venv}"/lib/python*/site-packages/librosa/util/__pycache__
+  do
+    [ -d "${_cleanup_parent}" ] || continue
+    for _cleanup_path in "${_cleanup_parent}"/*.nbc "${_cleanup_parent}"/*.nbi; do
+      if [ -e "${_cleanup_path}" ] || [ -L "${_cleanup_path}" ]; then
+        _cleanup_remaining=$((_cleanup_remaining + 1))
+      fi
+    done
+  done
+
+  if [ "${_cleanup_failed}" -ne 0 ] || [ "${_cleanup_remaining}" -ne 0 ]; then
+    _cleanup_status="failed"
+    _cleanup_emit
+    /bin/rm -f -- "${_cleanup_candidates}"
+    trap - EXIT HUP INT TERM
+    return 1
+  fi
+  if [ "${_cleanup_unexpected}" -ne 0 ]; then
+    _cleanup_status="partial_unexpected"
+  elif [ "${_cleanup_removed}" -ne 0 ]; then
+    _cleanup_status="removed"
+  else
+    _cleanup_status="not_required"
+  fi
+  _cleanup_emit
+  /bin/rm -f -- "${_cleanup_candidates}"
+  trap - EXIT HUP INT TERM
+  return 0
+}
+# END NUMBA LEGACY CACHE CLEANUP POLICY
 
 detect_build_tools_missing_log() {
   _log="$1"
@@ -1914,6 +2133,14 @@ PYTHON=""
 FFMPEG=""
 VENV_PY=""
 PYTHON_PATH=""
+NUMBA_LEGACY_CACHE_DETECTED="0"
+NUMBA_LEGACY_CACHE_REMOVED="0"
+NUMBA_LEGACY_CACHE_UNEXPECTED_PATHS="0"
+NUMBA_LEGACY_CACHE_ANOMALIES="0"
+NUMBA_LEGACY_CACHE_POSTCHECK_REMAINING="0"
+NUMBA_LEGACY_CACHE_NOT_REMOVED="0"
+NUMBA_LEGACY_CACHE_RUNTIME_CACHE_TOUCHED="no"
+NUMBA_LEGACY_CACHE_CLEANUP_STATUS="not_required"
 SUPPORTED_PYTHON_FOUND="no"
 DETECTED_PYTHON_VERSION=""
 DETECTED_PYTHON_PATH=""
@@ -2849,6 +3076,39 @@ do
     break
   fi
 done
+
+if [ "${MODE}" = "repair" ] && [ -n "${VENV_PY}" ] && [ -x "${VENV_PY}" ]; then
+  log_stage "Cleaning legacy Numba caches"
+  NUMBA_LEGACY_CACHE_OUTPUT="$(cleanup_legacy_numba_caches "${RUNTIME_BASE}/.venv")"
+  NUMBA_LEGACY_CACHE_RC=$?
+  while IFS= read -r _numba_cache_marker; do
+    [ -n "${_numba_cache_marker}" ] && log "${_numba_cache_marker}"
+  done <<EOF
+${NUMBA_LEGACY_CACHE_OUTPUT}
+EOF
+  NUMBA_LEGACY_CACHE_DETECTED="$(printf "%s\n" "${NUMBA_LEGACY_CACHE_OUTPUT}" | sed -n 's/^NUMBA_LEGACY_CACHE_DETECTED=//p' | tail -n 1)"
+  NUMBA_LEGACY_CACHE_REMOVED="$(printf "%s\n" "${NUMBA_LEGACY_CACHE_OUTPUT}" | sed -n 's/^NUMBA_LEGACY_CACHE_REMOVED=//p' | tail -n 1)"
+  NUMBA_LEGACY_CACHE_UNEXPECTED_PATHS="$(printf "%s\n" "${NUMBA_LEGACY_CACHE_OUTPUT}" | sed -n 's/^NUMBA_LEGACY_CACHE_UNEXPECTED_PATHS=//p' | tail -n 1)"
+  NUMBA_LEGACY_CACHE_ANOMALIES="$(printf "%s\n" "${NUMBA_LEGACY_CACHE_OUTPUT}" | sed -n 's/^NUMBA_LEGACY_CACHE_ANOMALIES=//p' | tail -n 1)"
+  NUMBA_LEGACY_CACHE_POSTCHECK_REMAINING="$(printf "%s\n" "${NUMBA_LEGACY_CACHE_OUTPUT}" | sed -n 's/^NUMBA_LEGACY_CACHE_POSTCHECK_REMAINING=//p' | tail -n 1)"
+  NUMBA_LEGACY_CACHE_NOT_REMOVED="$(printf "%s\n" "${NUMBA_LEGACY_CACHE_OUTPUT}" | sed -n 's/^NUMBA_LEGACY_CACHE_NOT_REMOVED=//p' | tail -n 1)"
+  NUMBA_LEGACY_CACHE_RUNTIME_CACHE_TOUCHED="$(printf "%s\n" "${NUMBA_LEGACY_CACHE_OUTPUT}" | sed -n 's/^NUMBA_LEGACY_CACHE_RUNTIME_CACHE_TOUCHED=//p' | tail -n 1)"
+  NUMBA_LEGACY_CACHE_CLEANUP_STATUS="$(printf "%s\n" "${NUMBA_LEGACY_CACHE_OUTPUT}" | sed -n 's/^NUMBA_LEGACY_CACHE_CLEANUP_STATUS=//p' | tail -n 1)"
+  case "${NUMBA_LEGACY_CACHE_CLEANUP_STATUS}" in
+    not_required|removed|partial_unexpected)
+      ;;
+    blocked_anomaly|failed)
+      NUMBA_LEGACY_CACHE_RC=1
+      ;;
+    *)
+      NUMBA_LEGACY_CACHE_CLEANUP_STATUS="failed"
+      NUMBA_LEGACY_CACHE_RC=1
+      ;;
+  esac
+  if [ "${NUMBA_LEGACY_CACHE_RC}" -ne 0 ]; then
+    set_status "deps_failed" "numba_legacy_cache_cleanup_failed"
+  fi
+fi
 
 if [ -z "${FFMPEG}" ]; then
   managed_ffmpeg=""

--- a/tests/test_linux_numba_legacy_cache_cleanup.py
+++ b/tests/test_linux_numba_legacy_cache_cleanup.py
@@ -1,0 +1,450 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BOOTSTRAP = ROOT / "scripts/reaper/STEMwerk_Bootstrap_Linux.sh"
+STATUS_VALUES = {
+    "not_required",
+    "removed",
+    "partial_unexpected",
+    "blocked_anomaly",
+    "failed",
+}
+
+
+def _venv(runtime_base: Path) -> Path:
+    venv = runtime_base / ".venv"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin/python").write_text("#!/bin/sh\n", encoding="utf-8")
+    (venv / "bin/python").chmod(0o755)
+    return venv
+
+
+def _allowlist_parents(venv: Path) -> tuple[Path, Path]:
+    core = venv / "lib/python3.12/site-packages/librosa/core/__pycache__"
+    util = venv / "lib/python3.12/site-packages/librosa/util/__pycache__"
+    core.mkdir(parents=True, exist_ok=True)
+    util.mkdir(parents=True, exist_ok=True)
+    return core, util
+
+
+def _runner(venv: Path) -> Path:
+    script = BOOTSTRAP.read_text(encoding="utf-8")
+    start = script.index("cleanup_legacy_numba_caches() {")
+    end = script.index("# END NUMBA LEGACY CACHE CLEANUP POLICY")
+    runner = venv.parent / "numba-cleanup-runner.sh"
+    runner.parent.mkdir(parents=True, exist_ok=True)
+    runner.write_text(
+        "#!/bin/sh\nset -u\n"
+        + script[start:end]
+        + '\ncleanup_legacy_numba_caches "$1"\n',
+        encoding="utf-8",
+    )
+    runner.chmod(0o755)
+    return runner
+
+
+def _run(venv: Path, *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    run_env = os.environ.copy()
+    if env:
+        run_env.update(env)
+    return subprocess.run(
+        ["/bin/sh", str(_runner(venv)), str(venv)],
+        cwd=ROOT,
+        env=run_env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+
+def _markers(result: subprocess.CompletedProcess[str]) -> dict[str, str]:
+    markers: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        if line.startswith("NUMBA_LEGACY_CACHE_") and "=" in line:
+            key, value = line.split("=", 1)
+            markers[key] = value
+    return markers
+
+
+def _assert_common(markers: dict[str, str]) -> None:
+    assert markers["NUMBA_LEGACY_CACHE_RUNTIME_CACHE_TOUCHED"] == "no"
+    assert markers["NUMBA_LEGACY_CACHE_CLEANUP_STATUS"] in STATUS_VALUES
+
+
+def test_no_caches_is_not_required(tmp_path: Path) -> None:
+    venv = _venv(tmp_path / "runtime")
+    _allowlist_parents(venv)
+
+    result = _run(venv)
+    markers = _markers(result)
+
+    assert result.returncode == 0, result.stdout
+    assert markers["NUMBA_LEGACY_CACHE_DETECTED"] == "0"
+    assert markers["NUMBA_LEGACY_CACHE_REMOVED"] == "0"
+    assert markers["NUMBA_LEGACY_CACHE_UNEXPECTED_PATHS"] == "0"
+    assert markers["NUMBA_LEGACY_CACHE_ANOMALIES"] == "0"
+    assert markers["NUMBA_LEGACY_CACHE_POSTCHECK_REMAINING"] == "0"
+    assert markers["NUMBA_LEGACY_CACHE_CLEANUP_STATUS"] == "not_required"
+    _assert_common(markers)
+
+
+def test_one_core_nbc_is_removed(tmp_path: Path) -> None:
+    venv = _venv(tmp_path / "runtime")
+    core, _ = _allowlist_parents(venv)
+    cache = core / "audio.fn-1.py312.1.nbc"
+    cache.write_bytes(b"cache")
+
+    result = _run(venv)
+    markers = _markers(result)
+
+    assert result.returncode == 0, result.stdout
+    assert not cache.exists()
+    assert markers["NUMBA_LEGACY_CACHE_DETECTED"] == "1"
+    assert markers["NUMBA_LEGACY_CACHE_REMOVED"] == "1"
+    assert markers["NUMBA_LEGACY_CACHE_NOT_REMOVED"] == "0"
+    assert markers["NUMBA_LEGACY_CACHE_POSTCHECK_REMAINING"] == "0"
+    assert markers["NUMBA_LEGACY_CACHE_CLEANUP_STATUS"] == "removed"
+
+
+def test_arbitrary_valid_caches_across_both_parents_are_removed(tmp_path: Path) -> None:
+    venv = _venv(tmp_path / "runtime")
+    core, util = _allowlist_parents(venv)
+    caches = [
+        core / "a.py312.1.nbc",
+        core / "a.py312.nbi",
+        util / "b.py312.1.nbc",
+        util / "b.py312.nbi",
+        util / "c.py312.7.nbc",
+    ]
+    for index, cache in enumerate(caches):
+        cache.write_bytes(f"cache-{index}".encode())
+
+    result = _run(venv)
+    markers = _markers(result)
+
+    assert result.returncode == 0, result.stdout
+    assert all(not cache.exists() for cache in caches)
+    assert int(markers["NUMBA_LEGACY_CACHE_DETECTED"]) == len(caches)
+    assert int(markers["NUMBA_LEGACY_CACHE_REMOVED"]) == len(caches)
+    assert markers["NUMBA_LEGACY_CACHE_CLEANUP_STATUS"] == "removed"
+
+
+def test_allowlist_caches_removed_but_unexpected_caches_preserved(tmp_path: Path) -> None:
+    venv = _venv(tmp_path / "runtime")
+    core, _ = _allowlist_parents(venv)
+    allowed = core / "allowed.py312.1.nbc"
+    unexpected = venv / "lib/python3.12/site-packages/other/__pycache__/other.py312.nbi"
+    unexpected.parent.mkdir(parents=True)
+    allowed.write_bytes(b"allowed")
+    unexpected.write_bytes(b"unexpected")
+
+    result = _run(venv)
+    markers = _markers(result)
+
+    assert result.returncode == 0, result.stdout
+    assert not allowed.exists()
+    assert unexpected.read_bytes() == b"unexpected"
+    assert markers["NUMBA_LEGACY_CACHE_UNEXPECTED_PATHS"] == "1"
+    assert markers["NUMBA_LEGACY_CACHE_CLEANUP_STATUS"] == "partial_unexpected"
+
+
+def test_only_unexpected_caches_are_preserved(tmp_path: Path) -> None:
+    venv = _venv(tmp_path / "runtime")
+    unexpected = venv / "lib/python3.12/site-packages/other/cache.nbc"
+    unexpected.parent.mkdir(parents=True)
+    unexpected.write_bytes(b"unexpected")
+
+    result = _run(venv)
+    markers = _markers(result)
+
+    assert result.returncode == 0, result.stdout
+    assert unexpected.exists()
+    assert markers["NUMBA_LEGACY_CACHE_DETECTED"] == "0"
+    assert markers["NUMBA_LEGACY_CACHE_REMOVED"] == "0"
+    assert markers["NUMBA_LEGACY_CACHE_UNEXPECTED_PATHS"] == "1"
+    assert markers["NUMBA_LEGACY_CACHE_CLEANUP_STATUS"] == "partial_unexpected"
+
+
+def test_symlink_in_allowlist_blocks_all_removal(tmp_path: Path) -> None:
+    venv = _venv(tmp_path / "runtime")
+    core, _ = _allowlist_parents(venv)
+    valid = core / "valid.nbc"
+    valid.write_bytes(b"valid")
+    (core / "linked.nbi").symlink_to(tmp_path / "outside")
+
+    result = _run(venv)
+    markers = _markers(result)
+
+    assert result.returncode != 0
+    assert valid.exists()
+    assert markers["NUMBA_LEGACY_CACHE_REMOVED"] == "0"
+    assert int(markers["NUMBA_LEGACY_CACHE_ANOMALIES"]) > 0
+    assert markers["NUMBA_LEGACY_CACHE_CLEANUP_STATUS"] == "blocked_anomaly"
+
+
+def test_parent_realpath_escape_blocks_all_removal(tmp_path: Path) -> None:
+    venv = _venv(tmp_path / "runtime")
+    site = venv / "lib/python3.12/site-packages/librosa"
+    outside = tmp_path / "outside/core/__pycache__"
+    outside.mkdir(parents=True)
+    (outside / "escaped.nbc").write_bytes(b"escape")
+    site.mkdir(parents=True)
+    (site / "core").symlink_to(outside.parent)
+
+    result = _run(venv)
+    markers = _markers(result)
+
+    assert result.returncode != 0
+    assert (outside / "escaped.nbc").exists()
+    assert markers["NUMBA_LEGACY_CACHE_REMOVED"] == "0"
+    assert markers["NUMBA_LEGACY_CACHE_CLEANUP_STATUS"] == "blocked_anomaly"
+
+
+@pytest.mark.parametrize("suffix", ["nbc", "nbi"])
+def test_cache_named_directory_blocks_all_removal(tmp_path: Path, suffix: str) -> None:
+    venv = _venv(tmp_path / "runtime")
+    core, _ = _allowlist_parents(venv)
+    valid = core / "valid.nbc"
+    valid.write_bytes(b"valid")
+    (core / f"directory.{suffix}").mkdir()
+
+    result = _run(venv)
+    markers = _markers(result)
+
+    assert result.returncode != 0
+    assert valid.exists()
+    assert markers["NUMBA_LEGACY_CACHE_REMOVED"] == "0"
+    assert markers["NUMBA_LEGACY_CACHE_CLEANUP_STATUS"] == "blocked_anomaly"
+
+
+def test_cache_like_unexpected_extension_blocks_all_removal(tmp_path: Path) -> None:
+    venv = _venv(tmp_path / "runtime")
+    core, _ = _allowlist_parents(venv)
+    valid = core / "valid.nbc"
+    invalid = core / "unfinished.nbc.tmp"
+    valid.write_bytes(b"valid")
+    invalid.write_bytes(b"invalid")
+
+    result = _run(venv)
+    markers = _markers(result)
+
+    assert result.returncode != 0
+    assert valid.exists() and invalid.exists()
+    assert markers["NUMBA_LEGACY_CACHE_REMOVED"] == "0"
+    assert markers["NUMBA_LEGACY_CACHE_CLEANUP_STATUS"] == "blocked_anomaly"
+
+
+def _fake_rm(tmp_path: Path, body: str) -> dict[str, str]:
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    script = fake_bin / "rm"
+    script.write_text("#!/bin/sh\n" + body, encoding="utf-8")
+    script.chmod(0o755)
+    return {"PATH": f"{fake_bin}:{os.environ['PATH']}"}
+
+
+def test_removal_failure_before_first_delete_is_hard_failure(tmp_path: Path) -> None:
+    venv = _venv(tmp_path / "runtime")
+    core, _ = _allowlist_parents(venv)
+    cache = core / "cache.nbc"
+    cache.write_bytes(b"cache")
+    env = _fake_rm(tmp_path, "exit 1\n")
+
+    result = _run(venv, env=env)
+    markers = _markers(result)
+
+    assert result.returncode != 0
+    assert cache.exists()
+    assert markers["NUMBA_LEGACY_CACHE_REMOVED"] == "0"
+    assert markers["NUMBA_LEGACY_CACHE_CLEANUP_STATUS"] == "failed"
+
+
+def test_partial_removal_reports_actual_removed_count(tmp_path: Path) -> None:
+    venv = _venv(tmp_path / "runtime")
+    core, _ = _allowlist_parents(venv)
+    first, second = core / "a.nbc", core / "b.nbi"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    counter = tmp_path / "rm-count"
+    env = _fake_rm(
+        tmp_path,
+        f'count=$(cat "{counter}" 2>/dev/null || echo 0)\n'
+        f'count=$((count + 1)); echo "$count" > "{counter}"\n'
+        'if [ "$count" -gt 1 ]; then exit 1; fi\n'
+        'exec /bin/rm "$@"\n',
+    )
+
+    result = _run(venv, env=env)
+    markers = _markers(result)
+
+    assert result.returncode != 0
+    assert sum(path.exists() for path in (first, second)) == 1
+    assert markers["NUMBA_LEGACY_CACHE_REMOVED"] == "1"
+    assert markers["NUMBA_LEGACY_CACHE_NOT_REMOVED"] == "1"
+    assert markers["NUMBA_LEGACY_CACHE_POSTCHECK_REMAINING"] == "1"
+    assert markers["NUMBA_LEGACY_CACHE_CLEANUP_STATUS"] == "failed"
+
+
+def test_postcheck_failure_is_hard_failure(tmp_path: Path) -> None:
+    venv = _venv(tmp_path / "runtime")
+    core, _ = _allowlist_parents(venv)
+    cache = core / "cache.nbc"
+    cache.write_bytes(b"cache")
+    env = _fake_rm(tmp_path, "exit 0\n")
+
+    result = _run(venv, env=env)
+    markers = _markers(result)
+
+    assert result.returncode != 0
+    assert cache.exists()
+    assert markers["NUMBA_LEGACY_CACHE_REMOVED"] == "0"
+    assert markers["NUMBA_LEGACY_CACHE_POSTCHECK_REMAINING"] == "1"
+    assert markers["NUMBA_LEGACY_CACHE_CLEANUP_STATUS"] == "failed"
+
+
+def test_controlled_runtime_cache_is_untouched_and_not_unexpected(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    venv = _venv(runtime)
+    runtime_cache = runtime / "cache/numba/compiled"
+    runtime_cache.mkdir(parents=True)
+    cache = runtime_cache / "runtime.nbc"
+    cache.write_bytes(b"runtime-cache")
+
+    result = _run(venv)
+    markers = _markers(result)
+
+    assert result.returncode == 0, result.stdout
+    assert cache.read_bytes() == b"runtime-cache"
+    assert markers["NUMBA_LEGACY_CACHE_UNEXPECTED_PATHS"] == "0"
+    assert markers["NUMBA_LEGACY_CACHE_RUNTIME_CACHE_TOUCHED"] == "no"
+
+
+def test_missing_active_venv_is_safe_noop_and_not_created(tmp_path: Path) -> None:
+    venv = tmp_path / "runtime/.venv"
+
+    result = _run(venv)
+    markers = _markers(result)
+
+    assert result.returncode == 0, result.stdout
+    assert not venv.exists()
+    assert markers["NUMBA_LEGACY_CACHE_CLEANUP_STATUS"] == "not_required"
+
+
+def test_sibling_venv_is_untouched(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    venv = _venv(runtime)
+    sibling = runtime / ".venv-drumsep-rocm/lib/python3.12/site-packages/librosa/core/__pycache__"
+    sibling.mkdir(parents=True)
+    cache = sibling / "sibling.nbc"
+    cache.write_bytes(b"sibling")
+
+    result = _run(venv)
+
+    assert result.returncode == 0, result.stdout
+    assert cache.read_bytes() == b"sibling"
+
+
+def test_non_numba_package_files_are_untouched(tmp_path: Path) -> None:
+    venv = _venv(tmp_path / "runtime")
+    core, _ = _allowlist_parents(venv)
+    dist_info = venv / "lib/python3.12/site-packages/librosa-1.0.dist-info/METADATA"
+    dist_info.parent.mkdir(parents=True)
+    files = {
+        core / "module.pyc": b"pyc",
+        core.parent / "module.py": b"source",
+        dist_info: b"metadata",
+    }
+    for path, content in files.items():
+        path.write_bytes(content)
+
+    result = _run(venv)
+
+    assert result.returncode == 0, result.stdout
+    assert all(path.read_bytes() == content for path, content in files.items())
+
+
+def test_status_vocabulary_is_exact() -> None:
+    helper = BOOTSTRAP.read_text(encoding="utf-8")
+
+    assert "NUMBA_LEGACY_CACHE_CLEANUP_STATUS" in helper
+    for value in STATUS_VALUES:
+        assert value in helper
+    assert "blocked_manifest_mismatch" not in helper
+
+
+def test_product_policy_contains_no_manifest_hash_or_fixed_count() -> None:
+    product = BOOTSTRAP.read_text(encoding="utf-8")
+
+    assert "numba-legacy-cache-manifest" not in product
+    assert "ALLOWLIST_EVIDENCE_FILE_COUNT" not in product
+    assert "LOCAL_EVIDENCE_MANIFEST" not in product
+    assert "sha256sum" not in product
+    assert "/home/flark" not in product
+
+
+def test_new_file_after_validation_is_not_silently_deleted(tmp_path: Path) -> None:
+    venv = _venv(tmp_path / "runtime")
+    core, _ = _allowlist_parents(venv)
+    original = core / "original.nbc"
+    appeared = core / "appeared.nbi"
+    original.write_bytes(b"original")
+    marker = tmp_path / "created"
+    env = _fake_rm(
+        tmp_path,
+        f'if [ ! -e "{marker}" ]; then : > "{marker}"; printf new > "{appeared}"; fi\n'
+        'exec /bin/rm "$@"\n',
+    )
+
+    result = _run(venv, env=env)
+    markers = _markers(result)
+
+    assert result.returncode != 0
+    assert not original.exists()
+    assert appeared.read_bytes() == b"new"
+    assert markers["NUMBA_LEGACY_CACHE_REMOVED"] == "1"
+    assert markers["NUMBA_LEGACY_CACHE_POSTCHECK_REMAINING"] == "1"
+    assert markers["NUMBA_LEGACY_CACHE_CLEANUP_STATUS"] == "failed"
+
+
+def test_bootstrap_runs_cleanup_only_for_repair_before_final_success() -> None:
+    script = BOOTSTRAP.read_text(encoding="utf-8")
+    call = 'if [ "${MODE}" = "repair" ] && [ -n "${VENV_PY}" ] && [ -x "${VENV_PY}" ]; then'
+
+    assert call in script
+    assert script.index(call) < script.index('log_step "Final verification"')
+    assert script.index(call) < script.index('log "Bootstrap finished successfully"')
+    assert "ready-to-go-verify" not in call
+
+
+def test_ready_to_go_metadata_probe_exits_before_cleanup_path() -> None:
+    script = BOOTSTRAP.read_text(encoding="utf-8")
+    probe = 'if [ "${MODE}" = "ready-to-go-verify" ]; then'
+    cleanup = 'if [ "${MODE}" = "repair" ] && [ -n "${VENV_PY}" ] && [ -x "${VENV_PY}" ]; then'
+
+    assert script.index(probe) < script.index(cleanup)
+    probe_body = script[script.index(probe) : script.index(cleanup)]
+    assert "exit 0" in probe_body
+
+
+def test_bootstrap_persists_cleanup_markers_in_state() -> None:
+    script = BOOTSTRAP.read_text(encoding="utf-8")
+
+    for marker in (
+        "NUMBA_LEGACY_CACHE_DETECTED",
+        "NUMBA_LEGACY_CACHE_REMOVED",
+        "NUMBA_LEGACY_CACHE_UNEXPECTED_PATHS",
+        "NUMBA_LEGACY_CACHE_ANOMALIES",
+        "NUMBA_LEGACY_CACHE_POSTCHECK_REMAINING",
+        "NUMBA_LEGACY_CACHE_NOT_REMOVED",
+        "NUMBA_LEGACY_CACHE_RUNTIME_CACHE_TOUCHED",
+        "NUMBA_LEGACY_CACHE_CLEANUP_STATUS",
+    ):
+        assert f'echo "{marker}=${{{marker}}}"' in script


### PR DESCRIPTION
## Background

Older Linux processing runs allowed Librosa/Numba JIT artifacts
to be written inside writable site-packages directories in the
production venv.

The cache-routing fix now sends new artifacts to
`<runtime-base>/cache/numba`, but existing legacy files require a
bounded Setup/Repair migration.

## Evidence-derived allowlist

Local evidence showed 46 legacy files across exactly two Librosa
cache parents. The local evidence manifest is validation-only and
is not included in product code or tests.

The product policy is class-based and supports arbitrary counts.

## Product policy

- no machine-specific manifest;
- no hashes or fixed expected count;
- only regular `.nbc`/`.nbi` files under the two validated
  Librosa cache parents in the active runtime venv;
- unknown `.nbc`/`.nbi` elsewhere are reported but preserved;
- anomalies inside the allowlist block all cleanup;
- partial technical removal is reported honestly;
- the controlled runtime cache is never touched.

## Status semantics

- `not_required`
- `removed`
- `partial_unexpected`
- `blocked_anomaly`
- `failed`

## Validation

- synthetic arbitrary-count fixtures;
- anomaly fail-closed tests;
- partial-unexpected tests;
- partial-removal reporting;
- runtimecache protection;
- sibling-venv protection;
- post-cleanup assert;
- Exact CI Fast;
- Linux bootstrap and release gates;
- production runtime untouched during development validation.

## Follow-up

After merge:

1. PR #96 will be updated only with main history.
2. Before Repair 1, the live local cache set will be compared
   against the existing 46-file evidence manifest.
3. A mismatch stops validation before Repair.
4. Repair 1 may perform exactly:
   - compatibility config legacy → canonical;
   - removal of the validated local legacy cache set.
5. Processing immutability and final Repair no-op will then be
   revalidated.