### PR TITLE
fix(linux): enforce transactional DrumSep runtime policy

### DIFF
--- a/docs/release/STEMwerk_2.4.0_RUNTIME_PAYLOAD_HANDOFF.md
+++ b/docs/release/STEMwerk_2.4.0_RUNTIME_PAYLOAD_HANDOFF.md
@@ -12,6 +12,16 @@ SOURCE_RELEASE_LINE=cancelled-2.3.0.5
 TARGET_RELEASE=2.4.0
 ```
 
+## Linux optional DrumSep runtime policy
+
+`DRUMSEP_OPTIONAL_RUNTIME_REPAIR_POLICY=preserve_only`
+
+Normal Linux Repair no longer creates or rebuilds the optional CPU or ROCm
+DrumSep sibling runtime. Setup can create an absent sibling through its explicit
+Drum Kit runtime action, and the same user-facing action is required to rebuild
+an existing consistent sibling. Missing, inconsistent, failed, or incomplete
+sibling state is reported without automatic mutation.
+
 Recommended local start branch:
 `feature/2.4-runtime-payload-unification`.
 

--- a/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
+++ b/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
@@ -242,26 +242,52 @@ PY
 ensure_drumsep_assets() {
   _py="$1"
   _model_dir="${2:-$(model_cache_dir)}"
-  [ -n "${_py}" ] && [ -x "${_py}" ] || return 1
-  mkdir -p "${_model_dir}" >/dev/null 2>&1 || return 1
-  copy_bundled_models_to_cache "${BUNDLED_PAYLOAD_DIR}/drumsep-models" "${_model_dir}" || return 1
+  [ -n "${_py}" ] && [ -x "${_py}" ] || return 20
+  mkdir -p "${_model_dir}" >/dev/null 2>&1 || return 20
+  copy_bundled_models_to_cache "${BUNDLED_PAYLOAD_DIR}/drumsep-models" "${_model_dir}" || return 20
   "${_py}" - <<PY >> "${LOG_FILE}" 2>&1
 import importlib.util
 from pathlib import Path
 
 script_path = Path(r"${SCRIPT_DIR}") / "audio_separator_process.py"
-spec = importlib.util.spec_from_file_location("stemwerk_audio_separator_process_ready", script_path)
-module = importlib.util.module_from_spec(spec)
-assert spec and spec.loader
-spec.loader.exec_module(module)
-ok, _requested, _resolved, detail = module._direct_dks_preflight_check(
-    module.DIRECT_DKS_MODEL_ALIAS,
-    Path(r"${_model_dir}"),
-)
+try:
+    spec = importlib.util.spec_from_file_location("stemwerk_audio_separator_process_ready", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("audio_separator_process_loader_missing")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+except Exception as exc:
+    print(f"DRUMSEP_ASSETS tooling_failure:{type(exc).__name__}:{exc}")
+    raise SystemExit(20)
+try:
+    ok, _requested, _resolved, detail = module._direct_dks_preflight_check(
+        module.DIRECT_DKS_MODEL_ALIAS,
+        Path(r"${_model_dir}"),
+    )
+except Exception as exc:
+    print(f"DRUMSEP_ASSETS unexpected_internal_failure:{type(exc).__name__}:{exc}")
+    raise SystemExit(22)
 if not ok:
-    raise SystemExit(str(detail or "drumsep_prefetch_failed"))
+    print(f"DRUMSEP_ASSETS model_assets_failure:{detail or 'drumsep_prefetch_failed'}")
+    raise SystemExit(21)
 print("STEMWERK_DRUMSEP_MODEL_PREFETCH ok")
 PY
+  _assets_rc=$?
+  case "${_assets_rc}" in
+    0|20|21|22) return "${_assets_rc}" ;;
+    *) return 22 ;;
+  esac
+}
+
+classify_drumsep_assets_result() {
+  case "${1:-22}" in
+    0) return 0 ;;
+    20) DRUMSEP_ASSETS_REASON="drumsep_assets_tooling_failed" ;;
+    21) DRUMSEP_ASSETS_REASON="drumsep_assets_model_failed" ;;
+    *) DRUMSEP_ASSETS_REASON="drumsep_assets_internal_failed" ;;
+  esac
+  set_status "deps_failed" "${DRUMSEP_ASSETS_REASON}"
+  return 1
 }
 
 write_ready_to_go_state() {
@@ -272,6 +298,10 @@ write_ready_to_go_state() {
   _main_runtime_status="${5:-ok}"
   _core_prefetch_status="${6:-${CORE_MODEL_PREFETCH_STATUS:-missing}}"
   _core_prefetch_detail="${7:-${CORE_MODEL_PREFETCH_DETAIL:-}}"
+  if [ "${DRUMSEP_INSTALL_TXN:-}" = "begin" ]; then
+    _runtime_status="incomplete"
+    _detail="drumsep_install_in_progress"
+  fi
   _out_file="$(ready_to_go_output_file)"
   _core="$(verify_core_model_cache)"
   _model_dir="$(printf "%s\n" "${_core}" | awk -F= '/^model_dir=/{print $2; exit}')"
@@ -319,7 +349,7 @@ write_ready_to_go_state() {
     echo "DRUMSEP_READY_RUNTIME=${_runtime_kind}"
     echo "DRUMSEP_READY_RUNTIME_STATUS=${_runtime_status}"
     echo "DRUMSEP_READY_MODEL_STATUS=${_drumsep_model_status}"
-  } > "${_out_file}"
+  } | atomic_write_state_file "${_out_file}"
   log_step "ready_to_go_state_file=${_out_file}"
   log_step "ready_to_go_state_written=1"
   log_step "ready_to_go_status=${_ready}"
@@ -406,7 +436,7 @@ probe_main_rocm_dks_ready() {
   _py="${1:-$(main_runtime_python)}"
   [ -x "${_py}" ] || {
     log_step "Main unified DKS probe failed: python_missing"
-    return 1
+    return 30
   }
   _probe="$("${_py}" - <<'PY' 2>/dev/null || true
 import importlib.metadata as metadata
@@ -468,11 +498,11 @@ PY
       ;;
     broken\|*)
       log_step "Main unified DKS probe failed: ${_probe#broken|}"
-      return 1
+      return 30
       ;;
     *)
       log_step "Main unified DKS probe failed: probe_failed"
-      return 1
+      return 31
       ;;
   esac
 }
@@ -486,17 +516,29 @@ main_dks_assets_ready() {
 load_ready_runtime_state() {
   _kind="${1:-cpu}"
   if [ "${_kind}" = "rocm" ] && [ -f "$(drumsep_rocm_state_file)" ]; then
+    DRUMSEP_INSTALL_TXN="$(awk -F= '/^DRUMSEP_ROCM_INSTALL_TXN=/{print $2; exit}' "$(drumsep_rocm_state_file)")"
     READY_RUNTIME_KIND="rocm"
     READY_RUNTIME_STATUS="$(awk -F= '/^DRUMSEP_ROCM_RUNTIME_STATUS=/{print $2; exit} /^STATUS=/{print $2; exit}' "$(drumsep_rocm_state_file)")"
     READY_DRUMSEP_MODEL_STATUS="$(awk -F= '/^DRUMSEP_ROCM_MODEL_STATUS=/{print $2; exit} /^DRUMSEP_MODEL_STATUS=/{print $2; exit}' "$(drumsep_rocm_state_file)")"
     READY_DETAIL="$(awk -F= '/^DRUMSEP_ROCM_RUNTIME_DETAIL=/{print $2; exit} /^STATUS_REASON=/{print $2; exit}' "$(drumsep_rocm_state_file)")"
+    if [ "${DRUMSEP_INSTALL_TXN}" = "begin" ]; then
+      READY_RUNTIME_STATUS="incomplete"
+      READY_DRUMSEP_MODEL_STATUS="missing"
+      READY_DETAIL="drumsep_install_in_progress"
+    fi
     return 0
   fi
   if [ -f "$(drumsep_state_file)" ]; then
+    DRUMSEP_INSTALL_TXN="$(awk -F= '/^DRUMSEP_CPU_INSTALL_TXN=/{print $2; exit}' "$(drumsep_state_file)")"
     READY_RUNTIME_KIND="cpu"
     READY_RUNTIME_STATUS="$(awk -F= '/^DRUMSEP_RUNTIME_STATUS=/{print $2; exit} /^STATUS=/{print $2; exit}' "$(drumsep_state_file)")"
     READY_DRUMSEP_MODEL_STATUS="$(awk -F= '/^DRUMSEP_MODEL_STATUS=/{print $2; exit}' "$(drumsep_state_file)")"
     READY_DETAIL="$(awk -F= '/^DRUMSEP_RUNTIME_DETAIL=/{print $2; exit} /^STATUS_REASON=/{print $2; exit}' "$(drumsep_state_file)")"
+    if [ "${DRUMSEP_INSTALL_TXN}" = "begin" ]; then
+      READY_RUNTIME_STATUS="incomplete"
+      READY_DRUMSEP_MODEL_STATUS="missing"
+      READY_DETAIL="drumsep_install_in_progress"
+    fi
     return 0
   fi
   return 1
@@ -504,6 +546,14 @@ load_ready_runtime_state() {
 
 verify_existing_ready_runtime() {
   _preferred="${1:-cpu}"
+  for _txn_kind in rocm cpu; do
+    DRUMSEP_INSTALL_TXN=""
+    if load_ready_runtime_state "${_txn_kind}" && [ "${DRUMSEP_INSTALL_TXN}" = "begin" ]; then
+      log_step "Open DrumSep install transaction dominates cached ready state: ${_txn_kind}"
+      return 1
+    fi
+  done
+  DRUMSEP_INSTALL_TXN=""
   if [ "${_preferred}" = "rocm" ]; then
     if probe_main_rocm_dks_ready "$(main_runtime_python)" && main_dks_assets_ready; then
       write_main_unified_rocm_state "ok"
@@ -629,11 +679,246 @@ drumsep_rocm_runtime_python() {
   printf "%s/.venv-drumsep-rocm/bin/python\n" "${RUNTIME_BASE}"
 }
 
+atomic_write_state_file() {
+  _atomic_target="$1"
+  _atomic_tmp="$(mktemp "${_atomic_target}.tmp.XXXXXX")" || return 1
+  if ! cat > "${_atomic_tmp}"; then
+    rm -f "${_atomic_tmp}"
+    return 1
+  fi
+  sync -f "${_atomic_tmp}" >/dev/null 2>&1 || true
+  if ! mv -f "${_atomic_tmp}" "${_atomic_target}"; then
+    rm -f "${_atomic_tmp}"
+    return 1
+  fi
+  sync -f "$(dirname "${_atomic_target}")" >/dev/null 2>&1 || true
+  return 0
+}
+
+drumsep_sibling_runtime_dir() {
+  case "${1:-cpu}" in
+    rocm) printf "%s/.venv-drumsep-rocm\n" "${RUNTIME_BASE}" ;;
+    *) printf "%s/.venv-drumsep\n" "${RUNTIME_BASE}" ;;
+  esac
+}
+
+drumsep_sibling_state_file() {
+  case "${1:-cpu}" in
+    rocm) drumsep_rocm_state_file ;;
+    *) drumsep_state_file ;;
+  esac
+}
+
+inspect_drumsep_sibling() {
+  _inspect_backend="${1:-cpu}"
+  _inspect_dir="$(drumsep_sibling_runtime_dir "${_inspect_backend}")"
+  _inspect_state="$(drumsep_sibling_state_file "${_inspect_backend}")"
+  DRUMSEP_SIBLING_PRESENT="absent"
+  # Presence is deliberately one non-recursive directory check. Runtime contents
+  # are never opened, inventoried, imported, or probed by this policy decision.
+  if [ -d "${_inspect_dir}" ]; then
+    DRUMSEP_SIBLING_PRESENT="present"
+  fi
+  DRUMSEP_SIBLING_RECORDED_STATE="missing-record"
+  DRUMSEP_INSTALL_TXN=""
+  if [ -f "${_inspect_state}" ]; then
+    case "${_inspect_backend}" in
+      rocm)
+        DRUMSEP_INSTALL_TXN="$(awk -F= '/^DRUMSEP_ROCM_INSTALL_TXN=/{print $2; exit}' "${_inspect_state}")"
+        _inspect_status="$(awk -F= '/^DRUMSEP_ROCM_RUNTIME_STATUS=/{print $2; exit} /^STATUS=/{print $2; exit}' "${_inspect_state}")"
+        ;;
+      *)
+        DRUMSEP_INSTALL_TXN="$(awk -F= '/^DRUMSEP_CPU_INSTALL_TXN=/{print $2; exit}' "${_inspect_state}")"
+        _inspect_status="$(awk -F= '/^DRUMSEP_RUNTIME_STATUS=/{print $2; exit} /^STATUS=/{print $2; exit}' "${_inspect_state}")"
+        ;;
+    esac
+    case "${DRUMSEP_INSTALL_TXN}" in
+      begin) DRUMSEP_SIBLING_RECORDED_STATE="incomplete" ;;
+      failed) DRUMSEP_SIBLING_RECORDED_STATE="failed" ;;
+      commit)
+        case "${_inspect_status}" in
+          ok|unified_main) DRUMSEP_SIBLING_RECORDED_STATE="ready" ;;
+          *) DRUMSEP_SIBLING_RECORDED_STATE="unknown" ;;
+        esac
+        ;;
+      *)
+        case "${_inspect_status}" in
+          ok|unified_main) DRUMSEP_SIBLING_RECORDED_STATE="ready" ;;
+          selected) DRUMSEP_SIBLING_RECORDED_STATE="selected" ;;
+          incomplete) DRUMSEP_SIBLING_RECORDED_STATE="incomplete" ;;
+          install_failed|failed|broken|deps_failed) DRUMSEP_SIBLING_RECORDED_STATE="failed" ;;
+          missing|"") DRUMSEP_SIBLING_RECORDED_STATE="missing-record" ;;
+          *) DRUMSEP_SIBLING_RECORDED_STATE="unknown" ;;
+        esac
+        ;;
+    esac
+  fi
+  DRUMSEP_SIBLING_CONSISTENCY="consistent"
+  if [ "${DRUMSEP_SIBLING_PRESENT}" = "present" ]; then
+    case "${DRUMSEP_SIBLING_RECORDED_STATE}" in
+      ready|selected|incomplete|failed) ;;
+      *) DRUMSEP_SIBLING_CONSISTENCY="inconsistent" ;;
+    esac
+  elif [ "${DRUMSEP_SIBLING_RECORDED_STATE}" != "missing-record" ]; then
+    DRUMSEP_SIBLING_CONSISTENCY="inconsistent"
+  fi
+  log_step "drumsep_sibling_backend=${_inspect_backend} presence=${DRUMSEP_SIBLING_PRESENT} recorded_state=${DRUMSEP_SIBLING_RECORDED_STATE} consistency=${DRUMSEP_SIBLING_CONSISTENCY}"
+}
+
+begin_drumsep_install_txn() {
+  _txn_backend="$1"
+  _txn_reason="$2"
+  _txn_state="$(drumsep_sibling_state_file "${_txn_backend}")"
+  case "${_txn_backend}" in
+    rocm) _txn_prefix="DRUMSEP_ROCM" ;;
+    *) _txn_prefix="DRUMSEP_CPU" ;;
+  esac
+  {
+    echo "${_txn_prefix}_INSTALL_TXN=begin"
+    echo "STATUS=incomplete"
+    echo "STATUS_REASON=drumsep_install_in_progress"
+    echo "${_txn_prefix}_MUTATION_REASON=${_txn_reason}"
+  } | atomic_write_state_file "${_txn_state}" || return 1
+  DRUMSEP_INSTALL_TXN="begin"
+  STATUS="incomplete"
+  STATUS_REASON="drumsep_install_in_progress"
+  log "DRUMSEP_INSTALL_TXN=begin backend=${_txn_backend} mutation_reason=${_txn_reason}"
+}
+
+fail_drumsep_install_txn() {
+  _txn_backend="$1"
+  _txn_reason="$2"
+  _txn_detail="${3:-drumsep_install_failed}"
+  _txn_state="$(drumsep_sibling_state_file "${_txn_backend}")"
+  case "${_txn_backend}" in
+    rocm) _txn_prefix="DRUMSEP_ROCM" ;;
+    *) _txn_prefix="DRUMSEP_CPU" ;;
+  esac
+  {
+    echo "${_txn_prefix}_INSTALL_TXN=failed"
+    echo "STATUS=failed"
+    echo "STATUS_REASON=${_txn_detail}"
+    echo "${_txn_prefix}_MUTATION_REASON=${_txn_reason}"
+  } | atomic_write_state_file "${_txn_state}" || true
+  DRUMSEP_INSTALL_TXN="failed"
+  STATUS="failed"
+  STATUS_REASON="${_txn_detail}"
+  log "DRUMSEP_INSTALL_TXN=failed backend=${_txn_backend} reason=${_txn_detail}"
+  return 1
+}
+
+commit_drumsep_install_txn() {
+  _txn_backend="$1"
+  _txn_reason="$2"
+  case "${_txn_backend}" in
+    rocm)
+      if ! write_drumsep_rocm_state "ok" "ok" "verified_ready" "$(drumsep_rocm_runtime_python)" "legacy_rocm" "present" "" "commit" "${_txn_reason}"; then
+        STATUS="failed"
+        STATUS_REASON="drumsep_state_commit_failed"
+        log "DRUMSEP_INSTALL_TXN=commit_failed backend=${_txn_backend}"
+        return 1
+      fi
+      ;;
+    *)
+      if ! write_drumsep_state "ok" "ok" "verified_ready" "$(drumsep_runtime_python)" "legacy_cpu" "commit" "${_txn_reason}"; then
+        STATUS="failed"
+        STATUS_REASON="drumsep_state_commit_failed"
+        log "DRUMSEP_INSTALL_TXN=commit_failed backend=${_txn_backend}"
+        return 1
+      fi
+      ;;
+  esac
+  DRUMSEP_INSTALL_TXN="commit"
+  STATUS="ok"
+  STATUS_REASON="verified_ready"
+  log "DRUMSEP_INSTALL_TXN=commit backend=${_txn_backend}"
+}
+
+run_drumsep_install_transaction() {
+  _txn_backend="$1"
+  _txn_reason="$2"
+  _txn_action="$3"
+  begin_drumsep_install_txn "${_txn_backend}" "${_txn_reason}" || return 1
+  if ! "${_txn_action}"; then
+    fail_drumsep_install_txn "${_txn_backend}" "${_txn_reason}" "${DRUMSEP_INSTALL_FAILURE_REASON:-drumsep_install_failed}"
+    return 1
+  fi
+  commit_drumsep_install_txn "${_txn_backend}" "${_txn_reason}"
+}
+
+apply_drumsep_sibling_policy() {
+  _policy_backend="${1:-cpu}"
+  inspect_drumsep_sibling "${_policy_backend}"
+  if [ "${DRUMSEP_SIBLING_CONSISTENCY}" != "consistent" ]; then
+    DRUMSEP_SIBLING_STATE="inconsistent"
+    set_status "deps_failed" "drumsep_sibling_state_inconsistent"
+    return 1
+  fi
+  _policy_explicit="no"
+  case "${_policy_backend}:${MODE}" in
+    cpu:drumsep-runtime|rocm:drumsep-rocm-runtime) _policy_explicit="yes" ;;
+  esac
+  if [ "${DRUMSEP_SIBLING_PRESENT}" = "absent" ]; then
+    if [ "${_policy_explicit}" != "yes" ]; then
+      DRUMSEP_SIBLING_STATE="absent_untouched"
+      log_step "Optional DrumSep sibling is missing; run the matching Drum Kit runtime action in Setup."
+      set_status "deps_failed" "drumsep_sibling_missing"
+      return 1
+    fi
+    DRUMSEP_MUTATION_REASON="create_absent"
+  else
+    if [ "${_policy_explicit}" != "yes" ]; then
+      DRUMSEP_SIBLING_STATE="present_untouched"
+      log_step "Optional DrumSep sibling needs an explicit rebuild; run the matching Drum Kit runtime action in Setup."
+      set_status "deps_failed" "drumsep_sibling_rebuild_required"
+      return 1
+    fi
+    DRUMSEP_MUTATION_REASON="rebuild_explicit"
+  fi
+  case "${_policy_backend}" in
+    rocm) install_drumsep_rocm_runtime ;;
+    *) install_drumsep_runtime ;;
+  esac
+}
+
+resolve_main_drumsep_runtime_policy() {
+  _policy_backend="${1:-cpu}"
+  case "${_policy_backend}" in
+    rocm)
+      probe_main_rocm_dks_ready "${VENV_PY:-$(main_runtime_python)}"
+      _probe_rc=$?
+      ;;
+    *) _probe_rc=30 ;;
+  esac
+  case "${_probe_rc}" in
+    0)
+      ensure_drumsep_assets "${VENV_PY:-$(main_runtime_python)}" "$(model_cache_dir)"
+      _assets_rc=$?
+      if ! classify_drumsep_assets_result "${_assets_rc}"; then
+        return 1
+      fi
+      case "${_policy_backend}" in
+        rocm) write_main_unified_rocm_state "ok" ;;
+        *) return 30 ;;
+      esac
+      return 0
+      ;;
+    30) apply_drumsep_sibling_policy "${_policy_backend}" ;;
+    *)
+      set_status "deps_failed" "drumsep_probe_error"
+      return 1
+      ;;
+  esac
+}
+
 write_drumsep_state() {
   _status="$1"
   _model_status="${2:-missing}"
   _detail="${3:-}"
-  _py="$(drumsep_runtime_python)"
+  _py="${4:-$(drumsep_runtime_python)}"
+  _selection="${5:-legacy_cpu}"
+  _install_txn="${6:-}"
+  _mutation_reason="${7:-}"
   _state="$(drumsep_state_file)"
   _model_dir="$(model_cache_dir)"
   _model_file="${_model_dir}/${DRUMSEP_MODEL_FILE}"
@@ -665,8 +950,11 @@ PY
   {
     echo "STATUS=${_status}"
     [ -n "${_detail}" ] && echo "STATUS_REASON=${_detail}"
+    [ -n "${_install_txn}" ] && echo "DRUMSEP_CPU_INSTALL_TXN=${_install_txn}"
+    [ -n "${_mutation_reason}" ] && echo "DRUMSEP_CPU_MUTATION_REASON=${_mutation_reason}"
     echo "DRUMSEP_RUNTIME_STATUS=${_status}"
     [ -n "${_detail}" ] && echo "DRUMSEP_RUNTIME_DETAIL=${_detail}"
+    echo "DRUMSEP_RUNTIME_SELECTION=${_selection}"
     echo "DRUMSEP_PYTHON=${_py}"
     if [ -n "${_versions}" ]; then
       printf "%s\n" "${_versions}"
@@ -683,7 +971,7 @@ PY
     echo "DRUMSEP_MODEL_STATUS=${_model_status}"
     echo "DRUMSEP_MODEL_FILE=${_model_file}"
     echo "DRUMSEP_MODEL_YAML=${_model_yaml}"
-  } > "${_state}"
+  } | atomic_write_state_file "${_state}"
 }
 
 write_drumsep_rocm_state() {
@@ -694,6 +982,8 @@ write_drumsep_rocm_state() {
   _selection="${5:-legacy_rocm}"
   _legacy_status="${6:-not_checked}"
   _legacy_install_skipped="${7:-}"
+  _install_txn="${8:-}"
+  _mutation_reason="${9:-}"
   _compat_status="${_status}"
   [ "${_status}" = "unified_main" ] && _compat_status="ok"
   _state="$(drumsep_rocm_state_file)"
@@ -763,6 +1053,8 @@ PY
   {
     echo "STATUS=${_compat_status}"
     [ -n "${_detail}" ] && echo "STATUS_REASON=${_detail}"
+    [ -n "${_install_txn}" ] && echo "DRUMSEP_ROCM_INSTALL_TXN=${_install_txn}"
+    [ -n "${_mutation_reason}" ] && echo "DRUMSEP_ROCM_MUTATION_REASON=${_mutation_reason}"
     echo "DRUMSEP_ROCM_RUNTIME_STATUS=${_status}"
     [ -n "${_detail}" ] && echo "DRUMSEP_ROCM_RUNTIME_DETAIL=${_detail}"
     echo "DRUMSEP_ROCM_RUNTIME_SELECTION=${_selection}"
@@ -787,15 +1079,13 @@ PY
     echo "DRUMSEP_ROCM_MODEL_FILE=${_model_file}"
     echo "DRUMSEP_ROCM_MODEL_YAML=${_model_yaml}"
     echo "DRUMSEP_ROCM_TEMP_DIR=${_tmp_dir}"
-  } > "${_state}"
+  } | atomic_write_state_file "${_state}"
 }
 
 write_main_unified_rocm_state() {
-  _legacy_status="missing"
-  [ -d "${RUNTIME_BASE}/.venv-drumsep-rocm" ] && _legacy_status="present"
   write_drumsep_rocm_state \
     "unified_main" "${1:-ok}" "main_unified_ready" \
-    "$(main_runtime_python)" "main_unified" "${_legacy_status}" "main_unified_ready"
+    "$(main_runtime_python)" "main_unified" "not_checked" "main_unified_ready"
   log_step "Legacy DrumSep ROCm install skipped: main_unified_ready"
 }
 
@@ -810,6 +1100,18 @@ write_state() {
     {
       echo "STATUS=${STATUS}"
       [ -n "${STATUS_REASON}" ] && echo "STATUS_REASON=${STATUS_REASON}"
+      if [ "${DRUMSEP_INSTALL_TXN:-}" = "begin" ]; then
+        case "${MODE}" in
+          drumsep-rocm-runtime)
+            echo "DRUMSEP_ROCM_INSTALL_TXN=begin"
+            echo "DRUMSEP_ROCM_MUTATION_REASON=${DRUMSEP_MUTATION_REASON:-unknown}"
+            ;;
+          drumsep-runtime)
+            echo "DRUMSEP_CPU_INSTALL_TXN=begin"
+            echo "DRUMSEP_CPU_MUTATION_REASON=${DRUMSEP_MUTATION_REASON:-unknown}"
+            ;;
+        esac
+      fi
       [ -n "${STEP_INDEX}" ] && echo "STEP_INDEX=${STEP_INDEX}"
       [ -n "${STEP_TOTAL}" ] && echo "STEP_TOTAL=${STEP_TOTAL}"
       [ -n "${STEP_LABEL}" ] && echo "STEP_LABEL=${STEP_LABEL}"
@@ -865,7 +1167,7 @@ write_state() {
       echo "NUMBA_LEGACY_CACHE_CLEANUP_STATUS=${NUMBA_LEGACY_CACHE_CLEANUP_STATUS}"
       [ -n "${STEMWERK_INSTALLER:-}" ] && echo "INSTALLER=1"
       [ -n "${RUNTIME_BASE}" ] && echo "RUNTIME_BASE=${RUNTIME_BASE}"
-    } > "${STATE_FILE}"
+    } | atomic_write_state_file "${STATE_FILE}"
   fi
 }
 
@@ -1389,12 +1691,14 @@ PY
 }
 
 verify_drumsep_runtime() {
+  DRUMSEP_VERIFY_DETAIL=""
   _py="$(drumsep_runtime_python)"
   _model_dir="$(model_cache_dir)"
   _model_file="${_model_dir}/${DRUMSEP_MODEL_FILE}"
   _model_yaml="${_model_dir}/${DRUMSEP_MODEL_YAML}"
   if [ ! -x "${_py}" ]; then
-    write_drumsep_state "missing" "missing" "python_missing"
+    DRUMSEP_VERIFY_DETAIL="python_missing"
+    [ "${DRUMSEP_INSTALL_TXN:-}" = "begin" ] || write_drumsep_state "missing" "missing" "${DRUMSEP_VERIFY_DETAIL}"
     return 1
   fi
   "${_py}" - <<PY >> "$(drumsep_log_file)" 2>&1
@@ -1456,19 +1760,23 @@ PY
   _rc=$?
   case "${_rc}" in
     0)
-      write_drumsep_state "ok" "ok" "ok"
+      DRUMSEP_VERIFY_DETAIL="verified_ready"
+      [ "${DRUMSEP_INSTALL_TXN:-}" = "begin" ] || write_drumsep_state "ok" "ok" "ok"
       return 0
       ;;
     2)
-      write_drumsep_state "model_missing" "missing" "model_missing"
+      DRUMSEP_VERIFY_DETAIL="model_missing"
+      [ "${DRUMSEP_INSTALL_TXN:-}" = "begin" ] || write_drumsep_state "model_missing" "missing" "${DRUMSEP_VERIFY_DETAIL}"
       return 1
       ;;
     3)
-      write_drumsep_state "broken" "load_failed" "model_load_failed"
+      DRUMSEP_VERIFY_DETAIL="model_load_failed"
+      [ "${DRUMSEP_INSTALL_TXN:-}" = "begin" ] || write_drumsep_state "broken" "load_failed" "${DRUMSEP_VERIFY_DETAIL}"
       return 1
       ;;
     *)
-      write_drumsep_state "broken" "missing" "verify_failed"
+      DRUMSEP_VERIFY_DETAIL="verify_failed"
+      [ "${DRUMSEP_INSTALL_TXN:-}" = "begin" ] || write_drumsep_state "broken" "missing" "${DRUMSEP_VERIFY_DETAIL}"
       return 1
       ;;
   esac
@@ -1527,12 +1835,14 @@ drumsep_rocm_disk_preflight() {
 }
 
 verify_drumsep_rocm_runtime() {
+  DRUMSEP_VERIFY_DETAIL=""
   _py="$(drumsep_rocm_runtime_python)"
   _model_dir="$(model_cache_dir)"
   _model_file="${_model_dir}/${DRUMSEP_MODEL_FILE}"
   _model_yaml="${_model_dir}/${DRUMSEP_MODEL_YAML}"
   if [ ! -x "${_py}" ]; then
-    write_drumsep_rocm_state "missing" "missing" "python_missing"
+    DRUMSEP_VERIFY_DETAIL="python_missing"
+    [ "${DRUMSEP_INSTALL_TXN:-}" = "begin" ] || write_drumsep_rocm_state "missing" "missing" "${DRUMSEP_VERIFY_DETAIL}"
     return 1
   fi
   "${_py}" - <<PY >> "$(drumsep_rocm_log_file)" 2>&1
@@ -1621,25 +1931,29 @@ PY
   _rc=$?
   case "${_rc}" in
     0)
-      write_drumsep_rocm_state "ok" "ok" "ok"
+      DRUMSEP_VERIFY_DETAIL="verified_ready"
+      [ "${DRUMSEP_INSTALL_TXN:-}" = "begin" ] || write_drumsep_rocm_state "ok" "ok" "ok"
       return 0
       ;;
     2)
-      write_drumsep_rocm_state "model_missing" "missing" "model_missing"
+      DRUMSEP_VERIFY_DETAIL="model_missing"
+      [ "${DRUMSEP_INSTALL_TXN:-}" = "begin" ] || write_drumsep_rocm_state "model_missing" "missing" "${DRUMSEP_VERIFY_DETAIL}"
       return 1
       ;;
     3)
-      write_drumsep_rocm_state "broken" "load_failed" "model_load_failed"
+      DRUMSEP_VERIFY_DETAIL="model_load_failed"
+      [ "${DRUMSEP_INSTALL_TXN:-}" = "begin" ] || write_drumsep_rocm_state "broken" "load_failed" "${DRUMSEP_VERIFY_DETAIL}"
       return 1
       ;;
     *)
-      write_drumsep_rocm_state "broken" "missing" "verify_failed"
+      DRUMSEP_VERIFY_DETAIL="verify_failed"
+      [ "${DRUMSEP_INSTALL_TXN:-}" = "begin" ] || write_drumsep_rocm_state "broken" "missing" "${DRUMSEP_VERIFY_DETAIL}"
       return 1
       ;;
   esac
 }
 
-install_drumsep_rocm_runtime() {
+install_drumsep_rocm_runtime_body() {
   _log="$(drumsep_rocm_log_file)"
   _py="$(drumsep_rocm_runtime_python)"
   : > "${_log}" || true
@@ -1647,19 +1961,9 @@ install_drumsep_rocm_runtime() {
   log_step "DrumSep ROCm runtime path: ${RUNTIME_BASE}/.venv-drumsep-rocm"
   log_step "DrumSep ROCm install log: ${_log}"
 
-  # Repair path: if runtime already exists and verifies, succeed without reinstall.
-  if [ -x "${_py}" ]; then
-    log_step "Existing DrumSep ROCm runtime detected; running verification before reinstall"
-    if verify_drumsep_rocm_runtime; then
-      log_step "Existing DrumSep ROCm runtime verified; skipping reinstall"
-      return 0
-    fi
-    log_step "Existing DrumSep ROCm runtime failed verification; rebuilding"
-  fi
-
   if ! drumsep_rocm_disk_preflight; then
     log_step "ROCm preflight failed: ${DRUMSEP_ROCM_PREFLIGHT_DETAIL:-unknown}"
-    write_drumsep_rocm_state "disk_space_insufficient" "missing" "${DRUMSEP_ROCM_PREFLIGHT_DETAIL:-disk_space_insufficient}"
+    DRUMSEP_INSTALL_FAILURE_REASON="${DRUMSEP_ROCM_PREFLIGHT_DETAIL:-disk_space_insufficient}"
     return 1
   fi
   log_step "ROCm temp dir selected: ${DRUMSEP_ROCM_TMPDIR}"
@@ -1670,17 +1974,17 @@ install_drumsep_rocm_runtime() {
   set_progress "1" "${STEP_TOTAL}" "Creating DrumSep ROCm runtime"
   rm -rf "${RUNTIME_BASE}/.venv-drumsep-rocm"
   if ! "${PYTHON}" -m venv "${RUNTIME_BASE}/.venv-drumsep-rocm" >> "${_log}" 2>&1; then
-    write_drumsep_rocm_state "install_failed" "missing" "venv_create_failed"
+    DRUMSEP_INSTALL_FAILURE_REASON="venv_create_failed"
     return 1
   fi
   if [ ! -x "${_py}" ]; then
-    write_drumsep_rocm_state "install_failed" "missing" "python_missing_after_create"
+    DRUMSEP_INSTALL_FAILURE_REASON="python_missing_after_create"
     return 1
   fi
 
   set_progress "2" "${STEP_TOTAL}" "Upgrading ROCm runtime pip"
   if ! pip_install_with_scope drumsep "${_py}" --no-cache-dir --upgrade pip setuptools wheel >> "${_log}" 2>&1; then
-    write_drumsep_rocm_state "install_failed" "missing" "pip_upgrade_failed"
+    DRUMSEP_INSTALL_FAILURE_REASON="pip_upgrade_failed"
     return 1
   fi
 
@@ -1689,14 +1993,14 @@ install_drumsep_rocm_runtime() {
     "torch==${DRUMSEP_ACTIVE_ROCM_TORCH_VERSION}" \
     "torchvision==${DRUMSEP_ACTIVE_ROCM_TORCHVISION_VERSION}" \
     "torchaudio==${DRUMSEP_ACTIVE_ROCM_TORCHAUDIO_VERSION}" >> "${_log}" 2>&1; then
-    write_drumsep_rocm_state "install_failed" "missing" "rocm_torch_install_failed"
+    DRUMSEP_INSTALL_FAILURE_REASON="rocm_torch_install_failed"
     return 1
   fi
 
   set_progress "4" "${STEP_TOTAL}" "Installing DrumSep packages"
   if ! pip_install_with_scope drumsep "${_py}" --no-cache-dir --no-deps \
     "audio-separator==${DRUMSEP_AUDIO_SEPARATOR_VERSION}" >> "${_log}" 2>&1; then
-    write_drumsep_rocm_state "install_failed" "missing" "audio_separator_install_failed"
+    DRUMSEP_INSTALL_FAILURE_REASON="audio_separator_install_failed"
     return 1
   fi
   if ! pip_install_with_scope drumsep "${_py}" --no-cache-dir \
@@ -1710,27 +2014,36 @@ install_drumsep_rocm_runtime() {
     "librosa==0.11.0" "ml_collections==1.1.0" "pydub==0.25.1" "pyyaml==6.0.3" \
     "requests==2.34.2" "resampy==0.4.3" "rotary-embedding-torch==0.6.5" \
     "samplerate==0.1.0" "scipy==1.17.1" "six==1.17.0" "tqdm==4.67.3" >> "${_log}" 2>&1; then
-    write_drumsep_rocm_state "install_failed" "missing" "package_install_failed"
+    DRUMSEP_INSTALL_FAILURE_REASON="package_install_failed"
     return 1
   fi
   if ! "${_py}" -m pip check >> "${_log}" 2>&1; then
-    write_drumsep_rocm_state "install_failed" "missing" "pip_check_failed"
+    DRUMSEP_INSTALL_FAILURE_REASON="pip_check_failed"
     return 1
   fi
 
   set_progress "5" "${STEP_TOTAL}" "Verifying DrumSep ROCm runtime"
-  if ! ensure_drumsep_assets "${_py}" "$(model_cache_dir)"; then
-    write_drumsep_rocm_state "install_failed" "missing" "model_download_failed"
+  ensure_drumsep_assets "${_py}" "$(model_cache_dir)"
+  _assets_rc=$?
+  if [ "${_assets_rc}" -ne 0 ]; then
+    classify_drumsep_assets_result "${_assets_rc}" || true
+    DRUMSEP_INSTALL_FAILURE_REASON="${DRUMSEP_ASSETS_REASON:-drumsep_assets_internal_failed}"
     return 1
   fi
   if ! verify_drumsep_rocm_runtime; then
+    DRUMSEP_INSTALL_FAILURE_REASON="${DRUMSEP_VERIFY_DETAIL:-verify_failed}"
     return 1
   fi
   log_step "DrumSep ROCm runtime verification complete"
   return 0
 }
 
-install_drumsep_runtime() {
+install_drumsep_rocm_runtime() {
+  DRUMSEP_INSTALL_FAILURE_REASON=""
+  run_drumsep_install_transaction "rocm" "${DRUMSEP_MUTATION_REASON:-rebuild_explicit}" install_drumsep_rocm_runtime_body
+}
+
+install_drumsep_runtime_body() {
   _drumsep_log="$(drumsep_log_file)"
   _drumsep_py="$(drumsep_runtime_python)"
   _drumsep_step_total="4"
@@ -1738,29 +2051,21 @@ install_drumsep_runtime() {
   log_stage "Installing optional DrumSep runtime"
   log_step "DrumSep runtime path: ${RUNTIME_BASE}/.venv-drumsep"
   log_step "DrumSep install log: ${_drumsep_log}"
-  if [ -x "${_drumsep_py}" ]; then
-    log_step "Existing DrumSep runtime detected; running verification before reinstall"
-    if verify_drumsep_runtime; then
-      log_step "Existing DrumSep runtime verified; skipping reinstall"
-      return 0
-    fi
-    log_step "Existing DrumSep runtime failed verification; rebuilding"
-  fi
   clear_drumsep_substep_state
   set_drumsep_substep_progress "1" "${_drumsep_step_total}" "Creating DrumSep runtime"
   rm -rf "${RUNTIME_BASE}/.venv-drumsep"
   if ! "${PYTHON}" -m venv "${RUNTIME_BASE}/.venv-drumsep" >> "${_drumsep_log}" 2>&1; then
-    write_drumsep_state "install_failed" "missing" "venv_create_failed"
+    DRUMSEP_INSTALL_FAILURE_REASON="venv_create_failed"
     return 1
   fi
   if [ ! -x "${_drumsep_py}" ]; then
-    write_drumsep_state "install_failed" "missing" "python_missing_after_create"
+    DRUMSEP_INSTALL_FAILURE_REASON="python_missing_after_create"
     return 1
   fi
 
   set_drumsep_substep_progress "2" "${_drumsep_step_total}" "Upgrading DrumSep pip"
   if ! pip_install_with_scope drumsep "${_drumsep_py}" --upgrade pip setuptools wheel >> "${_drumsep_log}" 2>&1; then
-    write_drumsep_state "install_failed" "missing" "pip_upgrade_failed"
+    DRUMSEP_INSTALL_FAILURE_REASON="pip_upgrade_failed"
     return 1
   fi
 
@@ -1775,20 +2080,29 @@ install_drumsep_runtime() {
     "torch==${DRUMSEP_TORCH_VERSION}" \
     "torchvision==${DRUMSEP_TORCHVISION_VERSION}" \
     "numba==${DRUMSEP_NUMBA_VERSION}" >> "${_drumsep_log}" 2>&1; then
-    write_drumsep_state "install_failed" "missing" "package_install_failed"
+    DRUMSEP_INSTALL_FAILURE_REASON="package_install_failed"
     return 1
   fi
 
   set_drumsep_substep_progress "4" "${_drumsep_step_total}" "Verifying DrumSep runtime"
-  if ! ensure_drumsep_assets "${_drumsep_py}" "$(model_cache_dir)"; then
-    write_drumsep_state "install_failed" "missing" "model_download_failed"
+  ensure_drumsep_assets "${_drumsep_py}" "$(model_cache_dir)"
+  _assets_rc=$?
+  if [ "${_assets_rc}" -ne 0 ]; then
+    classify_drumsep_assets_result "${_assets_rc}" || true
+    DRUMSEP_INSTALL_FAILURE_REASON="${DRUMSEP_ASSETS_REASON:-drumsep_assets_internal_failed}"
     return 1
   fi
   if ! verify_drumsep_runtime; then
+    DRUMSEP_INSTALL_FAILURE_REASON="${DRUMSEP_VERIFY_DETAIL:-verify_failed}"
     return 1
   fi
   log_step "DrumSep runtime verification complete"
   return 0
+}
+
+install_drumsep_runtime() {
+  DRUMSEP_INSTALL_FAILURE_REASON=""
+  run_drumsep_install_transaction "cpu" "${DRUMSEP_MUTATION_REASON:-rebuild_explicit}" install_drumsep_runtime_body
 }
 
 resolve_core_target() {
@@ -2579,20 +2893,14 @@ if [ -z "${PYTHON}" ]; then
   fi
 else
   if [ "${MODE}" = "drumsep-runtime" ]; then
-    if install_drumsep_runtime; then
-      STATUS="ok"
-      STATUS_REASON=""
-      write_drumsep_state "ok" "ok" "ok"
+    if apply_drumsep_sibling_policy "cpu"; then
       log_stage "DrumSep runtime install finished"
       exit 0
     fi
     log "DrumSep runtime install failed"
     exit 1
   elif [ "${MODE}" = "drumsep-rocm-runtime" ]; then
-    if install_drumsep_rocm_runtime; then
-      STATUS="ok"
-      STATUS_REASON=""
-      write_drumsep_rocm_state "ok" "ok" "ok"
+    if apply_drumsep_sibling_policy "rocm"; then
       log_stage "DrumSep ROCm runtime install finished"
       exit 0
     fi
@@ -3409,18 +3717,10 @@ fi
 if [ "${STATUS}" = "ok" ] && [ "${FINAL_OK}" -eq 1 ] && [ -n "${VENV_PY}" ] && [ -x "${VENV_PY}" ]; then
   if [ "${BACKEND}" = "rocm" ]; then
     READY_RUNTIME_KIND="rocm"
-    if probe_main_rocm_dks_ready "${VENV_PY}" && ensure_drumsep_assets "${VENV_PY}" "$(model_cache_dir)"; then
-      write_main_unified_rocm_state "ok"
-    else
-      if ! install_drumsep_rocm_runtime; then
-        set_status "deps_failed" "drumsep_ready_runtime_failed"
-      fi
-    fi
+    resolve_main_drumsep_runtime_policy "rocm" || true
   else
     READY_RUNTIME_KIND="cpu"
-    if ! install_drumsep_runtime; then
-      set_status "deps_failed" "drumsep_ready_runtime_failed"
-    fi
+    resolve_main_drumsep_runtime_policy "cpu" || true
   fi
 fi
 if [ "${READY_RUNTIME_KIND}" = "rocm" ] && [ -f "$(drumsep_rocm_state_file)" ]; then
@@ -3433,8 +3733,14 @@ fi
 if [ -z "${READY_RUNTIME_STATUS}" ]; then READY_RUNTIME_STATUS="missing"; fi
 if [ -z "${READY_DRUMSEP_MODEL_STATUS}" ]; then READY_DRUMSEP_MODEL_STATUS="missing"; fi
 if [ -z "${READY_DETAIL}" ]; then READY_DETAIL="${STATUS_REASON}"; fi
+READY_MAIN_RUNTIME_STATUS="ok"
+if [ "${STATUS}" != "ok" ]; then
+  READY_RUNTIME_STATUS="broken"
+  READY_DETAIL="${STATUS_REASON}"
+  READY_MAIN_RUNTIME_STATUS="broken"
+fi
 READY_STATE_FILE="$(ready_to_go_output_file)"
-write_ready_to_go_state "${READY_RUNTIME_KIND}" "${READY_RUNTIME_STATUS}" "${READY_DRUMSEP_MODEL_STATUS}" "${READY_DETAIL}" "ok" "${CORE_MODEL_PREFETCH_STATUS}" "${CORE_MODEL_PREFETCH_DETAIL}"
+write_ready_to_go_state "${READY_RUNTIME_KIND}" "${READY_RUNTIME_STATUS}" "${READY_DRUMSEP_MODEL_STATUS}" "${READY_DETAIL}" "${READY_MAIN_RUNTIME_STATUS}" "${CORE_MODEL_PREFETCH_STATUS}" "${CORE_MODEL_PREFETCH_DETAIL}"
 
 if [ -n "${STATE_FILE}" ] && [ "${STATE_FILE}" = "${READY_STATE_FILE}" ]; then
   log_step "ready_to_go_state_persists_in_state_file=1"

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -823,7 +823,9 @@ def test_linux_cuda_drumsep_path_uses_shared_five_step_setup_and_stays_out_of_ro
     bootstrap = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
     launcher = Path("scripts/reaper/STEMwerk_Bootstrap_Linux_Launcher.sh").read_text()
     setup_internal = Path("scripts/reaper/_internal/STEMwerk_Setup_Internal.lua").read_text()
-    drumsep_install = bootstrap.split("install_drumsep_runtime() {", 1)[1].split("\n\nresolve_core_target()", 1)[0]
+    drumsep_install = bootstrap.split("install_drumsep_runtime_body() {", 1)[1].split(
+        "\n\ninstall_drumsep_runtime() {", 1
+    )[0]
 
     assert 'STEP_TOTAL="5"' in bootstrap
     assert 'set_status "running" "launcher_started" "1" "5" "Launching bootstrap"' in launcher
@@ -4791,7 +4793,8 @@ def test_linux_drumsep_rocm_runtime_installer_has_disk_preflight_and_rocm_pins()
     assert 'DRUMSEP_ROCM_MIN_FREE_GB="20"' in script
     assert "drumsep_rocm_disk_preflight()" in script
     assert "resolve_drumsep_rocm_tmpdir()" in script
-    assert 'write_drumsep_rocm_state "disk_space_insufficient" "missing"' in script
+    assert 'DRUMSEP_INSTALL_FAILURE_REASON="${DRUMSEP_ROCM_PREFLIGHT_DETAIL:-disk_space_insufficient}"' in script
+    assert 'run_drumsep_install_transaction "rocm"' in script
     assert 'select_drumsep_rocm_torch_stack() {' in script
     assert 'pip_install_with_scope drumsep "${_py}" --no-cache-dir --index-url "${DRUMSEP_ACTIVE_ROCM_TORCH_INDEX_URL}"' in script
     assert '"torch==${DRUMSEP_ACTIVE_ROCM_TORCH_VERSION}"' in script
@@ -4831,7 +4834,11 @@ def test_linux_rocm_repair_skips_legacy_runtime_when_main_unified_is_ready():
     assert "probe_main_rocm_dks_ready()" in script
     assert 'metadata.version("audio-separator")' in script
     assert 'metadata.version("numpy")' in script
-    assert 'if probe_main_rocm_dks_ready "${VENV_PY}" && ensure_drumsep_assets' in script
+    resolver = script.split("resolve_main_drumsep_runtime_policy() {", 1)[1].split(
+        "write_drumsep_state() {", 1
+    )[0]
+    assert 'probe_main_rocm_dks_ready "${VENV_PY:-$(main_runtime_python)}"' in resolver
+    assert 'ensure_drumsep_assets "${VENV_PY:-$(main_runtime_python)}"' in resolver
     assert 'write_main_unified_rocm_state "ok"' in script
     assert 'log_step "Legacy DrumSep ROCm install skipped: main_unified_ready"' in script
 
@@ -4846,30 +4853,31 @@ def test_linux_rocm_unified_state_records_selection_and_legacy_skip_reason():
         'echo "DRUMSEP_ROCM_LEGACY_RUNTIME_STATUS=${_legacy_status}"',
         'echo "DRUMSEP_ROCM_LEGACY_INSTALL_SKIPPED=${_legacy_install_skipped}"',
         '"unified_main" "${1:-ok}" "main_unified_ready"',
-        '"$(main_runtime_python)" "main_unified" "${_legacy_status}" "main_unified_ready"',
+        '"$(main_runtime_python)" "main_unified" "not_checked" "main_unified_ready"',
     ):
         assert marker in script
     assert 'ok|skipped|unified_main)' in script
 
 
-def test_linux_rocm_repair_preserves_legacy_fallback_when_main_is_not_ready():
+def test_linux_rocm_repair_preserves_sibling_when_main_is_not_ready():
     script = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
     automatic_guard = script.split('READY_DETAIL="${STATUS_REASON}"', 1)[1].split(
         'if [ "${READY_RUNTIME_KIND}" = "rocm" ]', 1
     )[0]
 
-    assert 'if probe_main_rocm_dks_ready "${VENV_PY}" && ensure_drumsep_assets' in automatic_guard
-    assert 'if ! install_drumsep_rocm_runtime; then' in automatic_guard
-    assert 'set_status "deps_failed" "drumsep_ready_runtime_failed"' in automatic_guard
+    assert 'resolve_main_drumsep_runtime_policy "rocm" || true' in automatic_guard
+    assert 'install_drumsep_rocm_runtime' not in automatic_guard
+    assert 'set_status "deps_failed" "drumsep_sibling_rebuild_required"' in script
+    assert 'set_status "deps_failed" "drumsep_sibling_missing"' in script
     assert 'elif [ "${MODE}" = "drumsep-rocm-runtime" ]; then' in script
-    assert 'if install_drumsep_rocm_runtime; then' in script
+    assert 'if apply_drumsep_sibling_policy "rocm"; then' in script
 
 
 def test_linux_rocm_unified_guard_never_deletes_legacy_runtime():
     script = Path("scripts/reaper/STEMwerk_Bootstrap_Linux.sh").read_text()
     unified_writer = script.split("write_main_unified_rocm_state()", 1)[1].split("write_state()", 1)[0]
 
-    assert ".venv-drumsep-rocm" in unified_writer
+    assert ".venv-drumsep-rocm" not in unified_writer
     assert "rm -rf" not in unified_writer
     assert "rmdir" not in unified_writer
     assert "delete" not in unified_writer.lower()
@@ -7834,10 +7842,10 @@ def test_ready_to_go_state_is_wired_across_bootstraps_setup_and_support_bundle()
     assert 'CORE_MODEL_PREFETCH_STATUS="skipped"' in linux_bootstrap
     assert 'log_step "core_model_prefetch_skipped=${CORE_MODEL_PREFETCH_DETAIL}"' in linux_bootstrap
     assert 'set_status "deps_failed" "core_model_prefetch_failed"' not in linux_bootstrap
-    assert 'set_status "deps_failed" "drumsep_ready_runtime_failed"' in linux_bootstrap
+    assert 'set_status "deps_failed" "drumsep_sibling_rebuild_required"' in linux_bootstrap
     assert 'echo "MAIN_RUNTIME_STATUS=${_main_runtime_status}"' in linux_bootstrap
     assert 'echo "CORE_MODEL_PREFETCH_STATUS=${_core_prefetch_status}"' in linux_bootstrap
-    assert 'write_ready_to_go_state "${READY_RUNTIME_KIND}" "${READY_RUNTIME_STATUS}" "${READY_DRUMSEP_MODEL_STATUS}" "${READY_DETAIL}" "ok" "${CORE_MODEL_PREFETCH_STATUS}" "${CORE_MODEL_PREFETCH_DETAIL}"' in linux_bootstrap
+    assert 'write_ready_to_go_state "${READY_RUNTIME_KIND}" "${READY_RUNTIME_STATUS}" "${READY_DRUMSEP_MODEL_STATUS}" "${READY_DETAIL}" "${READY_MAIN_RUNTIME_STATUS}" "${CORE_MODEL_PREFETCH_STATUS}" "${CORE_MODEL_PREFETCH_DETAIL}"' in linux_bootstrap
 
     assert "ready_to_go_state_file()" in macos_bootstrap
     assert "ensure_core_model_cache" in macos_bootstrap
@@ -7907,8 +7915,9 @@ def test_linux_ready_to_go_verify_mode_is_non_destructive_and_reuses_existing_ru
     assert 'STATE_FILE=""' in linux_bootstrap
     assert 'verify_existing_ready_runtime "${READY_BACKEND}" || true' in linux_bootstrap
     assert 'probe_main_runtime_ready "$(main_runtime_python)" "${BACKEND}"' in linux_bootstrap
-    assert 'log_step "Existing DrumSep runtime detected; running verification before reinstall"' in linux_bootstrap
-    assert 'log_step "Existing DrumSep ROCm runtime detected; running verification before reinstall"' in linux_bootstrap
+    assert 'log_step "Open DrumSep install transaction dominates cached ready state: ${_txn_kind}"' in linux_bootstrap
+    assert 'log_step "Existing DrumSep runtime detected; running verification before reinstall"' not in linux_bootstrap
+    assert 'log_step "Existing DrumSep ROCm runtime detected; running verification before reinstall"' not in linux_bootstrap
     assert 'MODE="ready-to-go-verify"' not in linux_bootstrap
     assert 'if [ -n "${STATE_FILE}" ] && [ "${STATE_FILE}" != "${READY_STATE_FILE}" ]; then' in linux_bootstrap
     assert linux_bootstrap.index('write_ready_to_go_state "${READY_RUNTIME_KIND}" "${READY_RUNTIME_STATUS}" "${READY_DRUMSEP_MODEL_STATUS}" "${READY_DETAIL}" "${MAIN_READY_STATUS}"') < linux_bootstrap.index('if [ -n "${STATE_FILE}" ] && [ "${STATE_FILE}" = "${READY_STATE_FILE}" ]; then')

--- a/tests/test_linux_drumsep_runtime_policy.py
+++ b/tests/test_linux_drumsep_runtime_policy.py
@@ -1,0 +1,477 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BOOTSTRAP = ROOT / "scripts/reaper/STEMwerk_Bootstrap_Linux.sh"
+
+
+def _script() -> str:
+    return BOOTSTRAP.read_text(encoding="utf-8")
+
+
+def _function(script: str, name: str) -> str:
+    start = script.index(f"{name}() {{")
+    depth = 0
+    for index in range(start, len(script)):
+        if script[index] == "{":
+            depth += 1
+        elif script[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return script[start : index + 1]
+    raise AssertionError(f"unterminated shell function: {name}")
+
+
+def _run_policy_harness(tmp_path: Path, body: str) -> subprocess.CompletedProcess[str]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    script = _script()
+    names = (
+        "atomic_write_state_file",
+        "classify_drumsep_assets_result",
+        "drumsep_state_file",
+        "drumsep_rocm_state_file",
+        "drumsep_sibling_runtime_dir",
+        "drumsep_sibling_state_file",
+        "inspect_drumsep_sibling",
+        "begin_drumsep_install_txn",
+        "fail_drumsep_install_txn",
+        "commit_drumsep_install_txn",
+        "run_drumsep_install_transaction",
+        "apply_drumsep_sibling_policy",
+        "resolve_main_drumsep_runtime_policy",
+    )
+    functions = "\n\n".join(_function(script, name) for name in names)
+    harness = tmp_path / "policy-harness.sh"
+    harness.write_text(
+        "#!/bin/sh\nset -u\n"
+        f'RUNTIME_BASE="{tmp_path / "runtime"}"\n'
+        f'LOG_FILE="{tmp_path / "policy.log"}"\n'
+        'STATUS="ok"\nSTATUS_REASON=""\nMODE="repair"\n'
+        "log() { printf '%s\\n' \"$*\" >> \"${LOG_FILE}\"; }\n"
+        "log_step() { log \" - $*\"; }\n"
+        "set_status() { STATUS=\"$1\"; STATUS_REASON=\"$2\"; log \"STATUS=${STATUS} REASON=${STATUS_REASON}\"; }\n"
+        "write_main_unified_rocm_state() { log 'main_unified_state=written'; }\n"
+        "write_main_unified_cpu_state() { log 'main_unified_cpu_state=written'; }\n"
+        "install_drumsep_rocm_runtime() { log 'INSTALL_ROCM_CALLED'; return 0; }\n"
+        "install_drumsep_runtime() { log 'INSTALL_CPU_CALLED'; return 0; }\n"
+        f"{functions}\n"
+        "write_drumsep_rocm_state() { { echo STATUS=ok; echo STATUS_REASON=verified_ready; echo DRUMSEP_ROCM_INSTALL_TXN=\"$8\"; echo DRUMSEP_ROCM_MUTATION_REASON=\"$9\"; } | atomic_write_state_file \"$(drumsep_rocm_state_file)\"; }\n"
+        "write_drumsep_state() { { echo STATUS=ok; echo STATUS_REASON=verified_ready; echo DRUMSEP_CPU_INSTALL_TXN=\"$6\"; echo DRUMSEP_CPU_MUTATION_REASON=\"$7\"; } | atomic_write_state_file \"$(drumsep_state_file)\"; }\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+    return subprocess.run(
+        ["/bin/sh", str(harness)],
+        text=True,
+        capture_output=True,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        timeout=20,
+    )
+
+
+def test_structured_result_contract_and_internal_callsites_are_explicit() -> None:
+    script = _script()
+    assets = _function(script, "ensure_drumsep_assets")
+    rocm_probe = _function(script, "probe_main_rocm_dks_ready")
+    assert "return 20" in assets
+    assert 'raise SystemExit(21)' in assets
+    assert 'raise SystemExit(22)' in assets
+    assert '0|20|21|22' in assets
+    assert "return 30" in rocm_probe and "return 31" in rocm_probe
+    assert script.count("classify_drumsep_assets_result") >= 3
+
+
+def test_ensure_drumsep_assets_emits_all_structured_failure_classes(tmp_path: Path) -> None:
+    python = shutil.which("python3")
+    assert python
+    script = _script()
+    functions = "\n\n".join(
+        _function(script, name) for name in ("copy_bundled_models_to_cache", "ensure_drumsep_assets")
+    )
+
+    def run_with(source: str | None) -> int:
+        layout = tmp_path / ("missing" if source is None else str(abs(hash(source))))
+        layout.mkdir()
+        if source is not None:
+            (layout / "audio_separator_process.py").write_text(source, encoding="utf-8")
+        harness = layout / "assets.sh"
+        harness.write_text(
+            "#!/bin/sh\nset -u\n"
+            f'SCRIPT_DIR="{layout}"\nBUNDLED_PAYLOAD_DIR="{layout / "bundled"}"\n'
+            f'LOG_FILE="{layout / "assets.log"}"\n'
+            f"{functions}\n"
+            f'ensure_drumsep_assets "{python}" "{layout / "models"}"\n'
+            "exit $?\n",
+            encoding="utf-8",
+        )
+        return subprocess.run(["/bin/sh", str(harness)], timeout=20).returncode
+
+    assert run_with(None) == 20
+    assert run_with(
+        'DIRECT_DKS_MODEL_ALIAS="alias"\n'
+        "def _direct_dks_preflight_check(alias, model_dir):\n"
+        '    return False, alias, alias, "model_missing"\n'
+    ) == 21
+    assert run_with(
+        'DIRECT_DKS_MODEL_ALIAS="alias"\n'
+        "def _direct_dks_preflight_check(alias, model_dir):\n"
+        '    raise RuntimeError("unexpected")\n'
+    ) == 22
+
+
+def test_tooling_and_model_failures_never_reach_sibling_policy(tmp_path: Path) -> None:
+    for result, reason in (
+        (20, "drumsep_assets_tooling_failed"),
+        (21, "drumsep_assets_model_failed"),
+        (22, "drumsep_assets_internal_failed"),
+    ):
+        run = _run_policy_harness(
+            tmp_path / str(result),
+            f"""
+mkdir -p "${{RUNTIME_BASE}}/state"
+probe_main_rocm_dks_ready() {{ return 0; }}
+ensure_drumsep_assets() {{ return {result}; }}
+inspect_drumsep_sibling() {{ log INSPECT_CALLED; return 99; }}
+resolve_main_drumsep_runtime_policy rocm
+rc=$?
+printf 'rc=%s status=%s reason=%s\n' "$rc" "$STATUS" "$STATUS_REASON"
+""",
+        )
+        log = (tmp_path / str(result) / "policy.log").read_text(encoding="utf-8")
+        assert run.returncode == 0
+        assert f"reason={reason}" in run.stdout
+        assert "INSPECT_CALLED" not in log
+        assert "INSTALL_" not in log
+
+
+def test_runtime_probe_error_is_not_runtime_not_ready(tmp_path: Path) -> None:
+    run = _run_policy_harness(
+        tmp_path,
+        """
+mkdir -p "${RUNTIME_BASE}/state"
+probe_main_rocm_dks_ready() { return 31; }
+ensure_drumsep_assets() { log ASSETS_CALLED; return 0; }
+inspect_drumsep_sibling() { log INSPECT_CALLED; return 99; }
+resolve_main_drumsep_runtime_policy rocm
+printf 'status=%s reason=%s\n' "$STATUS" "$STATUS_REASON"
+""",
+    )
+    log = (tmp_path / "policy.log").read_text(encoding="utf-8")
+    assert "status=deps_failed reason=drumsep_probe_error" in run.stdout
+    assert "ASSETS_CALLED" not in log
+    assert "INSPECT_CALLED" not in log
+    assert "INSTALL_" not in log
+
+
+def test_main_unified_ready_assets_failure_never_inspects_sibling(tmp_path: Path) -> None:
+    sibling = tmp_path / "runtime" / "sibling-fixture"
+    sibling.mkdir(parents=True)
+    marker = sibling / "unchanged"
+    marker.write_bytes(b"unchanged\n")
+    before = marker.read_bytes()
+    run = _run_policy_harness(
+        tmp_path,
+        """
+probe_main_rocm_dks_ready() { return 0; }
+ensure_drumsep_assets() { return 21; }
+inspect_drumsep_sibling() { exit 97; }
+resolve_main_drumsep_runtime_policy rocm
+printf 'status=%s reason=%s\n' "$STATUS" "$STATUS_REASON"
+""",
+    )
+    assert run.returncode == 0
+    assert "reason=drumsep_assets_model_failed" in run.stdout
+    assert marker.read_bytes() == before
+
+
+def test_repair_preserves_present_or_absent_sibling(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    state = runtime / "state"
+    state.mkdir(parents=True)
+    sibling = runtime / ".venv-drumsep-rocm"
+    sibling.mkdir()
+    marker = sibling / "unchanged"
+    marker.write_bytes(b"present\n")
+    (state / "drumsep_runtime_rocm.env").write_text(
+        "STATUS=ok\nDRUMSEP_ROCM_RUNTIME_STATUS=ok\n", encoding="utf-8"
+    )
+    present = _run_policy_harness(
+        tmp_path,
+        """
+probe_main_rocm_dks_ready() { return 30; }
+resolve_main_drumsep_runtime_policy rocm
+printf 'status=%s reason=%s sibling=%s txn=%s\n' "$STATUS" "$STATUS_REASON" "$DRUMSEP_SIBLING_STATE" "${DRUMSEP_INSTALL_TXN:-none}"
+""",
+    )
+    assert "reason=drumsep_sibling_rebuild_required" in present.stdout
+    assert "sibling=present_untouched" in present.stdout
+    assert marker.read_bytes() == b"present\n"
+    assert "INSTALL_" not in (tmp_path / "policy.log").read_text(encoding="utf-8")
+
+    marker.unlink()
+    sibling.rmdir()
+    (state / "drumsep_runtime_rocm.env").unlink()
+    absent = _run_policy_harness(
+        tmp_path,
+        """
+probe_main_rocm_dks_ready() { return 30; }
+resolve_main_drumsep_runtime_policy rocm
+printf 'status=%s reason=%s\n' "$STATUS" "$STATUS_REASON"
+""",
+    )
+    assert "reason=drumsep_sibling_missing" in absent.stdout
+    assert not sibling.exists()
+
+
+def test_presence_mismatches_fail_closed_for_setup_and_repair(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    state = runtime / "state"
+    state.mkdir(parents=True)
+    sibling = runtime / ".venv-drumsep"
+    sibling.mkdir()
+    (state / "drumsep_runtime.env").write_text("STATUS=missing\n", encoding="utf-8")
+    present_missing = _run_policy_harness(
+        tmp_path,
+        """
+MODE=drumsep-runtime
+apply_drumsep_sibling_policy cpu
+printf 'status=%s reason=%s\n' "$STATUS" "$STATUS_REASON"
+""",
+    )
+    assert "reason=drumsep_sibling_state_inconsistent" in present_missing.stdout
+    assert "INSTALL_" not in (tmp_path / "policy.log").read_text(encoding="utf-8")
+
+    sibling.rmdir()
+    (state / "drumsep_runtime.env").write_text(
+        "STATUS=ok\nDRUMSEP_RUNTIME_STATUS=ok\n", encoding="utf-8"
+    )
+    absent_ready = _run_policy_harness(
+        tmp_path,
+        """
+MODE=repair
+apply_drumsep_sibling_policy cpu
+printf 'status=%s reason=%s\n' "$STATUS" "$STATUS_REASON"
+""",
+    )
+    assert "reason=drumsep_sibling_state_inconsistent" in absent_ready.stdout
+    assert not sibling.exists()
+
+
+def test_explicit_setup_transaction_orders_begin_mutation_commit(tmp_path: Path) -> None:
+    run = _run_policy_harness(
+        tmp_path,
+        """
+mkdir -p "${RUNTIME_BASE}/state"
+transaction_body() { log SIBLING_MUTATION; return 0; }
+run_drumsep_install_transaction rocm create_absent transaction_body
+cat "$(drumsep_rocm_state_file)"
+""",
+    )
+    assert run.returncode == 0
+    state = run.stdout
+    assert "DRUMSEP_ROCM_INSTALL_TXN=commit" in state
+    assert "STATUS=ok" in state
+    assert "DRUMSEP_ROCM_MUTATION_REASON=create_absent" in state
+    log = (tmp_path / "policy.log").read_text(encoding="utf-8")
+    assert log.index("DRUMSEP_INSTALL_TXN=begin") < log.index("SIBLING_MUTATION")
+    assert log.index("SIBLING_MUTATION") < log.index("DRUMSEP_INSTALL_TXN=commit")
+
+
+def test_interrupted_transaction_overrides_stale_ok(tmp_path: Path) -> None:
+    state_dir = tmp_path / "runtime" / "state"
+    state_dir.mkdir(parents=True)
+    state_file = state_dir / "drumsep_runtime_rocm.env"
+    state_file.write_text("STATUS=ok\nDRUMSEP_ROCM_RUNTIME_STATUS=ok\n", encoding="utf-8")
+    run = _run_policy_harness(
+        tmp_path,
+        """
+interrupt_body() { log SIBLING_MUTATION; kill -TERM $$; }
+run_drumsep_install_transaction rocm rebuild_explicit interrupt_body
+""",
+    )
+    assert run.returncode != 0
+    state = state_file.read_text(encoding="utf-8")
+    assert "DRUMSEP_ROCM_INSTALL_TXN=begin" in state
+    assert "STATUS=incomplete" in state
+    assert "STATUS=ok" not in state
+
+
+def test_commit_write_failure_cannot_report_ok(tmp_path: Path) -> None:
+    run = _run_policy_harness(
+        tmp_path,
+        """
+mkdir -p "${RUNTIME_BASE}/state"
+transaction_body() { log SIBLING_MUTATION; return 0; }
+write_drumsep_rocm_state() { return 1; }
+run_drumsep_install_transaction rocm create_absent transaction_body
+rc=$?
+printf 'rc=%s status=%s reason=%s\n' "$rc" "$STATUS" "$STATUS_REASON"
+""",
+    )
+    assert "status=failed reason=drumsep_state_commit_failed" in run.stdout
+    state = (tmp_path / "runtime" / "state" / "drumsep_runtime_rocm.env").read_text(
+        encoding="utf-8"
+    )
+    assert "DRUMSEP_ROCM_INSTALL_TXN=begin" in state
+    assert "STATUS=ok" not in state
+
+
+def test_cpu_policy_is_symmetric_for_absent_present_and_create(tmp_path: Path) -> None:
+    script = _script()
+    policy = _function(script, "apply_drumsep_sibling_policy")
+    assert '${1:-cpu}' in policy and 'rocm)' in policy
+    assert "drumsep_sibling_missing" in policy
+    assert "drumsep_sibling_rebuild_required" in policy
+    assert "create_absent" in policy
+    assert "rebuild_explicit" in policy
+
+    runtime = tmp_path / "runtime"
+    state = runtime / "state"
+    state.mkdir(parents=True)
+    absent_repair = _run_policy_harness(
+        tmp_path / "absent-repair",
+        """
+mkdir -p "${RUNTIME_BASE}/state"
+MODE=repair
+apply_drumsep_sibling_policy cpu
+printf 'reason=%s state=%s\n' "$STATUS_REASON" "$DRUMSEP_SIBLING_STATE"
+""",
+    )
+    assert "reason=drumsep_sibling_missing state=absent_untouched" in absent_repair.stdout
+
+    explicit_root = tmp_path / "explicit-cpu"
+    explicit = _run_policy_harness(
+        explicit_root,
+        """
+mkdir -p "${RUNTIME_BASE}/state"
+MODE=drumsep-runtime
+install_drumsep_runtime() { transaction_body() { log SIBLING_MUTATION; }; run_drumsep_install_transaction cpu "$DRUMSEP_MUTATION_REASON" transaction_body; }
+apply_drumsep_sibling_policy cpu
+cat "$(drumsep_state_file)"
+""",
+    )
+    assert explicit.returncode == 0
+    assert "DRUMSEP_CPU_INSTALL_TXN=commit" in explicit.stdout
+    assert "DRUMSEP_CPU_MUTATION_REASON=create_absent" in explicit.stdout
+
+
+def test_explicit_rebuild_requires_present_consistent_state(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    state = runtime / "state"
+    sibling = runtime / ".venv-drumsep-rocm"
+    state.mkdir(parents=True)
+    sibling.mkdir()
+    marker = sibling / "unchanged-before-action"
+    marker.write_text("same\n", encoding="utf-8")
+    (state / "drumsep_runtime_rocm.env").write_text(
+        "STATUS=ok\nDRUMSEP_ROCM_RUNTIME_STATUS=ok\n", encoding="utf-8"
+    )
+    run = _run_policy_harness(
+        tmp_path,
+        """
+MODE=drumsep-rocm-runtime
+apply_drumsep_sibling_policy rocm
+printf 'reason=%s\n' "$DRUMSEP_MUTATION_REASON"
+""",
+    )
+    assert run.returncode == 0
+    assert "reason=rebuild_explicit" in run.stdout
+    assert "INSTALL_ROCM_CALLED" in (tmp_path / "policy.log").read_text(encoding="utf-8")
+    assert marker.read_text(encoding="utf-8") == "same\n"
+
+
+def test_presence_contract_uses_one_non_recursive_directory_check() -> None:
+    inspect = _function(_script(), "inspect_drumsep_sibling")
+    assert inspect.count('[ -d "${_inspect_dir}" ]') == 1
+    for forbidden in ("find ", "rglob", '[ -x ', '"${_inspect_dir}"/', "pip ", "python "):
+        assert forbidden not in inspect
+
+
+def test_verify_only_and_ready_state_treat_open_transaction_as_incomplete() -> None:
+    script = _script()
+    loader = _function(script, "load_ready_runtime_state")
+    ready_writer = _function(script, "write_ready_to_go_state")
+    verify_only = _function(script, "run_ready_to_go_verify_only")
+    assert "INSTALL_TXN" in loader
+    assert "INSTALL_TXN" in ready_writer
+    assert "incomplete" in ready_writer
+    assert "verify_existing_ready_runtime" in verify_only
+
+
+def test_open_transaction_cannot_emit_ready_to_go_ok(tmp_path: Path) -> None:
+    script = _script()
+    functions = "\n\n".join(
+        _function(script, name)
+        for name in (
+            "atomic_write_state_file",
+            "drumsep_state_file",
+            "drumsep_rocm_state_file",
+            "load_ready_runtime_state",
+            "write_ready_to_go_state",
+        )
+    )
+    runtime = tmp_path / "runtime"
+    state_dir = runtime / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir / "drumsep_runtime_rocm.env").write_text(
+        "DRUMSEP_ROCM_INSTALL_TXN=begin\n"
+        "STATUS=ok\n"
+        "DRUMSEP_ROCM_RUNTIME_STATUS=ok\n"
+        "DRUMSEP_ROCM_MODEL_STATUS=ok\n",
+        encoding="utf-8",
+    )
+    harness = tmp_path / "ready-open-txn.sh"
+    harness.write_text(
+        "#!/bin/sh\nset -u\n"
+        f'RUNTIME_BASE="{runtime}"\nLOG_FILE="{tmp_path / "ready.log"}"\n'
+        "CORE_MODEL_PREFETCH_STATUS=ok\nCORE_MODEL_PREFETCH_DETAIL=\n"
+        "log() { :; }\nlog_step() { :; }\n"
+        f"{functions}\n"
+        f'ready_to_go_output_file() {{ printf "%s\\n" "{state_dir / "ready_to_go.env"}"; }}\n'
+        "verify_core_model_cache() { printf 'model_dir=/fixture\\nfast=ok\\nquality=ok\\nsixstem=ok\\n'; }\n"
+        "load_ready_runtime_state rocm\n"
+        'write_ready_to_go_state "$READY_RUNTIME_KIND" "$READY_RUNTIME_STATUS" "$READY_DRUMSEP_MODEL_STATUS" "$READY_DETAIL" ok\n'
+        f'cat "{state_dir / "ready_to_go.env"}"\n',
+        encoding="utf-8",
+    )
+    run = subprocess.run(["/bin/sh", str(harness)], text=True, capture_output=True, timeout=20)
+    assert run.returncode == 0
+    assert "READY_TO_GO_STATUS=ok" not in run.stdout
+    assert "DRUMSEP_READY_RUNTIME_STATUS=incomplete" in run.stdout
+    assert "READY_TO_GO_DETAIL=drumsep_install_in_progress" in run.stdout
+
+
+def test_transactional_status_has_one_commitpoint_and_no_open_txn_ok_path() -> None:
+    script = _script()
+    runner = _function(script, "run_drumsep_install_transaction")
+    commit = _function(script, "commit_drumsep_install_txn")
+    begin = _function(script, "begin_drumsep_install_txn")
+    assert runner.count("commit_drumsep_install_txn") == 1
+    assert "STATUS=incomplete" in begin
+    assert "STATUS=ok" not in begin
+    assert "INSTALL_TXN=commit" in commit
+    assert script.count("commit_drumsep_install_txn() {") == 1
+    writer = _function(script, "write_state")
+    assert "DRUMSEP_ROCM_INSTALL_TXN=begin" in writer
+    assert "DRUMSEP_CPU_INSTALL_TXN=begin" in writer
+    assert '| atomic_write_state_file "${STATE_FILE}"' in writer
+
+
+def test_normal_repair_no_longer_auto_installs_optional_siblings() -> None:
+    script = _script()
+    automatic = script[script.index('READY_RUNTIME_KIND="cpu"') :]
+    assert "resolve_main_drumsep_runtime_policy" in automatic
+    assert 'if ! install_drumsep_rocm_runtime; then' not in automatic
+    assert 'if ! install_drumsep_runtime; then' not in automatic
+
+
+def test_release_note_marks_intentional_repair_behavior_change() -> None:
+    note = (ROOT / "docs/release/STEMwerk_2.4.0_RUNTIME_PAYLOAD_HANDOFF.md").read_text(
+        encoding="utf-8"
+    )
+    assert "DRUMSEP_OPTIONAL_RUNTIME_REPAIR_POLICY=preserve_only" in note

--- a/tests/test_staged_layout_conformance.py
+++ b/tests/test_staged_layout_conformance.py
@@ -118,10 +118,9 @@ def test_linux_layout_validation_precedes_every_runtime_mutation_class() -> None
         "create_venv_with_selected_python",
         "pip_install_with_scope",
         "ensure_core_model_cache",
-        "ensure_drumsep_assets",
-        "install_drumsep_runtime",
-        "install_drumsep_rocm_runtime",
-        "write_main_unified_rocm_state",
+        'apply_drumsep_sibling_policy "cpu"',
+        'apply_drumsep_sibling_policy "rocm"',
+        'resolve_main_drumsep_runtime_policy "rocm"',
     )
     for marker in mutation_markers:
         assert validation < execution.index(marker), marker


### PR DESCRIPTION
## Incident and root cause

During the Linux native validation, an asset/tooling failure was treated like a missing runtime. The normal Repair path then entered a full optional sibling reinstall, and interruption during step 4/5 left stale `STATUS=ok` state behind.

## Structured result contract

- `ensure_drumsep_assets`: 0 ready, 20 tooling failure, 21 model-assets failure, 22 unexpected internal failure.
- main ROCm DKS probe: 0 ready, 30 runtime not ready, 31 probe error.
- tooling, model and probe errors are terminal policy failures and never install triggers.
- only runtime-not-ready enters sibling decision-making.

## Presence contract and decision table

Sibling presence uses exactly one non-recursive `test -d` on the canonical CPU or ROCm sibling path. The policy never opens, inventories, imports or probes sibling contents. State is classified only from the state file.

Evaluation order is probe, structured failure classification, then—only for runtime-not-ready—presence, state classification, consistency and action. A ready main-unified runtime short-circuits sibling inspection.

- absent + normal Repair: preserve absence; report `drumsep_sibling_missing` and direct the user to Setup.
- present + normal Repair: preserve bytes; report `drumsep_sibling_rebuild_required`.
- absent + explicit Drum Kit runtime Setup action: transactional `create_absent`.
- present + consistent state + explicit action: transactional `rebuild_explicit`.
- filesystem/state mismatch or unknown state: `drumsep_sibling_state_inconsistent`, no transaction and no mutation—even under Setup.

CPU and ROCm use the same centralized policy.

## Transactional state lifecycle

The repository had no atomic state writer; existing writers used direct redirection. This change centralizes same-directory temp-file, fsync and rename writes. Before the first sibling mutation, state is durably written with transaction `begin`, `STATUS=incomplete`, a stable reason and mutation reason. Failure remains failed/open; success has one final commit point. Verify-only and ready-to-go output treat open transactions as incomplete, overriding older ready state.

State consumers audited: Linux Setup UI, the main Lua runtime scheduler/fallback checks, ready-to-go state, and support-bundle/status presentation. Final ready-state generation now receives the actual main runtime status, so a policy failure cannot emit a false ready state. Verify-only retains its early route but explicitly rejects open transactions before runtime verification.

## Intentional behavior change

`DRUMSEP_OPTIONAL_RUNTIME_REPAIR_POLICY=preserve_only`

Normal Linux Repair no longer creates or rebuilds optional CPU/ROCm DrumSep siblings. The existing user-facing Setup actions `drumsep-runtime` and `drumsep-rocm-runtime` remain the explicit creation/rebuild mechanism. This is marked in the 2.4 runtime handoff release note.

## Validation

- 24/24 PR-beta plus PR-alpha staged-layout/conformance tests green.
- 396 targeted dependency/bootstrap tests green (9 existing skips).
- Exact CI Fast gates green.
- structured failure, short-circuit, CPU symmetry, mismatch, interruption, stale-ok, verify-only and transaction-order harnesses use synthetic fixtures only.
- broad-suite exceptions were reproduced on current main: six pending PR #96 conformance reds and two existing i18n expectation drifts; the local `direct_url.json` metadata exception remains CI-arbitrated.
- Bash, Python, Lua, PowerShell, workflow YAML and diff syntax gates green.
- main production venv inventory unchanged: `960dcac2d9f6959fb2ec4716f093c7d864ba4fa4aa210ecfba163eba5eb443c8`.
- real `.venv-drumsep-rocm` and `.venv-drumsep` were not accessed.

## Scope boundary

PR-alpha already made incomplete staged layouts fail before mutation. This PR handles only result classes, sibling policy and transactional status lifecycle; it does not change staged-layout contract, dependencies, models, processing, PR #96, or cross-platform product code.