### PR TITLE
test: fix STEMwerk I18N path casing

### DIFF
--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -6037,7 +6037,7 @@ def test_macos_bootstrap_seeds_bundled_models_and_drumsep_before_ready_checks():
 def test_drumkit_completion_copy_has_localized_title_and_source_item_words():
     main_script = Path("scripts/reaper/STEMwerk.lua").read_text()
     langs = Path("scripts/reaper/i18n/languages.lua").read_text()
-    i18n_internal = Path("scripts/reaper/_internal/STEMwerk_i18n.lua").read_text()
+    i18n_internal = Path("scripts/reaper/_internal/STEMwerk_I18N.lua").read_text()
 
     assert 'trSafeValue("drumkit_complete_title", "Direct Kit completed successfully!")' in main_script
     assert 'trPlural(srcCount, "drumkit_result_source_item_one", "drumkit_result_source_item_many"' in main_script


### PR DESCRIPTION
## Summary

- Classifies the baseline failure as `STALE_TEST_PATH`.
- Corrects the test reference from `STEMwerk_i18n.lua` to the existing runtime path `STEMwerk_I18N.lua`.
- Changes exactly one test file and one content line; product code and payload contracts remain unchanged.

## History and cause

- The incorrect lowercase reference was introduced by `3c26ade2b4b6011d48e1fd87efaf12afe0093985`.
- The plural fallback it intended to guard was implemented in the uppercase file by `0d669b7518e86681a73adc5773d8e2184215a07c`.
- The lowercase product file has never existed in Git history. The mismatch was likely hidden on case-insensitive filesystems.
- Functional localization remained intact: runtime loading, `index.xml`, and release payload validation all use `STEMwerk_I18N.lua`.

## Evidence

- RED: targeted test failed only with `FileNotFoundError` for the lowercase path.
- GREEN: targeted test `1 passed`.
- Full dependency constraints: `372 passed, 9 skipped`.
- i18n checks: `4/4 passed`.
- CI Fast: environment `3 passed`; curated coverage `93 passed, 1 warning`.
- Release gate and version sync: PASS.
- The general tracked-Python compile gate still finds only the independently known pre-hygiene AppleDouble fossil `scripts/reaper/vendor/stemwerk-core/src/stemwerk_core/._separator.py`; no allowlist or masking was added.
- Production main-venv inventory before/after is identical.

## Scope isolation

- Hygiene worktree remains unchanged.
- PR #96 worktree and active merge remain unchanged.
- No product code, Lua, `index.xml`, release gate, or payload files changed.
