### PR TITLE
fix(linux): audit Numba cache disposition across venv rebuild

### DIFF
--- a/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
+++ b/scripts/reaper/STEMwerk_Bootstrap_Linux.sh
@@ -1278,6 +1278,12 @@ write_state() {
       echo "NUMBA_LEGACY_CACHE_NOT_REMOVED=${NUMBA_LEGACY_CACHE_NOT_REMOVED}"
       echo "NUMBA_LEGACY_CACHE_RUNTIME_CACHE_TOUCHED=${NUMBA_LEGACY_CACHE_RUNTIME_CACHE_TOUCHED}"
       echo "NUMBA_LEGACY_CACHE_CLEANUP_STATUS=${NUMBA_LEGACY_CACHE_CLEANUP_STATUS}"
+      echo "NUMBA_LEGACY_CACHE_PRE_REBUILD_SCAN_STATUS=${NUMBA_LEGACY_CACHE_PRE_REBUILD_SCAN_STATUS}"
+      echo "NUMBA_LEGACY_CACHE_PRE_REBUILD_DETECTED=${NUMBA_LEGACY_CACHE_PRE_REBUILD_DETECTED}"
+      echo "NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST=${NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST}"
+      echo "NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST_SHA256=${NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST_SHA256}"
+      echo "NUMBA_LEGACY_CACHE_DISPOSITION=${NUMBA_LEGACY_CACHE_DISPOSITION}"
+      echo "NUMBA_LEGACY_CACHE_POST_ACTION_REMAINING=${NUMBA_LEGACY_CACHE_POST_ACTION_REMAINING}"
       [ -n "${STEMWERK_INSTALLER:-}" ] && echo "INSTALLER=1"
       [ -n "${RUNTIME_BASE}" ] && echo "RUNTIME_BASE=${RUNTIME_BASE}"
     } | atomic_write_state_file "${STATE_FILE}"
@@ -1301,6 +1307,217 @@ set_status() {
     fi
   fi
 }
