### PR TITLE
ci: enforce Linux offline gap meta-test in Fast checks

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -58,6 +58,7 @@ jobs:
             tests/test_model_registry_schema.py \
             tests/test_windows_normal_route_matrix.py \
             tests/test_vocals_hq_runtime_proof.py \
+            tests/test_drumsep_asset_distribution_contract.py::test_linux_offline_gap_tracking_remains_explicit_and_red \
             tests/test_dependency_constraints.py::test_ci_fast_quick_script_smoke_installs_pyyaml \
             tests/test_dependency_constraints.py::test_ci_fast_runs_curated_pytest_coverage \
             tests/test_dependency_constraints.py::test_no_stale_onnxruntime_ci_pins \

--- a/tests/test_drumsep_asset_distribution_contract.py
+++ b/tests/test_drumsep_asset_distribution_contract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+import re
 import xml.etree.ElementTree as ET
 
 import pytest
@@ -251,3 +252,24 @@ def test_linux_offline_gap_tracking_remains_explicit_and_red() -> None:
         "offline-rocm": False,
         "offline-nvidia": False,
     }
+
+
+def test_ci_fast_selects_only_linux_offline_gap_meta_test() -> None:
+    module_path = "tests/test_drumsep_asset_distribution_contract.py"
+    meta_test_name = "test_linux_offline_gap_tracking_remains_explicit_and_red"
+    meta_node_id = f"{module_path}::{meta_test_name}"
+    workflow = _text(".github/workflows/ci-full.yml")
+    ci_fast_selection = workflow.split("- name: Run curated fast pytest coverage", 1)[1].split(
+        "\n      - name:", 1
+    )[0]
+    distribution_selections = re.findall(
+        rf"{re.escape(module_path)}(?:::[A-Za-z0-9_\[\]-]+)?", ci_fast_selection
+    )
+
+    assert re.search(rf"^def {meta_test_name}\(.*\).*:$", _text(module_path), re.MULTILINE)
+    assert distribution_selections.count(meta_node_id) == 1
+    assert module_path not in distribution_selections
+    assert not {
+        f"{module_path}::test_linux_distribution_conforms_to_contract[{gap}]"
+        for gap in ("offline-cpu", "offline-rocm", "offline-nvidia")
+    }.intersection(distribution_selections)


### PR DESCRIPTION
Directe afgesproken CI-governancefollow-up op PR #96.

Deze micro-PR:
- selecteert in CI Fast uitsluitend `tests/test_drumsep_asset_distribution_contract.py::test_linux_offline_gap_tracking_remains_explicit_and_red`;
- selecteert niet de volledige distributiecontractmodule en niet rechtstreeks de drie intentionele rode offline-tests;
- voegt een self-guarding test toe die workflowselectie, testnaam en exclusiviteit fail-closed aan elkaar koppelt;
- bevat geen productcode, distributie-implementatie of claim dat offline Linux-support voltooid is;
- wijzigt exact twee paden: `.github/workflows/ci-full.yml` en `tests/test_drumsep_asset_distribution_contract.py`.

Lokale bewijzen:
- TDD-red bewezen door ontbrekende CI-selectie (`0 == 1`);
- meta-test: 1 passed;
- self-guard: 1 passed;
- gereconstrueerde CI Fast-selectie: 94 passed;
- volledige contractmodule: exact 3 intentionele offline-failures en 8 passed;
- YAML, Python compile, repositoryhygiëne en `git diff --check`: PASS.