+
+audit_legacy_numba_caches_for_rebuild() {
+  _audit_venv="$1"
+  _audit_manifest="$2"
+  NUMBA_LEGACY_CACHE_PRE_REBUILD_SCAN_STATUS="failed"
+  NUMBA_LEGACY_CACHE_PRE_REBUILD_DETECTED="0"
+  NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST="none"
+  NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST_SHA256="none"
+  NUMBA_LEGACY_CACHE_DISPOSITION="preserved_due_to_failure"
+  NUMBA_LEGACY_CACHE_POST_ACTION_REMAINING="0"
+
+  _audit_emit() {
+    log "NUMBA_LEGACY_CACHE_PRE_REBUILD_SCAN_STATUS=${NUMBA_LEGACY_CACHE_PRE_REBUILD_SCAN_STATUS}"
+    log "NUMBA_LEGACY_CACHE_PRE_REBUILD_DETECTED=${NUMBA_LEGACY_CACHE_PRE_REBUILD_DETECTED}"
+    log "NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST=${NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST}"
+    log "NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST_SHA256=${NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST_SHA256}"
+    log "NUMBA_LEGACY_CACHE_DISPOSITION=${NUMBA_LEGACY_CACHE_DISPOSITION}"
+    log "NUMBA_LEGACY_CACHE_POST_ACTION_REMAINING=${NUMBA_LEGACY_CACHE_POST_ACTION_REMAINING}"
+  }
+
+  _audit_manifest_dir=${_audit_manifest%/*}
+  if [ ! -d "${_audit_manifest_dir}" ] && ! mkdir -p "${_audit_manifest_dir}"; then
+    _audit_emit
+    return 1
+  fi
+  _audit_tmp="$(mktemp "${_audit_manifest_dir}/.numba-legacy-cache-pre-rebuild.XXXXXX")" || {
+    _audit_emit
+    return 1
+  }
+  trap '/bin/rm -f -- "${_audit_tmp}"' EXIT HUP INT TERM
+  : > "${_audit_tmp}" || {
+    _audit_emit
+    return 1
+  }
+
+  if [ ! -e "${_audit_venv}" ] && [ ! -L "${_audit_venv}" ]; then
+    :
+  elif [ ! -d "${_audit_venv}" ] || [ -L "${_audit_venv}" ]; then
+    _audit_emit
+    /bin/rm -f -- "${_audit_tmp}"
+    trap - EXIT HUP INT TERM
+    return 1
+  else
+    _audit_venv_real="$(readlink -f -- "${_audit_venv}" 2>/dev/null || true)"
+    [ -n "${_audit_venv_real}" ] || {
+      _audit_emit
+      /bin/rm -f -- "${_audit_tmp}"
+      trap - EXIT HUP INT TERM
+      return 1
+    }
+    for _audit_parent in \
+      "${_audit_venv}"/lib/python*/site-packages/librosa/core/__pycache__ \
+      "${_audit_venv}"/lib/python*/site-packages/librosa/util/__pycache__
+    do
+      [ -e "${_audit_parent}" ] || [ -L "${_audit_parent}" ] || continue
+      _audit_parent_real="$(readlink -f -- "${_audit_parent}" 2>/dev/null || true)"
+      _audit_parent_relative=${_audit_parent#"${_audit_venv}"/}
+      if [ -L "${_audit_parent}" ] || [ ! -d "${_audit_parent}" ] || [ "${_audit_parent_real}" != "${_audit_venv_real}/${_audit_parent_relative}" ]; then
+        _audit_emit
+        /bin/rm -f -- "${_audit_tmp}"
+        trap - EXIT HUP INT TERM
+        return 1
+      fi
+    done
+    _audit_paths="$(find "${_audit_venv}" \( -name '*.nbc' -o -name '*.nbi' \) -print 2>/dev/null)" || {
+      _audit_emit
+      /bin/rm -f -- "${_audit_tmp}"
+      trap - EXIT HUP INT TERM
+      return 1
+    }
+    while IFS= read -r _audit_path; do
+      [ -n "${_audit_path}" ] || continue
+      _audit_relative=${_audit_path#"${_audit_venv}"/}
+      case "${_audit_relative}" in
+        *"
+"*|*"	"*)
+          _audit_emit
+          /bin/rm -f -- "${_audit_tmp}"
+          trap - EXIT HUP INT TERM
+          return 1
+          ;;
+        lib/python*/site-packages/librosa/core/__pycache__/*.nbc|\
+        lib/python*/site-packages/librosa/core/__pycache__/*.nbi|\
+        lib/python*/site-packages/librosa/util/__pycache__/*.nbc|\
+        lib/python*/site-packages/librosa/util/__pycache__/*.nbi)
+          ;;
+        *)
+          _audit_emit
+          /bin/rm -f -- "${_audit_tmp}"
+          trap - EXIT HUP INT TERM
+          return 1
+          ;;
+      esac
+      if [ -L "${_audit_path}" ] || [ ! -f "${_audit_path}" ]; then
+        _audit_emit
+        /bin/rm -f -- "${_audit_tmp}"
+        trap - EXIT HUP INT TERM
+        return 1
+      fi
+      _audit_real="$(readlink -f -- "${_audit_path}" 2>/dev/null || true)"
+      case "${_audit_real}" in
+        "${_audit_venv_real}"/*) ;;
+        *)
+          _audit_emit
+          /bin/rm -f -- "${_audit_tmp}"
+          trap - EXIT HUP INT TERM
+          return 1
+          ;;
+      esac
+      _audit_size="$(wc -c < "${_audit_path}" 2>/dev/null)" || {
+        _audit_emit
+        /bin/rm -f -- "${_audit_tmp}"
+        trap - EXIT HUP INT TERM
+        return 1
+      }
+      _audit_sha="$(sha256sum "${_audit_path}" 2>/dev/null | awk '{print $1}')"
+      [ "${#_audit_sha}" -eq 64 ] || {
+        _audit_emit
+        /bin/rm -f -- "${_audit_tmp}"
+        trap - EXIT HUP INT TERM
+        return 1
+      }
+      printf '%s\tregular\t%s\t%s\n' "${_audit_relative}" "${_audit_size}" "${_audit_sha}" >> "${_audit_tmp}" || {
+        _audit_emit
+        /bin/rm -f -- "${_audit_tmp}"
+        trap - EXIT HUP INT TERM
+        return 1
+      }
+      NUMBA_LEGACY_CACHE_PRE_REBUILD_DETECTED=$((NUMBA_LEGACY_CACHE_PRE_REBUILD_DETECTED + 1))
+    done <<EOF
+${_audit_paths}
+EOF
+  fi
+
+  LC_ALL=C sort -o "${_audit_tmp}" "${_audit_tmp}" || {
+    _audit_emit
+    /bin/rm -f -- "${_audit_tmp}"
+    trap - EXIT HUP INT TERM
+    return 1
+  }
+  mv -f -- "${_audit_tmp}" "${_audit_manifest}" || {
+    _audit_emit
+    /bin/rm -f -- "${_audit_tmp}"
+    trap - EXIT HUP INT TERM
+    return 1
+  }
+  trap - EXIT HUP INT TERM
+  NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST="${_audit_manifest}"
+  NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST_SHA256="$(sha256sum "${_audit_manifest}" | awk '{print $1}')"
+  NUMBA_LEGACY_CACHE_PRE_REBUILD_SCAN_STATUS="ok"
+  _audit_emit
+  return 0
+}
+
+persist_numba_cache_rebuild_disposition() {
+  _disposition_manifest="$1"
+  _disposition_state="${_disposition_manifest%/*}/numba-legacy-cache-disposition.state"
+  _disposition_tmp="$(mktemp "${_disposition_state}.XXXXXX")" || return 1
+  {
+    printf 'NUMBA_LEGACY_CACHE_PRE_REBUILD_SCAN_STATUS=%s\n' "${NUMBA_LEGACY_CACHE_PRE_REBUILD_SCAN_STATUS}"
+    printf 'NUMBA_LEGACY_CACHE_PRE_REBUILD_DETECTED=%s\n' "${NUMBA_LEGACY_CACHE_PRE_REBUILD_DETECTED}"
+    printf 'NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST=%s\n' "${NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST}"
+    printf 'NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST_SHA256=%s\n' "${NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST_SHA256}"
+    printf 'NUMBA_LEGACY_CACHE_DISPOSITION=%s\n' "${NUMBA_LEGACY_CACHE_DISPOSITION}"
+    printf 'NUMBA_LEGACY_CACHE_POST_ACTION_REMAINING=%s\n' "${NUMBA_LEGACY_CACHE_POST_ACTION_REMAINING}"
+  } > "${_disposition_tmp}" || {
+    /bin/rm -f -- "${_disposition_tmp}"
+    return 1
+  }
+  mv -f -- "${_disposition_tmp}" "${_disposition_state}" || {
+    /bin/rm -f -- "${_disposition_tmp}"
+    return 1
+  }
+}
+
+remove_main_venv_with_numba_audit() {
+  _rebuild_venv="$1"
+  _rebuild_manifest="$2"
+  if ! audit_legacy_numba_caches_for_rebuild "${_rebuild_venv}" "${_rebuild_manifest}"; then
+    NUMBA_LEGACY_CACHE_DISPOSITION="preserved_due_to_failure"
+    log "NUMBA_LEGACY_CACHE_DISPOSITION=${NUMBA_LEGACY_CACHE_DISPOSITION}"
+    return 1
+  fi
+  if [ "${NUMBA_LEGACY_CACHE_PRE_REBUILD_DETECTED}" -eq 0 ]; then
+    NUMBA_LEGACY_CACHE_DISPOSITION="none_present"
+  else
+    NUMBA_LEGACY_CACHE_DISPOSITION="preserved_due_to_failure"
+  fi
+  log "NUMBA_LEGACY_CACHE_DISPOSITION=${NUMBA_LEGACY_CACHE_DISPOSITION}"
+  if ! persist_numba_cache_rebuild_disposition "${_rebuild_manifest}"; then
+    NUMBA_LEGACY_CACHE_DISPOSITION="preserved_due_to_failure"
+    log "NUMBA_LEGACY_CACHE_DISPOSITION=${NUMBA_LEGACY_CACHE_DISPOSITION}"
+    return 1
+  fi
+  if [ -e "${_rebuild_venv}" ] || [ -L "${_rebuild_venv}" ]; then
+    if ! rm -rf -- "${_rebuild_venv}" || [ -e "${_rebuild_venv}" ] || [ -L "${_rebuild_venv}" ]; then
+      NUMBA_LEGACY_CACHE_DISPOSITION="preserved_due_to_failure"
+      log "NUMBA_LEGACY_CACHE_DISPOSITION=${NUMBA_LEGACY_CACHE_DISPOSITION}"
+      return 1
+    fi
+  fi
+  if [ "${NUMBA_LEGACY_CACHE_PRE_REBUILD_DETECTED}" -ne 0 ]; then
+    NUMBA_LEGACY_CACHE_DISPOSITION="removed_with_venv_rebuild"
+  fi
+  NUMBA_LEGACY_CACHE_POST_ACTION_REMAINING="0"
+  log "NUMBA_LEGACY_CACHE_DISPOSITION=${NUMBA_LEGACY_CACHE_DISPOSITION}"
+  log "NUMBA_LEGACY_CACHE_POST_ACTION_REMAINING=${NUMBA_LEGACY_CACHE_POST_ACTION_REMAINING}"
+  persist_numba_cache_rebuild_disposition "${_rebuild_manifest}" || return 1
+  return 0
+}
+# END NUMBA LEGACY CACHE REBUILD AUDIT POLICY
 
 cleanup_legacy_numba_caches() {
   _cleanup_venv="$1"
@@ -1692,7 +1909,9 @@ classify_venv_failure() {
 }
 
 create_venv_with_selected_python() {
-  rm -rf "${RUNTIME_BASE}/.venv"
+  if [ -e "${RUNTIME_BASE}/.venv" ] || [ -L "${RUNTIME_BASE}/.venv" ]; then
+    remove_main_venv_with_numba_audit "${RUNTIME_BASE}/.venv" "${RUNTIME_BASE}/state/numba-legacy-cache-pre-rebuild.manifest" || return 1
+  fi
   _venv_log="${RUNTIME_BASE}/logs/venv_create.log"
   : > "${_venv_log}" || true
   log_step "Creating venv at ${RUNTIME_BASE}/.venv"
@@ -1703,7 +1922,7 @@ create_venv_with_selected_python() {
   cat "${_venv_log}" >> "${LOG_FILE}" 2>/dev/null || true
   VENV_CREATE_REASON="$(classify_venv_failure "${_venv_log}")"
   log_step "Venv creation failed with ${PYTHON}: ${VENV_CREATE_REASON}"
-  rm -rf "${RUNTIME_BASE}/.venv"
+  rm -rf -- "${RUNTIME_BASE}/.venv"
   return 1
 }
 
@@ -2582,9 +2801,13 @@ STAGED_LAYOUT_VALIDATION_ACTIVE=0
 log_stage "Bootstrap started"
 log_step "Requested mode: ${MODE}"
 log_step "Downloaded models are kept at: $(model_cache_dir)"
+mkdir -p "${RUNTIME_BASE}/state" "${RUNTIME_BASE}/logs" "${RUNTIME_BASE}/bin" "${RUNTIME_BASE}/ffmpeg" "${RUNTIME_BASE}/python"
 if [ "${MODE}" = "rebuild-venv" ] && [ -d "${RUNTIME_BASE}/.venv" ]; then
   log_step "Removing existing virtual environment: ${RUNTIME_BASE}/.venv"
-  rm -rf "${RUNTIME_BASE}/.venv"
+  if ! remove_main_venv_with_numba_audit "${RUNTIME_BASE}/.venv" "${RUNTIME_BASE}/state/numba-legacy-cache-pre-rebuild.manifest"; then
+    log_step "Pre-rebuild Numba cache audit failed; preserving existing virtual environment"
+    exit 1
+  fi
 fi
 log_step "Preparing runtime directories"
 log_step "Clearing GPU override env vars (HIP_VISIBLE_DEVICES/HSA_OVERRIDE_GFX_VERSION/ROCR_VISIBLE_DEVICES/CUDA_VISIBLE_DEVICES)"
@@ -2621,6 +2844,12 @@ NUMBA_LEGACY_CACHE_POSTCHECK_REMAINING="0"
 NUMBA_LEGACY_CACHE_NOT_REMOVED="0"
 NUMBA_LEGACY_CACHE_RUNTIME_CACHE_TOUCHED="no"
 NUMBA_LEGACY_CACHE_CLEANUP_STATUS="not_required"
+NUMBA_LEGACY_CACHE_PRE_REBUILD_SCAN_STATUS="${NUMBA_LEGACY_CACHE_PRE_REBUILD_SCAN_STATUS:-not_applicable}"
+NUMBA_LEGACY_CACHE_PRE_REBUILD_DETECTED="${NUMBA_LEGACY_CACHE_PRE_REBUILD_DETECTED:-0}"
+NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST="${NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST:-none}"
+NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST_SHA256="${NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST_SHA256:-none}"
+NUMBA_LEGACY_CACHE_DISPOSITION="${NUMBA_LEGACY_CACHE_DISPOSITION:-none_present}"
+NUMBA_LEGACY_CACHE_POST_ACTION_REMAINING="${NUMBA_LEGACY_CACHE_POST_ACTION_REMAINING:-0}"
 SUPPORTED_PYTHON_FOUND="no"
 DETECTED_PYTHON_VERSION=""
 DETECTED_PYTHON_PATH=""
@@ -3039,7 +3268,9 @@ else
   if [ -x "${RUNTIME_BASE}/.venv/bin/python" ]; then
     if venv_torch_requires_rebuild "${RUNTIME_BASE}/.venv/bin/python" || main_runtime_requires_rebuild "${RUNTIME_BASE}/.venv/bin/python"; then
       log_step "Removing existing virtual environment: ${RUNTIME_BASE}/.venv"
-      rm -rf "${RUNTIME_BASE}/.venv"
+      if ! remove_main_venv_with_numba_audit "${RUNTIME_BASE}/.venv" "${RUNTIME_BASE}/state/numba-legacy-cache-pre-rebuild.manifest"; then
+        set_status "deps_failed" "numba_legacy_cache_pre_rebuild_audit_failed"
+      fi
     elif probe_main_runtime_ready "${RUNTIME_BASE}/.venv/bin/python" "${BACKEND}" >/dev/null; then
       select_active_torch_policy "${BACKEND}"
       PRESERVED_RUNTIME_TORCH_VERSION="$("${RUNTIME_BASE}/.venv/bin/python" -c 'import torch; print(getattr(torch, "__version__", "unknown"))' 2>/dev/null || true)"
@@ -3049,18 +3280,22 @@ else
     else
       log_step "Existing venv runtime probe failed; rebuilding .venv"
       log_step "Removing existing virtual environment: ${RUNTIME_BASE}/.venv"
-      rm -rf "${RUNTIME_BASE}/.venv"
+      if ! remove_main_venv_with_numba_audit "${RUNTIME_BASE}/.venv" "${RUNTIME_BASE}/state/numba-legacy-cache-pre-rebuild.manifest"; then
+        set_status "deps_failed" "numba_legacy_cache_pre_rebuild_audit_failed"
+      fi
     fi
   fi
   if [ ! -x "${RUNTIME_BASE}/.venv/bin/python" ]; then
-    if ! create_venv_with_selected_python; then
-      if ! try_managed_python_after_venv_failure; then
-        if [ "${VENV_CREATE_REASON}" = "venv_create_failed_missing_ensurepip" ]; then
-          msg="Could not create Python virtual environment because Python venv/ensurepip is missing. STEMwerk could not use or install a managed Python runtime. Install python3.12-venv or use the STEMwerk Linux/macOS package with managed runtime, then run Repair/Rebuild."
-          log_step "${msg}"
-          printf "%s\n" "${msg}" >&2
+    if [ "${STATUS}" = "ok" ]; then
+      if ! create_venv_with_selected_python; then
+        if ! try_managed_python_after_venv_failure; then
+          if [ "${VENV_CREATE_REASON}" = "venv_create_failed_missing_ensurepip" ]; then
+            msg="Could not create Python virtual environment because Python venv/ensurepip is missing. STEMwerk could not use or install a managed Python runtime. Install python3.12-venv or use the STEMwerk Linux/macOS package with managed runtime, then run Repair/Rebuild."
+            log_step "${msg}"
+            printf "%s\n" "${msg}" >&2
+          fi
+          set_status "venv_failed" "${VENV_CREATE_REASON:-venv_create_failed}"
         fi
-        set_status "venv_failed" "${VENV_CREATE_REASON:-venv_create_failed}"
       fi
     fi
   fi
@@ -3074,7 +3309,7 @@ else
       msg="Could not create Python virtual environment because Python venv/ensurepip is missing. STEMwerk could not use or install a managed Python runtime. Install python3.12-venv or use the STEMwerk Linux/macOS package with managed runtime, then run Repair/Rebuild."
       log_step "${msg}"
       printf "%s\n" "${msg}" >&2
-      rm -rf "${RUNTIME_BASE}/.venv"
+      rm -rf -- "${RUNTIME_BASE}/.venv"
       set_status "venv_failed" "${VENV_CREATE_REASON}"
     fi
   fi
@@ -3568,6 +3803,19 @@ EOF
   NUMBA_LEGACY_CACHE_NOT_REMOVED="$(printf "%s\n" "${NUMBA_LEGACY_CACHE_OUTPUT}" | sed -n 's/^NUMBA_LEGACY_CACHE_NOT_REMOVED=//p' | tail -n 1)"
   NUMBA_LEGACY_CACHE_RUNTIME_CACHE_TOUCHED="$(printf "%s\n" "${NUMBA_LEGACY_CACHE_OUTPUT}" | sed -n 's/^NUMBA_LEGACY_CACHE_RUNTIME_CACHE_TOUCHED=//p' | tail -n 1)"
   NUMBA_LEGACY_CACHE_CLEANUP_STATUS="$(printf "%s\n" "${NUMBA_LEGACY_CACHE_OUTPUT}" | sed -n 's/^NUMBA_LEGACY_CACHE_CLEANUP_STATUS=//p' | tail -n 1)"
+  NUMBA_LEGACY_CACHE_POST_ACTION_REMAINING="${NUMBA_LEGACY_CACHE_POSTCHECK_REMAINING}"
+  if [ "${NUMBA_LEGACY_CACHE_DISPOSITION}" != "removed_with_venv_rebuild" ]; then
+    NUMBA_LEGACY_CACHE_PRE_REBUILD_DETECTED="${NUMBA_LEGACY_CACHE_DETECTED}"
+    if [ "${NUMBA_LEGACY_CACHE_CLEANUP_STATUS}" = "removed" ]; then
+      NUMBA_LEGACY_CACHE_DISPOSITION="removed_individually"
+    elif [ "${NUMBA_LEGACY_CACHE_DETECTED}" -eq 0 ]; then
+      NUMBA_LEGACY_CACHE_DISPOSITION="none_present"
+    else
+      NUMBA_LEGACY_CACHE_DISPOSITION="preserved_due_to_failure"
+    fi
+  fi
+  log "NUMBA_LEGACY_CACHE_DISPOSITION=${NUMBA_LEGACY_CACHE_DISPOSITION}"
+  log "NUMBA_LEGACY_CACHE_POST_ACTION_REMAINING=${NUMBA_LEGACY_CACHE_POST_ACTION_REMAINING}"
   case "${NUMBA_LEGACY_CACHE_CLEANUP_STATUS}" in
     not_required|removed|partial_unexpected)
       ;;

--- a/tests/test_linux_numba_legacy_cache_cleanup.py
+++ b/tests/test_linux_numba_legacy_cache_cleanup.py
@@ -50,6 +50,41 @@ def _runner(venv: Path) -> Path:
     return runner
 
 
+def _rebuild_runner(runtime: Path) -> Path:
+    script = BOOTSTRAP.read_text(encoding="utf-8")
+    start = script.index("audit_legacy_numba_caches_for_rebuild() {")
+    end = script.index("# END NUMBA LEGACY CACHE REBUILD AUDIT POLICY")
+    runner = runtime / "numba-rebuild-audit-runner.sh"
+    runner.parent.mkdir(parents=True, exist_ok=True)
+    runner.write_text(
+        "#!/bin/sh\nset -u\nlog() { printf '%s\\n' \"$*\"; }\n"
+        + script[start:end]
+        + '\nremove_main_venv_with_numba_audit "$1" "$2"\n',
+        encoding="utf-8",
+    )
+    runner.chmod(0o755)
+    return runner
+
+
+def _run_rebuild_audit(
+    runtime: Path, *, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    run_env = os.environ.copy()
+    if env:
+        run_env.update(env)
+    venv = runtime / ".venv"
+    manifest = runtime / "state/numba-legacy-cache-pre-rebuild.manifest"
+    return subprocess.run(
+        ["/bin/sh", str(_rebuild_runner(runtime)), str(venv), str(manifest)],
+        cwd=ROOT,
+        env=run_env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+
 def _run(venv: Path, *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
     run_env = os.environ.copy()
     if env:
@@ -380,13 +415,11 @@ def test_status_vocabulary_is_exact() -> None:
     assert "blocked_manifest_mismatch" not in helper
 
 
-def test_product_policy_contains_no_manifest_hash_or_fixed_count() -> None:
+def test_product_policy_contains_no_fixed_manifest_hash_or_count() -> None:
     product = BOOTSTRAP.read_text(encoding="utf-8")
 
-    assert "numba-legacy-cache-manifest" not in product
     assert "ALLOWLIST_EVIDENCE_FILE_COUNT" not in product
     assert "LOCAL_EVIDENCE_MANIFEST" not in product
-    assert "sha256sum" not in product
     assert "/home/flark" not in product
 
 
@@ -448,3 +481,170 @@ def test_bootstrap_persists_cleanup_markers_in_state() -> None:
         "NUMBA_LEGACY_CACHE_CLEANUP_STATUS",
     ):
         assert f'echo "{marker}=${{{marker}}}"' in script
+
+
+def test_rebuild_audit_records_exactly_46_allowlisted_caches_and_removes_venv(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    venv = _venv(runtime)
+    core, util = _allowlist_parents(venv)
+    caches = [
+        (core if index % 2 == 0 else util) / f"cache-{index:02d}.{'nbc' if index % 3 else 'nbi'}"
+        for index in range(46)
+    ]
+    for index, cache in enumerate(caches):
+        cache.write_bytes(f"cache-{index}".encode())
+
+    result = _run_rebuild_audit(runtime)
+    markers = _markers(result)
+    manifest = runtime / "state/numba-legacy-cache-pre-rebuild.manifest"
+
+    assert result.returncode == 0, result.stdout
+    assert not venv.exists()
+    assert markers["NUMBA_LEGACY_CACHE_PRE_REBUILD_SCAN_STATUS"] == "ok"
+    assert markers["NUMBA_LEGACY_CACHE_PRE_REBUILD_DETECTED"] == "46"
+    assert markers["NUMBA_LEGACY_CACHE_DISPOSITION"] == "removed_with_venv_rebuild"
+    assert markers["NUMBA_LEGACY_CACHE_POST_ACTION_REMAINING"] == "0"
+    assert len(manifest.read_text(encoding="utf-8").splitlines()) == 46
+    assert markers["NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST_SHA256"] == __import__("hashlib").sha256(
+        manifest.read_bytes()
+    ).hexdigest()
+    state_markers = _markers(
+        subprocess.CompletedProcess(
+            [], 0, (runtime / "state/numba-legacy-cache-disposition.state").read_text(encoding="utf-8")
+        )
+    )
+    assert state_markers["NUMBA_LEGACY_CACHE_DISPOSITION"] == markers["NUMBA_LEGACY_CACHE_DISPOSITION"]
+    assert state_markers["NUMBA_LEGACY_CACHE_PRE_REBUILD_DETECTED"] == "46"
+
+
+def test_rebuild_audit_with_no_cache_reports_none_present(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    venv = _venv(runtime)
+    _allowlist_parents(venv)
+
+    result = _run_rebuild_audit(runtime)
+    markers = _markers(result)
+
+    assert result.returncode == 0, result.stdout
+    assert not venv.exists()
+    assert markers["NUMBA_LEGACY_CACHE_PRE_REBUILD_DETECTED"] == "0"
+    assert markers["NUMBA_LEGACY_CACHE_DISPOSITION"] == "none_present"
+    assert markers["NUMBA_LEGACY_CACHE_POST_ACTION_REMAINING"] == "0"
+
+
+def test_rebuild_audit_unknown_cache_path_fails_closed_without_removal(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    venv = _venv(runtime)
+    unknown = venv / "lib/python3.12/site-packages/other/__pycache__/unknown.nbc"
+    unknown.parent.mkdir(parents=True)
+    unknown.write_bytes(b"unknown")
+
+    result = _run_rebuild_audit(runtime)
+    markers = _markers(result)
+
+    assert result.returncode != 0
+    assert unknown.exists()
+    assert markers["NUMBA_LEGACY_CACHE_PRE_REBUILD_SCAN_STATUS"] == "failed"
+    assert markers["NUMBA_LEGACY_CACHE_DISPOSITION"] == "preserved_due_to_failure"
+
+
+def test_rebuild_audit_symlink_is_not_followed_and_blocks_removal(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    venv = _venv(runtime)
+    core, _ = _allowlist_parents(venv)
+    outside = tmp_path / "outside.nbc"
+    outside.write_bytes(b"outside")
+    (core / "linked.nbc").symlink_to(outside)
+
+    result = _run_rebuild_audit(runtime)
+
+    assert result.returncode != 0
+    assert venv.exists()
+    assert outside.read_bytes() == b"outside"
+
+
+def test_rebuild_audit_cache_named_directory_blocks_removal(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    venv = _venv(runtime)
+    core, _ = _allowlist_parents(venv)
+    (core / "cache.nbc").mkdir()
+
+    result = _run_rebuild_audit(runtime)
+
+    assert result.returncode != 0
+    assert venv.exists()
+
+
+def test_rebuild_manifest_write_failure_preserves_venv(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    venv = _venv(runtime)
+    core, _ = _allowlist_parents(venv)
+    (core / "cache.nbc").write_bytes(b"cache")
+    (runtime / "state").write_text("not-a-directory", encoding="utf-8")
+
+    result = _run_rebuild_audit(runtime)
+    markers = _markers(result)
+
+    assert result.returncode != 0
+    assert venv.exists()
+    assert markers["NUMBA_LEGACY_CACHE_PRE_REBUILD_SCAN_STATUS"] == "failed"
+    assert markers["NUMBA_LEGACY_CACHE_DISPOSITION"] == "preserved_due_to_failure"
+
+
+def test_rebuild_removal_failure_reports_preserved(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    venv = _venv(runtime)
+    core, _ = _allowlist_parents(venv)
+    (core / "cache.nbc").write_bytes(b"cache")
+    env = _fake_rm(tmp_path, "exit 1\n")
+
+    result = _run_rebuild_audit(runtime, env=env)
+    markers = _markers(result)
+
+    assert result.returncode != 0
+    assert venv.exists()
+    assert markers["NUMBA_LEGACY_CACHE_DISPOSITION"] == "preserved_due_to_failure"
+
+
+def test_rebuild_audit_never_scans_sibling(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    _venv(runtime)
+    sibling = runtime / ".venv-drumsep-rocm/lib/python3.12/site-packages/librosa/core/__pycache__"
+    sibling.mkdir(parents=True)
+    cache = sibling / "sibling.nbc"
+    cache.write_bytes(b"sibling")
+
+    result = _run_rebuild_audit(runtime)
+
+    assert result.returncode == 0, result.stdout
+    assert cache.read_bytes() == b"sibling"
+
+
+def test_bootstrap_rebuild_audit_precedes_every_main_venv_removal_and_persists_disposition() -> None:
+    script = BOOTSTRAP.read_text(encoding="utf-8")
+
+    assert 'remove_main_venv_with_numba_audit "${RUNTIME_BASE}/.venv"' in script
+    assert 'rm -rf "${RUNTIME_BASE}/.venv"' not in script
+    for marker in (
+        "NUMBA_LEGACY_CACHE_PRE_REBUILD_SCAN_STATUS",
+        "NUMBA_LEGACY_CACHE_PRE_REBUILD_DETECTED",
+        "NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST",
+        "NUMBA_LEGACY_CACHE_PRE_REBUILD_MANIFEST_SHA256",
+        "NUMBA_LEGACY_CACHE_DISPOSITION",
+        "NUMBA_LEGACY_CACHE_POST_ACTION_REMAINING",
+    ):
+        assert f'echo "{marker}=${{{marker}}}"' in script
+
+
+def test_healthy_repair_maps_existing_cleanup_to_disposition_and_second_repair_none_present() -> None:
+    script = BOOTSTRAP.read_text(encoding="utf-8")
+
+    assert 'NUMBA_LEGACY_CACHE_DISPOSITION="removed_individually"' in script
+    assert 'NUMBA_LEGACY_CACHE_DISPOSITION="none_present"' in script
+    assert 'NUMBA_LEGACY_CACHE_PRE_REBUILD_DETECTED="${NUMBA_LEGACY_CACHE_DETECTED}"' in script
+    assert 'NUMBA_LEGACY_CACHE_POST_ACTION_REMAINING="${NUMBA_LEGACY_CACHE_POSTCHECK_REMAINING}"' in script
+    assert 'if [ "${NUMBA_LEGACY_CACHE_DISPOSITION}" != "removed_with_venv_rebuild" ]; then' in script
+    create_start = script.index("create_venv_with_selected_python() {")
+    create_end = script.index("selected_python_is_managed()", create_start)
+    create_body = script[create_start:create_end]
+    assert 'if [ -e "${RUNTIME_BASE}/.venv" ] || [ -L "${RUNTIME_BASE}/.venv" ]; then' in create_body


### PR DESCRIPTION
Follow-up op de native Linux AMD/ROCm-validatie van PR #96. In het bewezen scenario waren 46 allowlisted legacy Numba-cachebestanden vóór Repair aanwezig. Zij verdwenen feitelijk met de volledige hoofdvenvvervanging; de latere cleanup kon daardoor alleen `detected=0/not_required` rapporteren, wat de disposition onvoldoende auditbaar maakte.

Deze PR:
- inventariseert vóór destructieve hoofdvenvvervanging uitsluitend allowlisted `.nbc`/`.nbi`-bestanden onder de bestaande librosa core/util-cachepaden;
- schrijft een deterministisch manifest met relatieve paden, type, grootte en SHA256;
- volgt geen symlinks en blokkeert op onbekende cachepaden, scan-/manifestfailure of onduidelijke verwijdering;
- rapporteert structured pre-count, manifest-SHA, disposition en post-action remaining in log en state;
- behoudt gerichte cleanup voor een gezonde venv en vermijdt dubbele cleanupsemantiek na volledige vervanging;
- onderscheidt `none_present`, `removed_individually`, `removed_with_venv_rebuild` en `preserved_due_to_failure`.

Dit repareert observability/auditability; het claimt niet dat processing of de runtime eerder defect was. Er wijzigen geen dependencyversies, runtimepolicy, siblingpolicy, offline-distributie, wheels, modellen, workflow of algemene bootstraparchitectuur.

Synthetische acceptatie omvat een gezonde venv met/zonder cache, een incompatibele venv met exact 46 caches, nul-cache rebuild, onbekende paden, symlinks, audit-/verwijderfailure, siblinguitsluiting, state/loggelijkheid en tweede-Repairsemantiek.

Gates:
- cache/dependencycontract: 34 passed;
- Linux runtime/staged/releasecontract: 41 passed;
- bredere relevante selectie: 445 passed, 9 skipped;
- exact CI Fast: 94 passed;
- release gate, i18n, Bash, YAML, compile, hygiene en diff-check: PASS;
- distributiecontract behoudt exact drie intentionele offline-roden.

Brede pytestvergelijking: patch 12 failures versus post-#104-main 13. De gedeelde 12 zijn bestaande baseline/environmentfailures: twee i18n, één lokale-installcontext, drie intentionele offlinecontracttests en zes materializerfixtures met lokale execute-permission. De dertiende baselinetest verbood het manifest/SHA-contract dat deze goedgekeurde follow-up juist vereist. PATCH_INDUCED_FAILURE_COUNT=0.